### PR TITLE
Add mustache templating to index.html

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "idyll-compiler": "^1.1.10",
     "idyll-component": "^1.0.2",
     "minimist": "^1.2.0",
+    "mustache": "^2.3.0",
     "nearley": "^2.7.11",
     "node-watch": "^0.4.1",
     "react": "^15.4.2",

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ if (!fs.existsSync(TMP_PATH)){
 }
 
 const HTML_TEMPLATE = path.resolve('_index.html');
-const HTML_OUTPUT = path.resolve('index.html');
+const HTML_OUTPUT = path.resolve('build/index.html');
 const AST_FILE = path.resolve(TMP_PATH + '/ast.json');
 const COMPONENT_FILE = path.resolve(TMP_PATH + '/components.js');
 const CSS_INPUT = (argv.css) ?  path.resolve(argv.css) : false;
@@ -61,12 +61,8 @@ const writeCSS = () => {
 
 const handleHTML = () => {
   const templateString = fs.readFileSync(HTML_TEMPLATE, 'utf8');
-  console.log(templateContext);
-  console.log(templateString);
-  console.log('ummm')
   const output = Mustache.render(templateString, templateContext);
-  console.log(HTML_OUTPUT);
-  res.writeFileSync(HTML_OUTPUT, output);
+  fs.writeFileSync(HTML_OUTPUT, output);
 };
 
 const writeTemplates = (ast) => {
@@ -94,9 +90,9 @@ const writeTemplates = (ast) => {
       switch(name) {
         case 'meta':
           templateContext = {}
-          Object.keys(props).forEach((key) => {
-            templateContext[key] = props[key];
-          });
+          props.forEach((p) => {
+            templateContext[p[0]] = p[1][1];
+          })
           break;
       }
     }
@@ -108,6 +104,7 @@ const writeTemplates = (ast) => {
 
 
 const build = () => {
+  handleHTML();
   process.env['NODE_ENV'] = 'production';
   var b = browserify(path.resolve(__dirname + '/templates/entry.js'), {
     fullPaths: true,
@@ -142,7 +139,6 @@ const start = () => {
       }
       try {
         const ast = compile(data, compilerOptions);
-        handleHTML();
         writeTemplates(ast);
         writeCSS();
         fs.writeFile(AST_FILE, JSON.stringify(ast));
@@ -177,7 +173,6 @@ const start = () => {
 const idlInput = fs.readFileSync(IDL_FILE, 'utf8');
 try {
   const ast = compile(idlInput, compilerOptions);
-  handleHTML();
   writeTemplates(ast);
   writeCSS();
   fs.writeFileSync(AST_FILE, JSON.stringify(ast));

--- a/src/layouts/scroll.css
+++ b/src/layouts/scroll.css
@@ -23,6 +23,11 @@
   justify-content: center;
 }
 
+
+pre {
+  margin-top: 25px 75px;
+}
+
 section .waypoint {
   margin-top: 130vh;
   margin-bottom: 20vh;

--- a/src/themes/idyll.css
+++ b/src/themes/idyll.css
@@ -40,8 +40,8 @@ p, .article-body {
 .hed {
   font-size: 3rem;
   line-height: 3rem;
-  font-weight: 100;
   margin: 20px 0 20px;
+  font-weight: bold;
   width: 150%;
   max-width: 90vw;
 }
@@ -117,7 +117,8 @@ a:hover {
 
 
 pre {
-  margin: 25px 75px;
+  margin-top: 25px;
+  margin-bottom: 25px;
 }
 
 pre code {


### PR DESCRIPTION
So you can automatically embed project-specific metadata by defining a `Meta` component at the top of your idyll file e.g.:


```
[Meta title:"Page Title" description:"Short description" shareImageUrl:"..." twitterUsername:"@mathisonian" /]

Then continue writing the rest of the document as usuall
...
```

thanks @ritchieking for this suggestion