### PR TITLE
Add forceDefaltIndex to budo config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -162,6 +162,7 @@ const start = () => {
   budo(path.resolve(__dirname + '/client/live.js'), {
     live: true,
     open: true,
+    forceDefaultIndex: true,
     css: '.idyll/styles.css',
     middleware: compression(),
     watchGlob: '**/*.{html,css,json,js}',


### PR DESCRIPTION
Budo attempts to pick up any `index.html` in the cwd. I compiled `./index.idl` to `./index.html` (I mean should go in `build/`, but y'know, might not) and it broke the budo server. This PR adds [forceDefaultIndex](https://github.com/mattdesl/budo/blob/master/docs/api-usage.md#opts) so that it doesn't accidentally serve a static file.