### PR TITLE
Generalize path construction for windows compatiblity

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,4 +19,4 @@ test_script:
   - npm test
 
 # Don't actually build.
-build: on
+build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+# Test against the latest version of this Node.js version
+environment:
+  nodejs_version: "6"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: on

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,19 +3,19 @@ image:
 
 environment:
   nodejs_version: "6"
+  SPELLCHECKER_PREFER_HUNSPELL: true
 
 install:
   # Get the latest stable version of Node.js
   - ps: Install-Product node $env:nodejs_version
   # install modules
-  - npm install
+  - npm --msvs_version=2013 install
 
 # Post-install test scripts.
 test_script:
   # Output useful info for debugging.
   - node --version
   - npm --version
-  # run tests
   - npm test
 
 # Don't actually build.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,9 @@
-# Test against the latest version of this Node.js version
+image:
+  - Visual Studio 2017
+
 environment:
   nodejs_version: "6"
 
-# Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node.js
   - ps: Install-Product node $env:nodejs_version

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "compression": "^1.6.2",
     "envify": "^4.0.0",
     "html-tags": "^1.1.1",
-    "idyll-compiler": "^1.1.10",
+    "idyll-compiler": "github:idyll-lang/idyll-compiler#browser",
     "insert-css": "^2.0.0",
     "minimist": "^1.2.0",
     "mustache": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test-deps": "cd test/test-project && npm install",
-    "test": "npm run test-deps; mocha --timeout 20000"
+    "test": "npm run test-deps && mocha --timeout 20000"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "compression": "^1.6.2",
     "envify": "^4.0.0",
     "html-tags": "^1.1.1",
-    "idyll-compiler": "github:idyll-lang/idyll-compiler#browser",
+    "idyll-compiler": "^1.0.0",
     "insert-css": "^2.0.0",
     "minimist": "^1.2.0",
     "mustache": "^2.3.0",

--- a/src/index.js
+++ b/src/index.js
@@ -23,11 +23,11 @@ require('babel-core/register')({
 
 const idyll = (inputPath, opts, cb) => {
   options = Object.assign({}, {
-    output: 'build/',
+    output: 'build',
     htmlTemplate: '_index.html',
-    componentFolder: './components/',
-    defaultComponents: './components/default/',
-    dataFolder: './data',
+    componentFolder: 'components',
+    defaultComponents: path.join('components', 'default'),
+    dataFolder: 'data',
     layout: 'blog',
     theme: 'idyll',
     compilerOptions: {
@@ -37,7 +37,7 @@ const idyll = (inputPath, opts, cb) => {
   }, opts || {});
 
   const IDL_FILE = inputPath;
-  const TMP_PATH = path.resolve( './.idyll/');
+  const TMP_PATH = path.resolve('.idyll');
 
   if (!fs.existsSync(TMP_PATH)){
       fs.mkdirSync(TMP_PATH);
@@ -45,20 +45,20 @@ const idyll = (inputPath, opts, cb) => {
 
   const BUILD_PATH = path.resolve(options.output);
   const HTML_TEMPLATE = path.resolve(options.htmlTemplate);
-  const JAVASCRIPT_OUTPUT = path.resolve(BUILD_PATH + '/index.js');
-  const HTML_OUTPUT = path.resolve(BUILD_PATH + '/index.html');
-  const AST_FILE = path.resolve(TMP_PATH + '/ast.json');
-  const COMPONENT_FILE = path.resolve(TMP_PATH + '/components.js');
-  const DATA_FILE = path.resolve(TMP_PATH + '/data.js');
+  const JAVASCRIPT_OUTPUT = path.resolve(path.join(BUILD_PATH, 'index.js'));
+  const HTML_OUTPUT = path.resolve(path.join(BUILD_PATH, 'index.html'));
+  const AST_FILE = path.resolve(path.join(TMP_PATH, 'ast.json'));
+  const COMPONENT_FILE = path.resolve(path.join(TMP_PATH, 'components.js'));
+  const DATA_FILE = path.resolve(path.join(TMP_PATH, 'data.js'));
   const CSS_INPUT = (options.css) ?  path.resolve(options.css) : false;
-  const CSS_OUTPUT = path.resolve(BUILD_PATH + '/styles.css');
+  const CSS_OUTPUT = path.resolve(path.join(BUILD_PATH, 'styles.css'));
   const CUSTOM_COMPONENTS_FOLDER = path.resolve(options.componentFolder);
   const DEFAULT_COMPONENTS_FOLDER = path.resolve(options.defaultComponents);
   const DATA_FOLDER = path.resolve(options.dataFolder);
   const IDYLL_PATH = path.resolve(__dirname);
 
-  const LAYOUT_INPUT = path.resolve(`${IDYLL_PATH}/layouts/${options.layout}.css`);
-  const THEME_INPUT = path.resolve(`${IDYLL_PATH}/themes/${options.theme}.css`);
+  const LAYOUT_INPUT = path.resolve(path.join(IDYLL_PATH, 'layouts', options.layout + '.css'));
+  const THEME_INPUT = path.resolve(path.join(IDYLL_PATH, 'themes', options.theme + '.css'));
 
   const components = fs.readdirSync(DEFAULT_COMPONENTS_FOLDER);
   let customComponents = [];
@@ -132,10 +132,10 @@ const idyll = (inputPath, opts, cb) => {
               };
             })
             if (source.endsWith('.csv')) {
-              parsed = Baby.parseFiles(DATA_FOLDER + '/' + source, { header: true });
+              parsed = Baby.parseFiles(path.join(DATA_FOLDER, source), { header: true });
               data = parsed.data;
             } else {
-              data = require(DATA_FOLDER + '/' + source);
+              data = require(path.join(DATA_FOLDER, source));
             }
             outputData[key] = data;
             break;
@@ -158,7 +158,7 @@ const idyll = (inputPath, opts, cb) => {
   const build = (cb) => {
     process.env['NODE_ENV'] = 'production';
     handleHTML();
-    var b = browserify(path.resolve(__dirname + '/client/build.js'), {
+    var b = browserify(path.resolve(path.join(__dirname, 'client', 'build.js')), {
       fullPaths: true,
       transform: [
         [ babelify, { presets: [ reactPreset, es2015Preset ] } ],
@@ -206,11 +206,11 @@ const idyll = (inputPath, opts, cb) => {
 
     });
 
-    budo(path.resolve(__dirname + '/client/live.js'), {
+    budo(path.resolve(path.join(__dirname, 'client', 'live.js')), {
       live: true,
       open: true,
       forceDefaultIndex: true,
-      css: options.output + '/styles.css',
+      css: path.join(options.output, 'styles.css'),
       middleware: compression(),
       watchGlob: '**/*.{html,css,json,js}',
       browserify: {

--- a/src/index.js
+++ b/src/index.js
@@ -152,6 +152,7 @@ const idyll = (inputPath, opts, cb) => {
       children.map(handleNode);
     }
     ast.map(handleNode);
+    console.log(`module.exports = {\n${outputComponents.join(',\n')}\n}`);
     fs.writeFile(COMPONENT_FILE, `module.exports = {\n${outputComponents.join(',\n')}\n} `);
     fs.writeFile(DATA_FILE, `module.exports = ${JSON.stringify(outputData)}`);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -107,9 +107,9 @@ const idyll = (inputPath, opts, cb) => {
       const children = node[2] || [];
       if (ignoreNames.indexOf(name) === -1 && checkedComponents.indexOf(name) === -1) {
         if (customComponents.indexOf(name + '.js') > -1) {
-          outputComponents.push(`"${name}": require('${CUSTOM_COMPONENTS_FOLDER}/${name}')`);
+          outputComponents.push(`"${name}": require('${path.join(CUSTOM_COMPONENTS_FOLDER, name).replace(/\\/g, '\\\\')}')`);
         } else if (components.indexOf(name + '.js') > -1) {
-          outputComponents.push(`"${name}": require('${DEFAULT_COMPONENTS_FOLDER}/${name}')`);
+          outputComponents.push(`"${name}": require('${path.join(DEFAULT_COMPONENTS_FOLDER, name).replace(/\\/g, '\\\\')}')`);
         }
         checkedComponents.push(name);
       } else if (ignoreNames.indexOf(name) > -1) {

--- a/src/index.js
+++ b/src/index.js
@@ -89,6 +89,8 @@ const idyll = (inputPath, opts, cb) => {
   };
 
   const writeTemplates = (ast) => {
+    console.log(ast);
+
     const outputComponents = [];
     const outputData = {};
     const checkedComponents = [];

--- a/src/index.js
+++ b/src/index.js
@@ -89,13 +89,10 @@ const idyll = (inputPath, opts, cb) => {
   };
 
   const writeTemplates = (ast) => {
-    console.log(ast);
-
     const outputComponents = [];
     const outputData = {};
     const checkedComponents = [];
     const ignoreNames = ['var', 'data', 'meta', 'derived'];
-
 
     const handleNode = (node) => {
       if (typeof node === 'string') {
@@ -152,7 +149,6 @@ const idyll = (inputPath, opts, cb) => {
       children.map(handleNode);
     }
     ast.map(handleNode);
-    console.log(`module.exports = {\n${outputComponents.join(',\n')}\n}`);
     fs.writeFile(COMPONENT_FILE, `module.exports = {\n${outputComponents.join(',\n')}\n} `);
     fs.writeFile(DATA_FILE, `module.exports = ${JSON.stringify(outputData)}`);
   }

--- a/test/test-project/package.json
+++ b/test/test-project/package.json
@@ -7,7 +7,7 @@
     "deploy": "npm run build && gh-pages -d ./build"
   },
   "dependencies": {
-    "idyll": "^1.0.0",
+    "idyll": "idyll-lang/idyll#fix-paths",
     "idyll-default-components": "^1.0.0"
   },
   "devDependencies": {

--- a/test/test-project/package.json
+++ b/test/test-project/package.json
@@ -7,7 +7,6 @@
     "deploy": "npm run build && gh-pages -d ./build"
   },
   "dependencies": {
-    "idyll": "idyll-lang/idyll#fix-paths",
     "idyll-default-components": "^1.0.0"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -4,20 +4,19 @@ const idyll = require('..');
 const fs = require('fs');
 const path = require('path');
 
-const inputPath = __dirname + '/test-project/';
-const outputPath = __dirname + '/test-project/build/';
-const expectedPath = __dirname + '/expected-output';
+const inputPath = path.join(__dirname, 'test-project');
+const outputPath = path.join(__dirname, 'test-project', 'build');
+const expectedPath = path.join(__dirname, 'expected-output');
 const expectedFiles = fs.readdirSync(expectedPath);
 
 describe('build task', function() {
-
     it('should compile the files', function(done) {
-        idyll(inputPath + '/index.idl', {
+        idyll(path.join(inputPath, 'index.idl'), {
           output: outputPath,
-          htmlTemplate: inputPath + '/_index.html',
-          componentFolder: inputPath + '/components/',
-          defaultComponents: inputPath + '/components/default/',
-          dataFolder: inputPath + '/data',
+          htmlTemplate: path.join(inputPath, '_index.html'),
+          componentFolder: path.join(inputPath, 'components'),
+          defaultComponents: path.join(inputPath, 'components', 'default'),
+          dataFolder: path.join(inputPath, 'data'),
           compilerOptions: {
             spellcheck: false
           },


### PR DESCRIPTION
See #20. I'm not 100% sure this is absolutely correct, but I gave `src/index.js` a quick pass to replace manual `... + '/' + ...` path construction with `path.join(...)`. It passes the tests, but I haven't run it through the wringer so would need a second opinion before being absolutely confident it's the right move.

To be perfectly honest, I wouldn't be able to tell you the exact windows vs. *nix path/require semantics, so it's quite possible I've applied `path.join` in places where it's not strictly necessary. It's also possible I've missed a case or two where it might ultimately be required.

/cc @themre 