### PR TITLE
Add hint to convey generator *creates* a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ To use the generator:
 ```sh
 $ npm install -g yo generator-idyll
 $ yo idyll
+$ cd idyll-project
 ```
 
 The generator will produce a structure that looks like this:


### PR DESCRIPTION
This PR adds a tiny little hint to help convey that the generator *creates* a directory. You're more than welcome to disregard/close this PR (I'm not 100% sold it's the right way to convey it), but I get endlessly confused about whether a particular generator will generator the project *in* the current directory or create a directory and add the files to *that* directory.