### PR TITLE
Fix css watch pattern

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,7 @@ const idyll = (inputPath, opts, cb) => {
   const start = () => {
     const watchedFiles = CSS_INPUT ? [IDL_FILE, CSS_INPUT] : [IDL_FILE];
     watch(watchedFiles, (filename) => {
-      if (filename.indexOf('.css')) {
+      if (filename.indexOf('.css') !== -1) {
         writeCSS();
       } else {
         fs.readFile(IDL_FILE, 'utf8', function(err, data) {


### PR DESCRIPTION
This PR fixes the test for css which was `indexOf('.css')` instead of `indexOf('.css') !== -1`, causing it to bail out early.