### PR TITLE
Fix spellcheck arg parsing

### DIFF
--- a/bin/idyll.js
+++ b/bin/idyll.js
@@ -1,10 +1,15 @@
 #! /usr/bin/env node
 const idyll = require('../src/');
-const argv = require('minimist')(process.argv.slice(2));
+const argv = require('minimist')(process.argv.slice(2), {
+  boolean: ['spellcheck'],
+  default: {
+    spellcheck: true
+  }
+});
 
 let options = {
   compilerOptions: {
-    spellcheck: argv.spellcheck ? argv.spellcheck : true
+    spellcheck: argv.spellcheck
   },
   build: argv.build ? argv.build : false
 };


### PR DESCRIPTION
Spellcheck could not previously be disabled. This PR fixes minimist parsing so that `--spellcheck` and `--no-spellcheck` both work, with a default of spellcheck: true.