### PR TITLE
Throw bundling errors

### DIFF
--- a/src/pipeline/bundle-js.js
+++ b/src/pipeline/bundle-js.js
@@ -37,6 +37,8 @@ module.exports = function (paths) {
 
   return new Promise((resolve, reject) => {
     b.bundle((err, src) => {
+      if (err) return reject(err);
+
       resolve(src.toString('utf8'));
     }).pipe(fs.createWriteStream(path.join(paths.TMP_DIR, 'bundle.js')));
   })


### PR DESCRIPTION
Our error handling still needs a lot of improvement, but this should at least give more info on what went wrong during bundling.