### PR TITLE
Server files from input *and* output directories

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ const idyll = (options = {}, cb) => {
               logLevel: 'warn',
               logPrefix: 'Idyll',
               notify: false,
-              server: paths.OUTPUT_DIR,
+              server: [paths.INPUT_DIR, paths.OUTPUT_DIR],
               ui: false
             });
           }

--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ const idyll = (options = {}, cb) => {
               logLevel: 'warn',
               logPrefix: 'Idyll',
               notify: false,
-              server: [paths.INPUT_DIR, paths.OUTPUT_DIR],
+              server: [paths.OUTPUT_DIR, paths.INPUT_DIR],
               ui: false
             });
           }


### PR DESCRIPTION
**Observed behavior**: browser-sync fails to serve files from `data/*`, `images/*`, `fonts/*` etc unless the project has already been built. 

**Expected behavior**: the dev server serves files from your source directory

**Solution**: This PR adds the input directory to the browser-sync static directories