### PR TITLE
Add body margin and border box layout styles

### DIFF
--- a/src/layouts/blog.css
+++ b/src/layouts/blog.css
@@ -1,6 +1,9 @@
-
+body {
+  margin: 0;
+}
 
 .idyll-root {
+  box-sizing: border-box;
   max-width: 90vw;
   margin: 0 auto;
   padding: 60px 0;

--- a/src/layouts/centered.css
+++ b/src/layouts/centered.css
@@ -1,6 +1,9 @@
-
+body {
+  margin: 0;
+}
 
 .idyll-root {
+  box-sizing: border-box;
   max-width: 600px;
   margin: 0 auto;
   padding: 60px 0;


### PR DESCRIPTION
This PR fixes layouts for mobile in particular. I found two main problems:

- `box-sizing: border-box` prevents horizontal scrolling on narrow screens
- `margin: 0` on the body element prevents browser-default margins from taking up undesired extra space

The second could perhaps just be a style property in the generator css instead of idyll itself. Let me know if that sounds better.