### PR TITLE
[WIP] Build to static output

### DIFF
--- a/src/client/build.js
+++ b/src/client/build.js
@@ -2,6 +2,7 @@ const React = require('react');
 const ReactDOM = require('react-dom');
 
 const InteractiveDocument = require('./component');
-var mountNode = document.getElementById('idyll-mount');
+const mountNode = document.getElementById('idyll-mount');
+const ast = require('__IDYLL_AST__');
 
-ReactDOM.render(<InteractiveDocument />, mountNode);
+ReactDOM.render(<InteractiveDocument ast={ast}/>, mountNode);

--- a/src/client/component.js
+++ b/src/client/component.js
@@ -2,7 +2,7 @@ const React = require('react');
 const walkVars = require('./visitors/vars');
 const walkNode = require('./visitors/node');
 
-let results = require('__IDYLL_AST__');
+//require('__IDYLL_SYNTAX_HIGHLIGHT__');
 
 const transformRefs = (refs) => {
   const output = {};
@@ -33,12 +33,12 @@ class InteractiveDocument extends React.PureComponent {
     this.derivedVars = {};
     this.initialState = {};
 
-    results.map(walkVars(this));
+    props.ast.map(walkVars(this));
 
     this.state = this.initialState;
 
     this.getChildren = () => {
-      return results.map(walkNode(this));
+      return props.ast.map(walkNode(this));
     }
   }
 

--- a/src/client/visitors/node.js
+++ b/src/client/visitors/node.js
@@ -1,7 +1,7 @@
 const React = require('react');
 const htmlTags = require('html-tags');
 const changeCase = require('change-case');
-const componentClasses = require('__IDYLL_COMPONENTS__');
+const componentClasses = {};//require('__IDYLL_COMPONENTS__');
 const { COMPONENTS, PROPERTIES } = require('../constants');
 
 const processComponent = (component, name, id) => {

--- a/src/client/visitors/vars.js
+++ b/src/client/visitors/vars.js
@@ -1,6 +1,8 @@
 const ReactDOM = require('react-dom');
 const { COMPONENTS, DATASET, PROPERTIES, DERIVED, VARIABLE } = require('../constants');
-const datasets = require('__IDYLL_DATA__');
+
+const datasets = {};//require('__IDYLL_DATA__');
+
 module.exports = function(component) {
   let nodeID = -1;
   const walkVars = function (node) {

--- a/src/pipeline/parse.js
+++ b/src/pipeline/parse.js
@@ -5,6 +5,8 @@ const mustache = require('mustache');
 const resolve = require('resolve');
 const Baby = require('babyparse');
 const { paramCase } = require('change-case');
+const ReactDOMServer = require('react-dom/server');
+const React = require('react');
 
 const getNodesByName = (name, tree) => {
   const predicate = typeof name === 'string' ? (s) => s === name : name;
@@ -119,10 +121,11 @@ exports.getHTML = (ast, template) => {
       return acc;
     },
     {}
-  )
+  ) || {};
 
-  // const InteractiveDocument = require('./client/component');
-  // meta.idyllContent = ReactDOMServer.renderToString(React.createElement(InteractiveDocument));
+  const InteractiveDocument = require('../client/component');
+  meta.idyllContent = ReactDOMServer.renderToString(React.createElement(InteractiveDocument, {ast: ast}));
+
   return mustache.render(template, meta || {});
 }
 


### PR DESCRIPTION
This PR starts working in the direction of building to static output. For one, it makes the simple change of passing `ast` to `InteractiveDocument` instead of requiring it from within. That makes it trivial to pass the AST to the component when building to static or to use the fancy `require('__IDYLL_AST__')` trick from *outside* the component when building the client bundle.