### PR TITLE
update node_modules path logic

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,12 +20,6 @@ const idyll = (options = {}, cb) => {
       datasets: 'data',
       minify: true,
       components: 'components',
-      defaultComponents: join(
-        __dirname,
-        '..',
-        'node_modules',
-        'idyll-default-components'
-      ),
       layout: 'blog',
       output: 'build',
       template: join(

--- a/src/path-builder.js
+++ b/src/path-builder.js
@@ -21,23 +21,31 @@ module.exports = function (opts) {
     return join(basedir, p);
   }
 
+  const getNodeModulesPath = () => {
+    if (pathIsInside(__dirname, basedir) && __dirname.indexOf('node_modules') > -1) {
+      return join(basedir, 'node_modules');
+    }
+     return join(__dirname, '..', 'node_modules');
+  }
+
   const OUTPUT_DIR = getPath(opts.output);
   const TMP_DIR = getPath('.idyll');
 
   if (!fs.existsSync(OUTPUT_DIR)) fs.mkdirSync(OUTPUT_DIR);
   if (!fs.existsSync(TMP_DIR)) fs.mkdirSync(TMP_DIR);
 
+  const NODE_MODULES = getNodeModulesPath();
+
   return {
     CSS_INPUT_FILE: getPath(opts.css),
     COMPONENTS_DIR: getPath(opts.components),
     DATA_DIR: getPath(opts.datasets),
-    DEFAULT_COMPONENTS_DIR: getPath(opts.defaultComponents),
+    DEFAULT_COMPONENTS_DIR: getPath(opts.defaultComponents || join(NODE_MODULES, 'idyll-default-components')),
     HTML_TEMPLATE_FILE: getPath(opts.template),
     IDYLL_INPUT_FILE: getPath(opts.inputFile),
     INPUT_DIR: basedir,
-    NODE_MODULES: pathIsInside(__dirname, basedir) ? join(basedir, 'node_modules') : join(__dirname, '..', 'node_modules'),
+    NODE_MODULES,
     PACKAGE_FILE: getPath('package.json'),
-
     OUTPUT_DIR,
     CSS_OUTPUT_FILE: join(OUTPUT_DIR, 'styles.css'),
     HTML_OUTPUT_FILE: join(OUTPUT_DIR, 'index.html'),


### PR DESCRIPTION
This makes it so idyll can correctly look into the node modules path in a variety of situations:
* `idyll` is used as a global install
* idyll is installed locally inside of a project's `node_modules`
* either of the above situation, and idyll is linked locally