### PR TITLE
smaller bundlesize

### DIFF
--- a/src/pipeline/bundle-js.js
+++ b/src/pipeline/bundle-js.js
@@ -48,7 +48,7 @@ module.exports = function (opts, paths, output) {
       cache: {},
       packageCache: {},
       fullPaths: true,
-      cacheFile: path.join(paths.TMP_DIR, `browserify-cache-${opts.watch ? 'watch' : 'build'}.json`),
+      cacheFile: path.join(paths.TMP_DIR, `browserify-cache${opts.minify ? '-min' : ''}.json`),
       transform: getTransform(opts),
       paths: [
         // Input package's NODE_MODULES

--- a/src/pipeline/bundle-js.js
+++ b/src/pipeline/bundle-js.js
@@ -48,7 +48,7 @@ module.exports = function (opts, paths, output) {
       cache: {},
       packageCache: {},
       fullPaths: true,
-      cacheFile: path.join(paths.TMP_DIR, 'browserify-cache.json'),
+      cacheFile: path.join(paths.TMP_DIR, `browserify-cache-${opts.watch ? 'watch' : 'build'}.json`),
       transform: getTransform(opts),
       paths: [
         // Input package's NODE_MODULES
@@ -58,6 +58,10 @@ module.exports = function (opts, paths, output) {
       ],
       plugin: [
         (b) => {
+          if (opts.minify) {
+            b.require('react/dist/react.min.js', { expose: 'react' });
+            b.require('react-dom/dist/react-dom.min.js', { expose: 'react-dom' });
+          }
           const aliases = {
             ast: '__IDYLL_AST__',
             components: '__IDYLL_COMPONENTS__',


### PR DESCRIPTION
This uses the minified react and react-dom packages if the `minify` option is set to true. One thing to note is that currently the command line api doesn't like the `--minify` flag, I think we should update it to accept this since it defaults to not minifying.

<img width="513" alt="screen shot 2017-06-07 at 1 13 34 pm" src="https://user-images.githubusercontent.com/1074773/26899292-867f3ae4-4b83-11e7-96d5-64b5edef6179.png">

Here's the build output from the default generated idyll project with these changes 