### PR TITLE
Make reloading work in watch mode

### DIFF
--- a/src/pipeline/bundle-js.js
+++ b/src/pipeline/bundle-js.js
@@ -42,7 +42,7 @@ const getTransform = (opts) => {
 module.exports = function (opts, paths, output) {
   process.env['NODE_ENV'] = opts.watch ? 'development' : 'production';
   if (!config) {
-    const config = {
+    config = {
       entries: [path.join(__dirname, '..', 'client', 'build.js')],
       cache: {},
       packageCache: {},

--- a/src/pipeline/bundle-js.js
+++ b/src/pipeline/bundle-js.js
@@ -8,7 +8,7 @@ const brfs = require('brfs');
 const Promise = require('bluebird');
 const stream = require('stream');
 
-let b;
+let config;
 
 const toStream = (k, o) => {
   let src;
@@ -41,8 +41,7 @@ const getTransform = (opts) => {
 
 module.exports = function (opts, paths, output) {
   process.env['NODE_ENV'] = opts.watch ? 'development' : 'production';
-
-  if (!b) {
+  if (!config) {
     const config = {
       entries: [path.join(__dirname, '..', 'client', 'build.js')],
       cache: {},
@@ -79,9 +78,9 @@ module.exports = function (opts, paths, output) {
         }
       ]
     };
-
-    b = browserifyInc(config);
   }
+
+  const b = browserifyInc(config);
 
   return new Promise((resolve, reject) => {
     b.bundle((err, src) => {

--- a/src/pipeline/parse.js
+++ b/src/pipeline/parse.js
@@ -166,10 +166,6 @@ exports.getHighlightJS = (ast, paths, server) => {
   return js;
 }
 
-const requireHighlightJS = (ast, paths) => {
-  exports.getHighlightJS(ast, paths, true);
-}
-
 exports.getHTML = (paths, ast, components, datasets, template) => {
   // there should only be one meta node
   const metaNodes = getNodesByName('meta', ast);
@@ -188,7 +184,7 @@ exports.getHTML = (paths, ast, components, datasets, template) => {
     componentClasses[key] = require(components[key])
   })
 
-  requireHighlightJS(ast, paths);
+  exports.getHighlightJS(ast, paths, true);
   const ReactDOMServer = require('react-dom/server');
   const React = require('react');
   const InteractiveDocument = require('../client/component');


### PR DESCRIPTION
**What broke:**

The changes to use streams instead of temp files broke the reloading in our incremental browserify setup.

**Why this fix works:**

This changes it so that the bundler is re-initialized on every build, which isn't ideal but is okay because it persists its cache to a file. This basically forces it to reload the streams every time, so there's some additional optimization to be done to not e.g. reload the data files or components if those haven't changed, but I'm not really sure how to do that with streams ATM