### PR TITLE
Faster! Faster!

### DIFF
--- a/bin/idyll.js
+++ b/bin/idyll.js
@@ -16,7 +16,7 @@ var argv = require('yargs')
     l: 'layout',
     n: 'no-minify',
     o: 'output',
-    k: 'spellcheck',
+    k: 'no-spellcheck',
     r: 'no-ssr',
     t: 'template',
     e: 'theme',
@@ -36,9 +36,8 @@ var argv = require('yargs')
   .describe('no-minify', 'Skip JS minification')
   .describe('output', 'Directory where built files should be written')
   .default('output', 'build')
-  .boolean('spellcheck')
-  .default('spellcheck', true)
-  .describe('spellcheck', 'Check spelling of Idyll source input')
+  .boolean('no-spellcheck')
+  .describe('no-spellcheck', `Don't check spelling of Idyll source input`)
   .boolean('no-ssr')
   .describe('no-ssr', 'Do not pre-render HTML as part of the build')
   .describe('template', 'Path to HTML template')
@@ -60,9 +59,9 @@ if (argv._[0]) argv.f = argv.inputFile = argv._[0];
 argv.minify = !argv['no-minify'];
 argv.ssr = !argv['no-ssr'];
 
-// move spellcheck down a level
+// spellcheck lives down a level
 argv.compilerOptions = {
-  spellcheck: argv.spellcheck
+  spellcheck: !argv['no-spellcheck']
 };
 
 // delete stuff we don't need
@@ -72,7 +71,8 @@ delete argv.n;
 delete argv.noMinify;
 delete argv['no-minify'];
 delete argv.k;
-delete argv.spellcheck;
+delete argv.noSpellcheck;
+delete argv['no-spellcheck'];
 delete argv.r;
 delete argv.noSsr;
 delete argv['no-ssr'];

--- a/bin/idyll.js
+++ b/bin/idyll.js
@@ -17,6 +17,7 @@ var argv = require('yargs')
     n: 'no-minify',
     o: 'output',
     k: 'spellcheck',
+    r: 'no-ssr',
     t: 'template',
     e: 'theme',
     w: 'watch'
@@ -38,6 +39,8 @@ var argv = require('yargs')
   .boolean('spellcheck')
   .default('spellcheck', true)
   .describe('spellcheck', 'Check spelling of Idyll source input')
+  .boolean('no-ssr')
+  .describe('no-ssr', 'Do not pre-render HTML as part of the build')
   .describe('template', 'Path to HTML template')
   .array('transform')
   .describe('transform', 'Custom browserify transforms to apply.')
@@ -55,6 +58,7 @@ if (argv._[0]) argv.f = argv.inputFile = argv._[0];
 
 // API checks the inverse
 argv.minify = !argv['no-minify'];
+argv.ssr = !argv['no-ssr'];
 
 // move spellcheck down a level
 argv.compilerOptions = {
@@ -69,6 +73,9 @@ delete argv.noMinify;
 delete argv['no-minify'];
 delete argv.k;
 delete argv.spellcheck;
+delete argv.r;
+delete argv.noSsr;
+delete argv['no-ssr'];
 
 // delete undefined keys so Object.assign won't use them
 Object.keys(argv).forEach((key) => {

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ const idyll = (options = {}, cb) => {
       watch: false,
       datasets: 'data',
       minify: true,
+      ssr: true,
       components: 'components',
       defaultComponents: dirname(require.resolve('idyll-default-components')),
       layout: 'blog',

--- a/src/pipeline/index.js
+++ b/src/pipeline/index.js
@@ -36,8 +36,7 @@ const build = (opts, paths, inputConfig) => {
         data: getDataJS(ast, paths.DATA_DIR),
         syntaxHighlighting: getHighlightJS(ast, paths)
       };
-      // avoid SSR unless minify is true, indicating a final build
-      if (!opts.minify) {
+      if (!opts.ssr) {
         output.html = getBaseHTML(ast, template);
       } else {
         output.html = getHTML(

--- a/src/pipeline/index.js
+++ b/src/pipeline/index.js
@@ -8,6 +8,7 @@ const {
   getComponentsJS,
   getDataJS,
   getHighlightJS,
+  getBaseHTML,
   getHTML
 } = require('./parse');
 const css = require('./css');
@@ -26,6 +27,8 @@ const build = (opts, paths, inputConfig) => {
     // to start a Promise chain and turn any synchronous exceptions into a rejection
     () => {
       const ast = compile(opts.inputString, opts.compilerOptions);
+      const template = fs.readFileSync(paths.HTML_TEMPLATE_FILE, 'utf8');
+
       output = {
         ast: getASTJSON(ast),
         components: getComponentsJS(ast, paths, inputConfig),
@@ -33,13 +36,18 @@ const build = (opts, paths, inputConfig) => {
         data: getDataJS(ast, paths.DATA_DIR),
         syntaxHighlighting: getHighlightJS(ast, paths)
       };
-      output.html = getHTML(
-        paths,
-        ast,
-        output.components,
-        output.data,
-        fs.readFileSync(paths.HTML_TEMPLATE_FILE, 'utf8')
-      )
+      // avoid SSR unless minify is true, indicating a final build
+      if (!opts.minify) {
+        output.html = getBaseHTML(ast, template);
+      } else {
+        output.html = getHTML(
+          paths,
+          ast,
+          output.components,
+          output.data,
+          template
+        );
+      }
     }
   )
   .then(() => {

--- a/src/pipeline/parse.js
+++ b/src/pipeline/parse.js
@@ -166,19 +166,25 @@ exports.getHighlightJS = (ast, paths, server) => {
   return js;
 }
 
-exports.getHTML = (paths, ast, components, datasets, template) => {
+const parseMeta = (ast) => {
   // there should only be one meta node
   const metaNodes = getNodesByName('meta', ast);
 
   // data is stored in props, hence [1]
-  const meta = metaNodes.length ? metaNodes[0][1].reduce(
+  return metaNodes.length ? metaNodes[0][1].reduce(
     (acc, prop) => {
       acc[prop[0]] = prop[1][1];
       return acc;
     },
     {}
   ) : {};
+}
 
+exports.getBaseHTML = (ast, template) => {
+  return mustache.render(template, parseMeta(ast));
+}
+
+exports.getHTML = (paths, ast, components, datasets, template) => {
   const componentClasses = {};
   Object.keys(components).forEach(key => {
     componentClasses[key] = require(components[key])
@@ -188,6 +194,7 @@ exports.getHTML = (paths, ast, components, datasets, template) => {
   const ReactDOMServer = require('react-dom/server');
   const React = require('react');
   const InteractiveDocument = require('../client/component');
+  const meta = parseMeta(ast);
   meta.idyllContent = ReactDOMServer.renderToString(
     React.createElement(InteractiveDocument, {
       ast,


### PR DESCRIPTION
This commit skips SSR when minify is turned off, which saves about 500ms from the build time. (Interestingly enough, the time seems to be spent requiring the component files, not doing the actual render to string.) I'm not sure tying it to minify (or watch) is the best way to determine the behavior, so maybe we should add a `--ssr` flag? I think if `watch` is true you definitely don't want/need SSR, but for something like a REPL `watch` would be false but you still don't want SSR.

Additionally, it appears we can shave about 300ms from the bundle time by setting `react` and `react-dom` as external. I can consistently get build times under 400ms in that scenario so I think it's worth doing. The question is how do we include those dependencies then? Maybe that's also conditional and we stick a couple of script tags in the HTML in that case?