### PR TITLE
only transform necessary front-end files

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.22.0",
+    "babel-register": "^6.24.1",
     "babelify": "^7.3.0",
     "babyparse": "^0.4.6",
     "bluebird": "^3.5.0",

--- a/src/client/build.js
+++ b/src/client/build.js
@@ -10,10 +10,6 @@ const datasets = require('__IDYLL_DATA__');
 require('__IDYLL_SYNTAX_HIGHLIGHT__');
 
 ReactDOM.render(
-  <InteractiveDocument
-    ast={ast}
-    componentClasses={componentClasses}
-    datasets={datasets}
-  />,
+  React.createElement(InteractiveDocument, { ast, componentClasses, datasets }),
   mountNode
 );

--- a/src/index.js
+++ b/src/index.js
@@ -10,9 +10,6 @@ const changeCase = require('change-case');
 const pathBuilder = require('./path-builder');
 const pipeline = require('./pipeline');
 
-require('babel-core/register')({
-    presets: ['react', 'es2015']
-});
 
 const idyll = (options = {}, cb) => {
   const opts = Object.assign({}, {
@@ -41,6 +38,12 @@ const idyll = (options = {}, cb) => {
   if (opts.watch) opts.minify = false; // speed!
 
   const paths = pathBuilder(opts);
+  const transformFolders = [paths.COMPONENTS_DIR, paths.DEFAULT_COMPONENTS_DIR];
+  require('babel-register')({
+      presets: ['react', 'es2015'],
+      only: new RegExp(`(${transformFolders.join('|')})`)
+  });
+
   const inputPackage = fs.existsSync(paths.PACKAGE_FILE) ? require(paths.PACKAGE_FILE) : {};
   const inputConfig = Object.assign({
     components: {},


### PR DESCRIPTION
This reduces the number of files that get registered with babel to only include those files in component folders. It fixes a bug where the registering the files would cause issues in other programs that `require('idyll')`.

/cc @bclinkinbeard 
