### PR TITLE
remove need for special updateProps on idyll component

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "idyll-compiler": "^1.4.4",
     "idyll-default-components": "^1.3.2",
     "insert-css": "^2.0.0",
+    "memoizee": "^0.4.5",
     "mkdirp": "^0.5.1",
     "mustache": "^2.3.0",
     "react": "^15.4.2",

--- a/src/client/component.js
+++ b/src/client/component.js
@@ -36,9 +36,10 @@ class InteractiveDocument extends React.PureComponent {
     props.ast.map(walkVars(this, props.datasets));
 
     this.state = this.initialState;
-
+    
+    const nodeWalker = walkNode(this, props.componentClasses);
     this.getChildren = () => {
-      return props.ast.map(walkNode(this, props.componentClasses));
+      return props.ast.map(nodeWalker());
     }
   }
 


### PR DESCRIPTION
This refactors the `nodeWalker` to dynamically inject the special `updateProps` method, instead of relying on components to extend a special component that implements them. 

This also adds `memoizee` to cut down on repeated work in the node walker across state updates, making things slightly faster. There is probably some more work to be done here to make things as fast as possible, but thats for a different PR.