### PR TITLE
config to make things work more cleanly with linked local modules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,12 @@ const {
   dirname,
   isAbsolute,
   join,
-  parse,
+  parse
 } = require('path');
 const EventEmitter = require('events');
 const changeCase = require('change-case');
 const pathBuilder = require('./path-builder');
+const configureNode = require('./node-config');
 const pipeline = require('./pipeline');
 
 
@@ -38,11 +39,7 @@ const idyll = (options = {}, cb) => {
   if (opts.watch) opts.minify = false; // speed!
 
   const paths = pathBuilder(opts);
-  const transformFolders = [paths.COMPONENTS_DIR, paths.DEFAULT_COMPONENTS_DIR];
-  require('babel-register')({
-      presets: ['react', 'es2015'],
-      only: new RegExp(`(${transformFolders.join('|')})`)
-  });
+  configureNode(paths);
 
   const inputPackage = fs.existsSync(paths.PACKAGE_FILE) ? require(paths.PACKAGE_FILE) : {};
   const inputConfig = Object.assign({

--- a/src/node-config.js
+++ b/src/node-config.js
@@ -1,0 +1,25 @@
+
+const React = require('react');
+const ReactDOM = require('react-dom');
+var Module = require('module');
+
+module.exports = (paths) => {
+  const transformFolders = [paths.COMPONENTS_DIR, paths.DEFAULT_COMPONENTS_DIR];
+  var originalLoad = Module._load;
+  Module._load = function (path) {
+    switch (path) {
+      case 'react':
+        return React;
+      case 'react-dom':
+        return ReactDOM;
+      default:
+        return originalLoad.apply(Module, arguments);
+    }
+  };
+
+  require('babel-register')({
+      presets: ['react', 'es2015'],
+      babelrc: false,
+      only: new RegExp(`(${transformFolders.join('|')})`)
+  });
+}

--- a/src/node-config.js
+++ b/src/node-config.js
@@ -1,11 +1,11 @@
 
 const React = require('react');
 const ReactDOM = require('react-dom');
-var Module = require('module');
+const Module = require('module');
 
 module.exports = (paths) => {
   const transformFolders = [paths.COMPONENTS_DIR, paths.DEFAULT_COMPONENTS_DIR];
-  var originalLoad = Module._load;
+  const originalLoad = Module._load;
   Module._load = function (path) {
     switch (path) {
       case 'react':


### PR DESCRIPTION
This change:
 * ignore babelrc files in the component directories when loading them on the server, this avoids "module not found" errors
 * injects the local version of react for all requires, this way even if you link a module that depends on `react` as a peer dependency, things will still work even if that module doesn't have a local copy of react