### PR TITLE
allow bare derived variables and datasets

### DIFF
--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -95,17 +95,25 @@ const getVars = (arr, context) => {
     const [, [, nameValue]] = nameArr
     const [, [valueType, valueValue]] = valueArr;
 
-    if (valueType === 'value') acc[nameValue] = valueValue;
-    if (valueType === 'variable') acc[nameValue] = context[valueValue];
-    if (valueType === 'expression') {
-      const expr = valueValue;
-
-      acc[nameValue] = {
-        value: evalExpression(context, expr),
-        update: (newState, oldState) => {
-          return evalExpression(Object.assign({}, oldState, newState), expr)
+    switch(valueType) {
+      case 'value':
+        acc[nameValue] = valueValue;
+        break;
+      case 'variable':
+        if (context.hasOwnProperty(valueValue)) {
+          acc[nameValue] = context[valueValue];
+        } else {
+          acc[nameValue] = evalExpression(context, expr);
         }
-      }
+        break;
+      case 'expression':
+        const expr = valueValue;
+        acc[nameValue] = {
+          value: evalExpression(context, expr),
+          update: (newState, oldState) => {
+            return evalExpression(Object.assign({}, oldState, newState), expr)
+          }
+        }
     }
 
     return acc;


### PR DESCRIPTION
This updates the syntax to be more flexible, fixing an issue that was tripping a lot of people up (see  https://github.com/idyll-lang/idyll/issues/123)

It allows for properties to be passed like 

`[Component prop1:myVar prop2:myDerivedVar prop3:myDataset /]` instead of forcing

``[Component prop1:myVar prop2:`myDerivedVar` prop3:`myDataset` /]``
