### PR TITLE
Build system to properly support ES workflows

### DIFF
--- a/packages/idyll-compiler/package.json
+++ b/packages/idyll-compiler/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "nearleyc src/grammar.ne -o src/grammar.js",
     "test": "npm run build && mocha",
-    "prepublish": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/packages/idyll-components/.babelrc
+++ b/packages/idyll-components/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["env", "stage-2", "react"]
+  "presets": [ "./.babelrc.js" ]
 }

--- a/packages/idyll-components/.babelrc.js
+++ b/packages/idyll-components/.babelrc.js
@@ -1,0 +1,12 @@
+const BABEL_ENV = process.env.BABEL_ENV;
+const env = BABEL_ENV === 'cjs' ? 'env' : [
+  'env', { loose: true, modules: false }
+]
+
+module.exports = {
+  plugins: ['transform-object-rest-spread'],
+  presets: [
+    env,
+    'react',
+  ],
+};

--- a/packages/idyll-components/package.json
+++ b/packages/idyll-components/package.json
@@ -2,11 +2,14 @@
   "name": "idyll-components",
   "version": "2.0.0-alpha.2",
   "description": "Components that ship by default in new Idyll projects",
-  "main": "dist/index.js",
-  "module": "src/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/es/index.js",
   "scripts": {
-    "build": "babel src -d dist",
-    "prepublish": "npm run build",
+    "prebuild": "rimraf dist",
+    "build:cjs": "BABEL_ENV=cjs babel src -d dist/cjs",
+    "build:es": "BABEL_ENV=es babel src -d dist/es",
+    "build": "npm run build:cjs && npm run build:es",
+    "prepublishOnly": "npm run build",
     "test": "jest"
   },
   "jest": {
@@ -48,13 +51,14 @@
   },
   "devDependencies": {
     "babel-cli": "6.26.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.24.1",
-    "babel-preset-stage-2": "^6.24.1",
     "enzyme": "^2.9.1",
     "jest": "^21.1.0",
     "react": "next",
     "react-addons-test-utils": "^15.6.0",
-    "react-dom": "next"
+    "react-dom": "next",
+    "rimraf": "^2.6.2"
   }
 }

--- a/packages/idyll-components/src/action.js
+++ b/packages/idyll-components/src/action.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 
 class Action extends React.PureComponent {
   render() {
@@ -8,4 +8,4 @@ class Action extends React.PureComponent {
   }
 }
 
-module.exports = Action;
+export default Action;

--- a/packages/idyll-components/src/analytics.js
+++ b/packages/idyll-components/src/analytics.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 
 class Analytics extends React.PureComponent {
   componentDidMount() {
@@ -20,4 +20,4 @@ class Analytics extends React.PureComponent {
 }
 
 
-module.exports = Analytics;
+export default Analytics;

--- a/packages/idyll-components/src/aside.js
+++ b/packages/idyll-components/src/aside.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 
 class Aside extends React.PureComponent {
   render() {
@@ -12,4 +12,4 @@ class Aside extends React.PureComponent {
   }
 }
 
-module.exports = Aside;
+export default Aside;

--- a/packages/idyll-components/src/boolean.js
+++ b/packages/idyll-components/src/boolean.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 
 class Boolean extends React.PureComponent {
   constructor(props) {
@@ -23,4 +23,4 @@ Boolean.defaultProps = {
   value: false
 };
 
-module.exports = Boolean;
+export default Boolean;

--- a/packages/idyll-components/src/button.js
+++ b/packages/idyll-components/src/button.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 
 class Button extends React.PureComponent {
   render() {
@@ -14,4 +14,4 @@ Button.defaultProps = {
   onClick: function() {}
 };
 
-module.exports = Button;
+export default Button;

--- a/packages/idyll-components/src/chart.js
+++ b/packages/idyll-components/src/chart.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 const V = require('victory');
 const d3Arr = require('d3-array');
 
@@ -64,4 +64,4 @@ Chart.defaultProps = {
   type: 'line'
 };
 
-module.exports = Chart;
+export default Chart;

--- a/packages/idyll-components/src/code-highlight.js
+++ b/packages/idyll-components/src/code-highlight.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 import SyntaxHighlighter from "react-syntax-highlighter/dist/light";
 import style from 'react-syntax-highlighter/dist/styles/github';
 
@@ -8,4 +8,4 @@ class CodeHighlight extends React.PureComponent {
   }
 }
 
-module.exports = CodeHighlight;
+export default CodeHighlight;

--- a/packages/idyll-components/src/display.js
+++ b/packages/idyll-components/src/display.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 const Format = require('d3-format');
 
 class Display extends React.PureComponent {
@@ -31,4 +31,4 @@ class Display extends React.PureComponent {
   }
 }
 
-module.exports = Display;
+export default Display;

--- a/packages/idyll-components/src/dynamic.js
+++ b/packages/idyll-components/src/dynamic.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 const ReactDOM = require('react-dom');
 const Format = require('d3-format');
 const Drag = require('d3-drag');
@@ -35,4 +35,4 @@ Dynamic.defaultProps = {
   interval: 1
 };
 
-module.exports = Dynamic;
+export default Dynamic;

--- a/packages/idyll-components/src/equation.js
+++ b/packages/idyll-components/src/equation.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 const ReactDOM = require('react-dom');
 const Latex = require('react-latex');
 const select = require('d3-selection').select;
@@ -122,4 +122,4 @@ class Equation extends React.PureComponent {
   }
 }
 
-module.exports = Equation;
+export default Equation;

--- a/packages/idyll-components/src/feature-content.js
+++ b/packages/idyll-components/src/feature-content.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 const ReactDOM = require('react-dom');
 
 class Content extends React.PureComponent {
@@ -9,4 +9,4 @@ class Content extends React.PureComponent {
   }
 }
 
-module.exports = Content;
+export default Content;

--- a/packages/idyll-components/src/feature.js
+++ b/packages/idyll-components/src/feature.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 const ReactDOM = require('react-dom');
 const Content = require('./feature-content');
 
@@ -117,4 +117,4 @@ class Feature extends React.PureComponent {
 }
 
 
-module.exports = Feature;
+export default Feature;

--- a/packages/idyll-components/src/fixed.js
+++ b/packages/idyll-components/src/fixed.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 
 class Fixed extends React.PureComponent {
   render() {
@@ -10,4 +10,4 @@ class Fixed extends React.PureComponent {
   }
 }
 
-module.exports = Fixed;
+export default Fixed;

--- a/packages/idyll-components/src/float.js
+++ b/packages/idyll-components/src/float.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 
 class Float extends React.PureComponent {
   render() {
@@ -10,4 +10,4 @@ class Float extends React.PureComponent {
   }
 }
 
-module.exports = Float;
+export default Float;

--- a/packages/idyll-components/src/full-screen.js
+++ b/packages/idyll-components/src/full-screen.js
@@ -1,5 +1,5 @@
 
-const React = require('react');
+import React from 'react';
 const ReactDOM = require('react-dom');
 const Screen = require('./utils/screen');
 
@@ -14,4 +14,4 @@ class FullScreen extends React.PureComponent {
 
 }
 
-module.exports = FullScreen;
+export default FullScreen;

--- a/packages/idyll-components/src/gist.js
+++ b/packages/idyll-components/src/gist.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 const PropTypes = require('prop-types');
 
 class EmbeddedGist extends React.PureComponent {
@@ -74,5 +74,5 @@ EmbeddedGist.nextGistCallback = () => {
     return "embed_gist_callback_" + gistCallbackId++;
 };
 
-module.exports = EmbeddedGist;
+export default EmbeddedGist;
 

--- a/packages/idyll-components/src/header.js
+++ b/packages/idyll-components/src/header.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 
 class Header extends React.PureComponent {
   render() {
@@ -27,4 +27,4 @@ class Header extends React.PureComponent {
   }
 }
 
-module.exports = Header;
+export default Header;

--- a/packages/idyll-components/src/index.js
+++ b/packages/idyll-components/src/index.js
@@ -1,22 +1,20 @@
-module.exports = {
-  action: require('./action.js'),
-  analytics: require('./analytics.js'),
-  aside: require('./aside.js'),
-  boolean: require('./boolean.js'),
-  button: require('./button.js'),
-  chart: require('./chart.js'),
-  display: require('./display.js'),
-  dynamic: require('./dynamic.js'),
-  equation: require('./equation.js'),
-  fixed: require('./fixed.js'),
-  float: require('./float.js'),
-  gist: require('./gist.js'),
-  header: require('./header.js'),
-  inline: require('./inline.js'),
-  link: require('./link.js'),
-  range: require('./range.js'),
-  slide: require('./slide.js'),
-  slideshow: require('./slideshow.js'),
-  svg: require('./svg.js'),
-  table: require('./table.js')
-}
+export { default as Action } from './action';
+export { default as Analytics } from './analytics';
+export { default as Aside } from './aside';
+export { default as Bool } from './boolean';
+export { default as Button } from './button';
+export { default as Chart } from './chart';
+export { default as Display } from './display';
+export { default as Dynamic } from './dynamic';
+export { default as Equation } from './equation';
+export { default as Fixed } from './fixed';
+export { default as Float } from './float';
+export { default as Gist } from './gist';
+export { default as Header } from './header';
+export { default as Inline } from './inline';
+export { default as Link } from './link';
+export { default as Range } from './range';
+export { default as Slide } from './slide';
+export { default as Slideshow } from './slideshow';
+export { default as Svg } from './svg';
+export { default as Table } from './table';

--- a/packages/idyll-components/src/inline.js
+++ b/packages/idyll-components/src/inline.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 
 class Inline extends React.PureComponent {
   render() {
@@ -10,4 +10,4 @@ class Inline extends React.PureComponent {
   }
 }
 
-module.exports = Inline;
+export default Inline;

--- a/packages/idyll-components/src/link.js
+++ b/packages/idyll-components/src/link.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 
 class Link extends React.PureComponent {
   constructor(props) {
@@ -18,4 +18,4 @@ class Link extends React.PureComponent {
   }
 }
 
-module.exports = Link;
+export default Link;

--- a/packages/idyll-components/src/panel.js
+++ b/packages/idyll-components/src/panel.js
@@ -1,5 +1,5 @@
 
-const React = require('react');
+import React from 'react';
 const ReactDOM = require('react-dom');
 
 class Panel extends React.PureComponent {
@@ -13,4 +13,4 @@ class Panel extends React.PureComponent {
 
 }
 
-module.exports = Panel;
+export default Panel;

--- a/packages/idyll-components/src/preload.js
+++ b/packages/idyll-components/src/preload.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 const ReactDOM = require('react-dom');
 const imageCache = [];
 
@@ -16,4 +16,4 @@ class Preloader extends React.PureComponent {
   }
 }
 
-module.exports = Preloader;
+export default Preloader;

--- a/packages/idyll-components/src/radio.js
+++ b/packages/idyll-components/src/radio.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 const ReactDOM = require('react-dom');
 let id = 0;
 
@@ -27,4 +27,4 @@ class Radio extends React.PureComponent {
   }
 }
 
-module.exports = Radio;
+export default Radio;

--- a/packages/idyll-components/src/range.js
+++ b/packages/idyll-components/src/range.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 
 class Range extends React.PureComponent {
   constructor(props) {
@@ -26,4 +26,4 @@ Range.defaultProps = {
   step: 1
 };
 
-module.exports = Range;
+export default Range;

--- a/packages/idyll-components/src/select.js
+++ b/packages/idyll-components/src/select.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 const ReactDOM = require('react-dom');
 
 class Select extends React.PureComponent {
@@ -25,4 +25,4 @@ class Select extends React.PureComponent {
   }
 }
 
-module.exports = Select;
+export default Select;

--- a/packages/idyll-components/src/slide.js
+++ b/packages/idyll-components/src/slide.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 
 class Slide extends React.PureComponent {
   render() {
@@ -10,4 +10,4 @@ class Slide extends React.PureComponent {
   }
 }
 
-module.exports = Slide;
+export default Slide;

--- a/packages/idyll-components/src/slideshow.js
+++ b/packages/idyll-components/src/slideshow.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 const Slide = require('./slide');
 
 class Slideshow extends React.PureComponent {
@@ -31,4 +31,4 @@ Slideshow.defaultProps = {
   currentSlide: 1
 };
 
-module.exports = Slideshow;
+export default Slideshow;

--- a/packages/idyll-components/src/svg.js
+++ b/packages/idyll-components/src/svg.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 const InlineSVG = require('react-inlinesvg');
 
 class SVG extends React.PureComponent {
@@ -9,5 +9,5 @@ class SVG extends React.PureComponent {
   }
 }
 
-module.exports = SVG;
+export default SVG;
 

--- a/packages/idyll-components/src/table.js
+++ b/packages/idyll-components/src/table.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 const Reactable = require('reactable');
 const Table = Reactable.Table;
 const Tr = Reactable.Tr;
@@ -12,4 +12,4 @@ class TableComponent extends React.PureComponent {
   }
 }
 
-module.exports = TableComponent;
+export default TableComponent;

--- a/packages/idyll-components/src/text-input.js
+++ b/packages/idyll-components/src/text-input.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 const ReactDOM = require('react-dom');
 
 class TextInput extends React.PureComponent {
@@ -18,4 +18,4 @@ class TextInput extends React.PureComponent {
   }
 }
 
-module.exports = TextInput;
+export default TextInput;

--- a/packages/idyll-components/src/utils/container.js
+++ b/packages/idyll-components/src/utils/container.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 const ReactDOM = require('react-dom');
 
 class Container extends React.Component {
@@ -69,4 +69,4 @@ Container.defaultProps = {
   fullBleed: false
 }
 
-module.exports = Container;
+export default Container;

--- a/packages/idyll-components/src/utils/screen.js
+++ b/packages/idyll-components/src/utils/screen.js
@@ -1,5 +1,5 @@
 
-const React = require('react');
+import React from 'react';
 const ReactDOM = require('react-dom');
 const Container = require('./container');
 
@@ -71,4 +71,4 @@ Screen.defaultProps = {
   align: 'left',
 };
 
-module.exports = Screen;
+export default Screen;

--- a/packages/idyll-components/src/waypoint.js
+++ b/packages/idyll-components/src/waypoint.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 const ReactDOM = require('react-dom');
 const Screen = require('./utils/screen');
 

--- a/packages/idyll-components/src/waypoint.js
+++ b/packages/idyll-components/src/waypoint.js
@@ -12,3 +12,5 @@ class Waypoint extends React.PureComponent {
   }
 
 }
+
+export default Waypoint;

--- a/packages/idyll-document/.babelrc
+++ b/packages/idyll-document/.babelrc
@@ -1,4 +1,3 @@
 {
-  "presets": ["env", "react"],
-  "plugins": ["transform-object-rest-spread"]
+  "presets": ["./.babelrc.js"]
 }

--- a/packages/idyll-document/.babelrc.js
+++ b/packages/idyll-document/.babelrc.js
@@ -1,0 +1,12 @@
+const BABEL_ENV = process.env.BABEL_ENV;
+const env = BABEL_ENV === 'cjs' ? 'env' : [
+  'env', { loose: true, modules: false }
+]
+
+module.exports = {
+  plugins: ['transform-object-rest-spread'],
+  presets: [
+    env,
+    'react',
+  ],
+};

--- a/packages/idyll-document/package.json
+++ b/packages/idyll-document/package.json
@@ -6,11 +6,14 @@
     "Matthew Conlen",
     "Ben Clinkinbeard"
   ],
-  "main": "dist/index.js",
-  "module": "src/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/es/index.js",
   "scripts": {
-    "build": "babel src -d dist",
-    "prepublish": "npm run build",
+    "prebuild": "rimraf dist",
+    "build:cjs": "BABEL_ENV=cjs babel src -d dist/cjs",
+    "build:es": "BABEL_ENV=es babel src -d dist/es",
+    "build": "npm run build:cjs && npm run build:es",
+    "prepublishOnly": "npm run build",
     "test": "jest"
   },
   "jest": {
@@ -35,7 +38,8 @@
     "jest": "^21.1.0",
     "react": "next",
     "react-dom": "next",
-    "react-test-renderer": "^15.6.1"
+    "react-test-renderer": "^15.6.1",
+    "rimraf": "^2.6.2"
   },
   "peerDependencies": {
     "react": "next",

--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -1,13 +1,11 @@
-const React = require('react');
-const ReactDOM = require('react-dom');
-const scrollMonitor = require('scrollmonitor');
-const ReactJsonSchema = require('./utils/schema2element').default;
-const entries = require('object.entries');
-const values = require('object.values');
-const {
-  flattenObject,
+import React from 'react';
+import ReactDOM from 'react-dom';
+import scrollMonitor from 'scrollmonitor';
+import ReactJsonSchema from './utils/schema2element';
+import entries from 'object.entries';
+import values from 'object.values';
+import {
   getData,
-  getNodesByName,
   getVars,
   splitAST,
   translate,
@@ -15,7 +13,7 @@ const {
   mapTree,
   evalExpression,
   hooks,
-} = require('./utils');
+} from './utils';
 
 const updatePropsCallbacks = [];
 const updateRefsCallbacks = [];
@@ -372,4 +370,4 @@ class IdyllDocument extends React.PureComponent {
   }
 }
 
-module.exports = IdyllDocument;
+export default IdyllDocument;

--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -1,25 +1,6 @@
 const values = require('object.values');
 const entries = require('object.entries');
 
-const flattenObject = (name, obj) => {
-  const output = {};
-  if (obj === undefined || obj === null) {
-    return output;
-  }
-  Object.keys(obj).forEach((key) => {
-    const val = obj[key];
-    if (typeof val === 'object') {
-      const results = flattenObject(key, val);
-      Object.keys(results).forEach((result) => {
-        output[name + result] = results[result];
-      });
-    } else {
-      output[name + key] = val;
-    }
-  });
-  return output;
-};
-
 const getNodesByName = (name, tree) => {
   const predicate = typeof name === 'string' ? (s) => s === name : name;
 
@@ -41,7 +22,7 @@ const getNodesByName = (name, tree) => {
   )
 }
 
-const evalExpression = (acc, expr) => {
+export const evalExpression = (acc, expr) => {
   const e = `
     (() => {
       ${
@@ -70,7 +51,7 @@ const evalExpression = (acc, expr) => {
   } catch (err) {}
 }
 
-const getVars = (arr, context) => {
+export const getVars = (arr, context) => {
   const pluck = (acc, val) => {
     const [ , attrs, ] = val
     const [nameArr, valueArr] = attrs;
@@ -108,7 +89,7 @@ const getVars = (arr, context) => {
   )
 }
 
-const getData = (arr, datasets = {}) => {
+export const getData = (arr, datasets = {}) => {
   const pluck = (acc, val) => {
     const [ , attrs, ] = val
     const [nameArr, ] = attrs;
@@ -126,7 +107,7 @@ const getData = (arr, datasets = {}) => {
   )
 }
 
-const splitAST = (ast) => {
+export const splitAST = (ast) => {
   const state = {
     vars: [],
     derived: [],
@@ -148,7 +129,7 @@ const splitAST = (ast) => {
   return state;
 }
 
-const hooks = [
+export const hooks = [
   'onEnterView',
   'onEnterViewFully',
   'onExitView',
@@ -156,7 +137,7 @@ const hooks = [
   'onScroll',
 ];
 
-const translate = (arr) => {
+export const translate = (arr) => {
   const attrConvert = (list) => {
     return list.reduce(
       (acc, [name, [type, val]]) => {
@@ -196,7 +177,7 @@ const translate = (arr) => {
   return splitAST(arr).elements.map(tNode)
 }
 
-const mapTree = (tree, mapFn) => {
+export const mapTree = (tree, mapFn) => {
   const walkFn = (acc, node) => {
     if (typeof node !== 'string') {
       node.children = node.children.reduce(walkFn, [])
@@ -212,7 +193,7 @@ const mapTree = (tree, mapFn) => {
   )
 }
 
-const findWrapTargets = (schema, state) => {
+export const findWrapTargets = (schema, state) => {
   const targets = [];
   const stateKeys = Object.keys(state);
 
@@ -256,16 +237,3 @@ const findWrapTargets = (schema, state) => {
 
   return targets;
 }
-
-module.exports = {
-  flattenObject,
-  getData,
-  getNodesByName,
-  getVars,
-  splitAST,
-  translate,
-  findWrapTargets,
-  mapTree,
-  evalExpression,
-  hooks,
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5972,6 +5972,12 @@ rimraf@2, rimraf@2.6.1, rimraf@^2.5.1, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
+rimraf@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
+  dependencies:
+    glob "^7.0.5"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.1.tgz#0f4584295c53a3628af7e6d79aca21ce57d1c6e7"


### PR DESCRIPTION
Fixes #168 

There were two things needed to enable consuming projects to actually take advantage of the `main` and `module` fields defined in the `package.json` files.

First, the source needed to actually be defined as ES modules, which it previously wasn't. This PR converts `idyll-components` and `idyll-document`. Not sure if we'll want/need to convert the others in the future.

Second, we needed to actually create an "ES bundle" via the build. This is essentially a copy of the ES source with everything but the module definitions/entry file transpiled ahead of time. This allows tree shaking in consumer builds without having to replicate our Babel setup.

Speaking of, the Babel setup for the `idyll-components` and `idyll-document` packages was streamlined and brought up to date. The `stage-2` preset was swapped out for the `babel-plugin-transform-object-rest-spread` plugin since I think that's all we were using from `stage-2`. We also need to use `BABEL_ENV` to create the two types of builds, so the `.babelrc` files now point to `.babelrc.js` files. This prepares us well for Babel 7, which will [deprecate](https://github.com/babel/babel/issues/5276) the use of `env` in `.babelrc` files.

This PR was modeled after `react-router`'s [setup](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/tools/babel-preset.js).