### PR TITLE
handle errors for unknown languages

### DIFF
--- a/packages/idyll-cli/src/pipeline/parse.js
+++ b/packages/idyll-cli/src/pipeline/parse.js
@@ -163,7 +163,11 @@ exports.getHighlightJS = (ast, paths, server) => {
       if (languageMap[language]) {
         cleanedLanguage = languageMap[language];
       }
-      rsh.registerLanguage(language, require(slash(path.join(rshPath, 'languages', cleanedLanguage))).default);
+      try {
+        rsh.registerLanguage(language, require(slash(path.join(rshPath, 'languages', cleanedLanguage))).default);
+      } catch(e) {
+        console.warn(`Warning: could not find syntax highlighter for ${language}`);
+      }
     });
     return;
   }
@@ -175,7 +179,13 @@ exports.getHighlightJS = (ast, paths, server) => {
     if (languageMap[language]) {
       cleanedLanguage = languageMap[language];
     }
-    js += `\nrsh.registerLanguage('${language}', require('${slash(path.join(rshPath, 'languages', cleanedLanguage))}').default);`
+    js += `
+      try {
+        rsh.registerLanguage('${language}', require('${slash(path.join(rshPath, 'languages', cleanedLanguage))}').default);
+      } catch(e) {
+        console.warn("Warning: could not find syntax highlighter for ${language}");
+      }
+    `
   });
 
   return js;


### PR DESCRIPTION
Better error handling if syntax highlighting is requested for an unknown language

Fixes https://github.com/idyll-lang/idyll/issues/137