### PR TITLE
Remove react-addons-test-utils

### DIFF
--- a/packages/idyll-components/package.json
+++ b/packages/idyll-components/package.json
@@ -59,7 +59,6 @@
     "enzyme-adapter-react-16": "^1.0.0",
     "jest": "^20.0.4",
     "react": "^16.0.0",
-    "react-addons-test-utils": "^15.6.2",
     "react-dom": "^16.0.0",
     "rimraf": "^2.6.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5358,10 +5358,6 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-addons-test-utils@^15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz#c12b6efdc2247c10da7b8770d185080a7b047156"
-
 react-dom-factories@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/react-dom-factories/-/react-dom-factories-1.0.2.tgz#eb7705c4db36fb501b3aa38ff759616aa0ff96e0"


### PR DESCRIPTION
Partly just to test AppVeyor config, but I also don't think we need it.