### PR TITLE
Rely more directly on scrollmonitor, address perf issues 

### DIFF
--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -18,6 +18,7 @@ import {
 const updatePropsCallbacks = [];
 const updateRefsCallbacks = [];
 const scrollWatchers = [];
+const scrollOffsets = {};
 let scrollContainer;
 
 const getScrollableContainer = el => {
@@ -217,7 +218,7 @@ class IdyllDocument extends React.PureComponent {
 
             const domNode = ReactDOM.findDOMNode(el);
             domNode.dataset.ref = node.refName;
-            domNode.dataset.scrollOffset = node.scrollOffset ? JSON.stringify(node.scrollOffset) : undefined;
+            scrollOffsets[node.refName] = node.scrollOffset || 0;
           };
         }
 
@@ -307,7 +308,7 @@ class IdyllDocument extends React.PureComponent {
     const scroller = getScrollableContainer(el) || window;
     scrollContainer = scrollMonitor.createContainer(scroller);
     Array.from(document.getElementsByClassName('is-ref')).forEach(ref => {
-      scrollWatchers.push(scrollContainer.create(ref, ref.dataset.scrollOffset ? JSON.parse(ref.dataset.scrollOffset) : undefined));
+      scrollWatchers.push(scrollContainer.create(ref, scrollOffsets[ref.dataset.ref]));
     });
     scroller.addEventListener('scroll', this.scrollListener);
   }

--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -35,10 +35,9 @@ const getRefs = () => {
   scrollWatchers.forEach(watcher => {
     // left and right props assume no horizontal scrolling
     const { watchItem, callbacks, container, recalculateLocation, offsets, ...watcherProps} = watcher;
-    const domNode = watchItem;
     refs[domNode.dataset.ref] = {
       ...watcherProps,
-      domNode
+      domNode: watchItem
     };
   });
 

--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -33,7 +33,7 @@ const getRefs = () => {
 
   scrollWatchers.forEach(watcher => {
     // left and right props assume no horizontal scrolling
-    const { watchItem, callbacks, container, recalculateLocation, ...watcherProps} = watcher;
+    const { watchItem, callbacks, container, recalculateLocation, offsets, ...watcherProps} = watcher;
     const domNode = watchItem;
     refs[domNode.dataset.ref] = {
       ...watcherProps,


### PR DESCRIPTION
This is in response to https://github.com/idyll-lang/idyll/issues/157. It modifies the properties that get added to the ref object to just be those that scrollmonitor provides directly (and adds `domNode`), and removes `portionInView`, because I don't think theres a way to do this reliably without triggering reflows. In the future we can investigate was to cache element sizes and watch for resize events (see https://stackoverflow.com/questions/6492683/how-to-detect-divs-dimension-changed for more info), but for the time being this should capture the majority of use cases. The props are:

```
isInViewport - true if any part of the element is visible, false if not.
isFullyInViewport - true if the entire element is visible [1].
isAboveViewport - true if any part of the element is above the viewport.
isBelowViewport - true if any part of the element is below the viewport.
top - distance from the top of the document to the top of this watcher.
bottom - distance from the top of the document to the bottom of this watcher.
height - top - bottom.
domNode - a reference to the dom node
```

This also adds a `scrollOffset` property to items so that they may have more fine grained control about elements near the edge of the screen. For example you can create a component like

```
[Chart  ref:"myChart" scrollOffset:-200 /]
```

and scrollmonitor will consider the "edge" of the screen to be 200 pixels outside of the viewport, or 


```
[Chart  ref:"myChart" scrollOffset:`{ top: -200, bottom: 200 }` /]
```
to customize the top and bottom offsets.