### PR TITLE
use idyll-document module

### DIFF
--- a/packages/idyll-editor/src/renderer.js
+++ b/packages/idyll-editor/src/renderer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as components from 'idyll-components';
-import IdyllDocument from '../../idyll-document/src';
+import IdyllDocument from 'idyll-document';
 
 class Renderer extends React.PureComponent {
   render() {


### PR DESCRIPTION
from @bclinkinbeard on [gitter](https://gitter.im/idyll-lang/Lobby):

> two weird things with the editor. it’s using the CJS builds of idyll-components and the editor’s start script is somehow watching and reacting to changes in idyll-document

1. I think this is "as expected" because we're bundling with browserify and it uses `main` or `browser` fields in package.json to resolve an entry point

2. Because we were importing idyll document directly from its source folder and not from the node_modules the changes were getting picked up. This updates the import to not point directly to the source