### PR TITLE
recursive parsing of headings

### DIFF
--- a/packages/idyll-compiler/src/grammar.ne
+++ b/packages/idyll-compiler/src/grammar.ne
@@ -38,9 +38,14 @@ BreakBlock -> (Paragraph) {%
   }
 %}
 
-Header -> "HEADER_" [1-6] __ TokenValue {%
+Header -> "HEADER_" [1-6] (__ ParagraphItem):+ __ "HEADER_END" {%
   function(data, location, reject) {
-    return ["h" + data[1], [], [data[3]]];
+    var children = [];
+    data[2].map(function (child) {
+      children.push(child[1]);
+    });
+
+    return ["h" + data[1], [], children];
   }
 %}
 

--- a/packages/idyll-compiler/src/lexer.js
+++ b/packages/idyll-compiler/src/lexer.js
@@ -68,7 +68,7 @@ const lex = function(options) {
   lexer.addRule(/^\s*(#{1,6})\s*([^\n]*)\n*/gm, function(lexeme, hashes, text) {
     if (this.reject) return;
     updatePosition(lexeme);
-    return ['HEADER_' + hashes.length].concat(formatToken(text));
+    return ['HEADER_' + hashes.length].concat(recurse(text)).concat(['HEADER_END']);
   });
 
   lexer.addRule(/\*([^\s\n\*][^\*]*[^\s\n\*])\*/g, function(lexeme, text) {

--- a/packages/idyll-compiler/test/test.js
+++ b/packages/idyll-compiler/test/test.js
@@ -22,7 +22,7 @@ describe('compiler', function() {
     it('should recognize headings', function() {
       var lex = Lexer();
       var results = lex("\n## my title");
-      expect(results.tokens.join(' ')).to.eql('HEADER_2 TOKEN_VALUE_START "my title" TOKEN_VALUE_END EOF');
+      expect(results.tokens.join(' ')).to.eql('HEADER_2 WORDS TOKEN_VALUE_START "my title" TOKEN_VALUE_END HEADER_END EOF');
     });
     it('should handle newlines', function() {
       var lex = Lexer();
@@ -409,7 +409,15 @@ describe('compiler', function() {
       var lex = Lexer();
       var lexResults = lex(input);
       var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
-        expect(output).to.eql([['Slideshow', [], [['Slide', [], []], ['Slide', [], []], ['Slide', [], []]] ]]);
+      expect(output).to.eql([['Slideshow', [], [['Slide', [], []], ['Slide', [], []], ['Slide', [], []]] ]]);
+    });
+
+    it('should handle items nested in a header', function() {
+      const input = `# My header is **bold**!`;
+      var lex = Lexer();
+      var lexResults = lex(input);
+      var output = parse(input, lexResults.tokens.join(' '), lexResults.positions);
+      expect(output).to.eql([["h1",[],["My header is ",["strong",[],["bold"]],"!"]]]);
     })
 });
 


### PR DESCRIPTION
this addresses https://github.com/idyll-lang/idyll/issues/131 (and #134) by updating "headers" in the AST to be recursively parsed. this means that bold and italic items are supported within headers now, along with components. 