### PR TITLE
Improved IdyllDocument tests

### DIFF
--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import scrollMonitor from 'scrollmonitor';
+import compile from 'idyll-compiler';
 import ReactJsonSchema from './utils/schema2element';
 import entries from 'object.entries';
 import values from 'object.values';
@@ -178,12 +179,19 @@ class IdyllDocument extends React.PureComponent {
     this.scrollListener = this.scrollListener.bind(this);
     this.initScrollListener = this.initScrollListener.bind(this);
 
+    if (!props.ast && !props.src) {
+      this.kids = null;
+      return;
+    }
+
+    const ast = props.ast || compile(props.src);
+
     const {
       vars,
       derived,
       data,
       elements,
-    } = splitAST(props.ast);
+    } = splitAST(ast);
 
     const initialState = {
       ...getVars(vars),
@@ -197,7 +205,7 @@ class IdyllDocument extends React.PureComponent {
     };
 
     const rjs = new ReactJsonSchema({...props.components, Wrapper});
-    const schema = translate(props.ast);
+    const schema = translate(ast);
 
     const wrapTargets = findWrapTargets(schema, this.state);
 

--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -208,6 +208,13 @@ export const findWrapTargets = (schema, state) => {
       return node;
     }
 
+    // wrap all custom components
+    const startsWith = node.component.charAt(0);
+    if (startsWith === startsWith.toUpperCase()) {
+      targets.push(node);
+      return node;
+    }
+
     // pull off the props we don't need to check
     const { component, children, __vars__, __expr__, ...props } = node;
     const expressions = Object.keys(__expr__ || {});

--- a/packages/idyll-document/test/__snapshots__/schema2element.js.snap
+++ b/packages/idyll-document/test/__snapshots__/schema2element.js.snap
@@ -1,0 +1,2258 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReactJsonSchema can parse a schema 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <div>
+    <h1>
+        Welcome to Idyll
+    </h1>
+    <h3>
+        Idyll is a language for creating interactive documents on the web.
+    </h3>
+    <p>
+        This document is being rendered from 
+        <strong>
+            Idyll markup
+        </strong>
+        . If you’ve used 
+        <a
+            href="https://daringfireball.net/projects/markdown/"
+        >
+            markdown
+        </a>
+        , Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.
+    </p>
+    <p>
+        To make things a little more interesting you can add JavaScript components to your text.
+        For example, a 
+        <code>
+            [Chart /]
+        </code>
+         component can be used to render a simple visualization:
+    </p>
+    <Chart
+        domain={
+            Array [
+                -1,
+                1,
+              ]
+        }
+        domainPadding={0}
+        range={
+            Array [
+                -1,
+                1,
+              ]
+        }
+        samplePoints={100}
+        type="scatter"
+    >
+        
+    </Chart>
+    <p>
+        Try changing the chart’s type from 
+        <code>
+            scatter
+        </code>
+         to 
+        <code>
+            line
+        </code>
+        , 
+        <code>
+            area
+        </code>
+        , or 
+        <code>
+            pie
+        </code>
+        .
+    </p>
+    <p>
+        A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (
+        <code>
+            \`2 * Math.PI\`
+        </code>
+        ).
+    </p>
+    <p>
+        There are a number of components available — see 
+        <a
+            href="https://idyll-lang.github.io/components-built-in"
+        >
+            Idyll’s documentation
+        </a>
+         for a full list — Additional components can be installed via 
+        <code>
+            npm
+        </code>
+         (any React component should work), and if you are comfortable with JavaScript you can write 
+        <a
+            href="https://idyll-lang.github.io/components-custom"
+        >
+            custom components
+        </a>
+         as well.
+    </p>
+    <p>
+        Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.
+    </p>
+    <p>
+        Instantiating a variable is similar to instantiating a component:
+    </p>
+    <code>
+        [var name:"x" value:1 /]
+    </code>
+    <p>
+        Once you’ve created a variable, it can be displayed inline with text
+        (x = 
+        <Display
+            __vars__={
+                Object {
+                    "var": "x",
+                  }
+            }
+            var="x"
+        >
+            
+        </Display>
+        ),
+        or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:
+    </p>
+    <code>
+        [derived name:"xSquared" value:\`x * x\` /]
+    </code>
+    <p>
+        Here I bind the value of 
+        <code>
+            x
+        </code>
+         to a range slider. Move the slider and watch the variables update.
+    </p>
+    <Range
+        __vars__={
+            Object {
+                "value": "x",
+              }
+        }
+        max={100}
+        min={0}
+        step={1}
+        value="x"
+    >
+        
+    </Range>
+    <p>
+        <Equation>
+            x
+        </Equation>
+        :
+         
+        <Display
+            __expr__={
+                Object {
+                    "var": "x",
+                  }
+            }
+            var="x"
+        >
+            
+        </Display>
+    </p>
+    <p>
+        <Equation>
+            x^2
+        </Equation>
+        :
+         
+        <Display
+            __expr__={
+                Object {
+                    "var": "xSquared",
+                  }
+            }
+            var="xSquared"
+        >
+            
+        </Display>
+    </p>
+    <p>
+        Here is an example of how you could use a variable to control the frequency of a sine wave:
+    </p>
+    <Chart
+        __expr__={
+            Object {
+                "domain": "[0, 2 * Math.PI]",
+                "equation": "(t) => Math.sin(t * frequency)",
+              }
+        }
+        domain="[0, 2 * Math.PI]"
+        domainPadding={0}
+        equation="(t) => Math.sin(t * frequency)"
+        range={
+            Array [
+                -1,
+                1,
+              ]
+        }
+        samplePoints={1000}
+        type="line"
+    >
+        
+    </Chart>
+    <Range
+        __expr__={
+            Object {
+                "max": "2 * Math.PI",
+              }
+        }
+        __vars__={
+            Object {
+                "value": "frequency",
+              }
+        }
+        max="2 * Math.PI"
+        min={0.5}
+        step={0.0001}
+        value="frequency"
+    >
+        
+    </Range>
+    <p>
+        Read more about Idyll at 
+        <a
+            href="https://idyll-lang.github.io/"
+        >
+            https://idyll-lang.github.io/
+        </a>
+        , and come say “Hi!” in our 
+        <a
+            href="https://gitter.im/idyll-lang/Lobby"
+        >
+            chatroom on gitter
+        </a>
+        .
+    </p>
+</div>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": null,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <h1>
+          Welcome to Idyll
+</h1>,
+        <h3>
+          Idyll is a language for creating interactive documents on the web.
+</h3>,
+        <p>
+          This document is being rendered from 
+          <strong>
+                    Idyll markup
+          </strong>
+          . If you’ve used 
+          <a
+                    href="https://daringfireball.net/projects/markdown/"
+          >
+                    markdown
+          </a>
+          , Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.
+</p>,
+        <p>
+          To make things a little more interesting you can add JavaScript components to your text.
+          For example, a 
+          <code>
+                    [Chart /]
+          </code>
+           component can be used to render a simple visualization:
+</p>,
+        <Chart
+          domain={
+                    Array [
+                              -1,
+                              1,
+                            ]
+          }
+          domainPadding={0}
+          range={
+                    Array [
+                              -1,
+                              1,
+                            ]
+          }
+          samplePoints={100}
+          type="scatter"
+>
+          
+</Chart>,
+        <p>
+          Try changing the chart’s type from 
+          <code>
+                    scatter
+          </code>
+           to 
+          <code>
+                    line
+          </code>
+          , 
+          <code>
+                    area
+          </code>
+          , or 
+          <code>
+                    pie
+          </code>
+          .
+</p>,
+        <p>
+          A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (
+          <code>
+                    \`2 * Math.PI\`
+          </code>
+          ).
+</p>,
+        <p>
+          There are a number of components available — see 
+          <a
+                    href="https://idyll-lang.github.io/components-built-in"
+          >
+                    Idyll’s documentation
+          </a>
+           for a full list — Additional components can be installed via 
+          <code>
+                    npm
+          </code>
+           (any React component should work), and if you are comfortable with JavaScript you can write 
+          <a
+                    href="https://idyll-lang.github.io/components-custom"
+          >
+                    custom components
+          </a>
+           as well.
+</p>,
+        <p>
+          Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.
+</p>,
+        <p>
+          Instantiating a variable is similar to instantiating a component:
+</p>,
+        <code>
+          [var name:"x" value:1 /]
+</code>,
+        <p>
+          Once you’ve created a variable, it can be displayed inline with text
+          (x = 
+          <Display
+                    __vars__={
+                              Object {
+                                        "var": "x",
+                                      }
+                    }
+                    var="x"
+          >
+                    
+          </Display>
+          ),
+          or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:
+</p>,
+        <code>
+          [derived name:"xSquared" value:\`x * x\` /]
+</code>,
+        <p>
+          Here I bind the value of 
+          <code>
+                    x
+          </code>
+           to a range slider. Move the slider and watch the variables update.
+</p>,
+        <Range
+          __vars__={
+                    Object {
+                              "value": "x",
+                            }
+          }
+          max={100}
+          min={0}
+          step={1}
+          value="x"
+>
+          
+</Range>,
+        <p>
+          <Equation>
+                    x
+          </Equation>
+          :
+           
+          <Display
+                    __expr__={
+                              Object {
+                                        "var": "x",
+                                      }
+                    }
+                    var="x"
+          >
+                    
+          </Display>
+</p>,
+        <p>
+          <Equation>
+                    x^2
+          </Equation>
+          :
+           
+          <Display
+                    __expr__={
+                              Object {
+                                        "var": "xSquared",
+                                      }
+                    }
+                    var="xSquared"
+          >
+                    
+          </Display>
+</p>,
+        <p>
+          Here is an example of how you could use a variable to control the frequency of a sine wave:
+</p>,
+        <Chart
+          __expr__={
+                    Object {
+                              "domain": "[0, 2 * Math.PI]",
+                              "equation": "(t) => Math.sin(t * frequency)",
+                            }
+          }
+          domain="[0, 2 * Math.PI]"
+          domainPadding={0}
+          equation="(t) => Math.sin(t * frequency)"
+          range={
+                    Array [
+                              -1,
+                              1,
+                            ]
+          }
+          samplePoints={1000}
+          type="line"
+>
+          
+</Chart>,
+        <Range
+          __expr__={
+                    Object {
+                              "max": "2 * Math.PI",
+                            }
+          }
+          __vars__={
+                    Object {
+                              "value": "frequency",
+                            }
+          }
+          max="2 * Math.PI"
+          min={0.5}
+          step={0.0001}
+          value="frequency"
+>
+          
+</Range>,
+        <p>
+          Read more about Idyll at 
+          <a
+                    href="https://idyll-lang.github.io/"
+          >
+                    https://idyll-lang.github.io/
+          </a>
+          , and come say “Hi!” in our 
+          <a
+                    href="https://gitter.im/idyll-lang/Lobby"
+          >
+                    chatroom on gitter
+          </a>
+          .
+</p>,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": "0",
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            "Welcome to Idyll",
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          "Welcome to Idyll",
+        ],
+        "type": "h1",
+      },
+      Object {
+        "instance": null,
+        "key": "1",
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            "Idyll is a language for creating interactive documents on the web.",
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          "Idyll is a language for creating interactive documents on the web.",
+        ],
+        "type": "h3",
+      },
+      Object {
+        "instance": null,
+        "key": "2",
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            "This document is being rendered from ",
+            <strong>
+              Idyll markup
+</strong>,
+            ". If you’ve used ",
+            <a
+              href="https://daringfireball.net/projects/markdown/"
+>
+              markdown
+</a>,
+            ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.",
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          "This document is being rendered from ",
+          Object {
+            "instance": null,
+            "key": "0",
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                "Idyll markup",
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              "Idyll markup",
+            ],
+            "type": "strong",
+          },
+          ". If you’ve used ",
+          Object {
+            "instance": null,
+            "key": "1",
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                "markdown",
+              ],
+              "href": "https://daringfireball.net/projects/markdown/",
+            },
+            "ref": null,
+            "rendered": Array [
+              "markdown",
+            ],
+            "type": "a",
+          },
+          ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.",
+        ],
+        "type": "p",
+      },
+      Object {
+        "instance": null,
+        "key": "3",
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            "To make things a little more interesting you can add JavaScript components to your text.
+For example, a ",
+            <code>
+              [Chart /]
+</code>,
+            " component can be used to render a simple visualization:",
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          "To make things a little more interesting you can add JavaScript components to your text.
+For example, a ",
+          Object {
+            "instance": null,
+            "key": "0",
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                "[Chart /]",
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              "[Chart /]",
+            ],
+            "type": "code",
+          },
+          " component can be used to render a simple visualization:",
+        ],
+        "type": "p",
+      },
+      Object {
+        "instance": null,
+        "key": "4",
+        "nodeType": "class",
+        "props": Object {
+          "children": Array [],
+          "domain": Array [
+            -1,
+            1,
+          ],
+          "domainPadding": 0,
+          "range": Array [
+            -1,
+            1,
+          ],
+          "samplePoints": 100,
+          "type": "scatter",
+        },
+        "ref": null,
+        "rendered": Array [],
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": "5",
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            "Try changing the chart’s type from ",
+            <code>
+              scatter
+</code>,
+            " to ",
+            <code>
+              line
+</code>,
+            ", ",
+            <code>
+              area
+</code>,
+            ", or ",
+            <code>
+              pie
+</code>,
+            ".",
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          "Try changing the chart’s type from ",
+          Object {
+            "instance": null,
+            "key": "0",
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                "scatter",
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              "scatter",
+            ],
+            "type": "code",
+          },
+          " to ",
+          Object {
+            "instance": null,
+            "key": "1",
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                "line",
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              "line",
+            ],
+            "type": "code",
+          },
+          ", ",
+          Object {
+            "instance": null,
+            "key": "2",
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                "area",
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              "area",
+            ],
+            "type": "code",
+          },
+          ", or ",
+          Object {
+            "instance": null,
+            "key": "3",
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                "pie",
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              "pie",
+            ],
+            "type": "code",
+          },
+          ".",
+        ],
+        "type": "p",
+      },
+      Object {
+        "instance": null,
+        "key": "6",
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (",
+            <code>
+              \`2 * Math.PI\`
+</code>,
+            ").",
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (",
+          Object {
+            "instance": null,
+            "key": "0",
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                "\`2 * Math.PI\`",
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              "\`2 * Math.PI\`",
+            ],
+            "type": "code",
+          },
+          ").",
+        ],
+        "type": "p",
+      },
+      Object {
+        "instance": null,
+        "key": "7",
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            "There are a number of components available — see ",
+            <a
+              href="https://idyll-lang.github.io/components-built-in"
+>
+              Idyll’s documentation
+</a>,
+            " for a full list — Additional components can be installed via ",
+            <code>
+              npm
+</code>,
+            " (any React component should work), and if you are comfortable with JavaScript you can write ",
+            <a
+              href="https://idyll-lang.github.io/components-custom"
+>
+              custom components
+</a>,
+            " as well.",
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          "There are a number of components available — see ",
+          Object {
+            "instance": null,
+            "key": "0",
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                "Idyll’s documentation",
+              ],
+              "href": "https://idyll-lang.github.io/components-built-in",
+            },
+            "ref": null,
+            "rendered": Array [
+              "Idyll’s documentation",
+            ],
+            "type": "a",
+          },
+          " for a full list — Additional components can be installed via ",
+          Object {
+            "instance": null,
+            "key": "1",
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                "npm",
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              "npm",
+            ],
+            "type": "code",
+          },
+          " (any React component should work), and if you are comfortable with JavaScript you can write ",
+          Object {
+            "instance": null,
+            "key": "2",
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                "custom components",
+              ],
+              "href": "https://idyll-lang.github.io/components-custom",
+            },
+            "ref": null,
+            "rendered": Array [
+              "custom components",
+            ],
+            "type": "a",
+          },
+          " as well.",
+        ],
+        "type": "p",
+      },
+      Object {
+        "instance": null,
+        "key": "8",
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            "Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.",
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          "Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.",
+        ],
+        "type": "p",
+      },
+      Object {
+        "instance": null,
+        "key": "9",
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            "Instantiating a variable is similar to instantiating a component:",
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          "Instantiating a variable is similar to instantiating a component:",
+        ],
+        "type": "p",
+      },
+      Object {
+        "instance": null,
+        "key": "10",
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            "[var name:\\"x\\" value:1 /]",
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          "[var name:\\"x\\" value:1 /]",
+        ],
+        "type": "code",
+      },
+      Object {
+        "instance": null,
+        "key": "11",
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            "Once you’ve created a variable, it can be displayed inline with text
+(x = ",
+            <Display
+              __vars__={
+                            Object {
+                                          "var": "x",
+                                        }
+              }
+              var="x"
+>
+              
+</Display>,
+            "),
+or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:",
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          "Once you’ve created a variable, it can be displayed inline with text
+(x = ",
+          Object {
+            "instance": null,
+            "key": "0",
+            "nodeType": "class",
+            "props": Object {
+              "__vars__": Object {
+                "var": "x",
+              },
+              "children": Array [],
+              "var": "x",
+            },
+            "ref": null,
+            "rendered": Array [],
+            "type": [Function],
+          },
+          "),
+or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:",
+        ],
+        "type": "p",
+      },
+      Object {
+        "instance": null,
+        "key": "12",
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            "[derived name:\\"xSquared\\" value:\`x * x\` /]",
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          "[derived name:\\"xSquared\\" value:\`x * x\` /]",
+        ],
+        "type": "code",
+      },
+      Object {
+        "instance": null,
+        "key": "13",
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            "Here I bind the value of ",
+            <code>
+              x
+</code>,
+            " to a range slider. Move the slider and watch the variables update.",
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          "Here I bind the value of ",
+          Object {
+            "instance": null,
+            "key": "0",
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                "x",
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              "x",
+            ],
+            "type": "code",
+          },
+          " to a range slider. Move the slider and watch the variables update.",
+        ],
+        "type": "p",
+      },
+      Object {
+        "instance": null,
+        "key": "14",
+        "nodeType": "class",
+        "props": Object {
+          "__vars__": Object {
+            "value": "x",
+          },
+          "children": Array [],
+          "max": 100,
+          "min": 0,
+          "step": 1,
+          "value": "x",
+        },
+        "ref": null,
+        "rendered": Array [],
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": "15",
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <Equation>
+              x
+</Equation>,
+            ":
+ ",
+            <Display
+              __expr__={
+                            Object {
+                                          "var": "x",
+                                        }
+              }
+              var="x"
+>
+              
+</Display>,
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": "0",
+            "nodeType": "class",
+            "props": Object {
+              "children": Array [
+                "x",
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              "x",
+            ],
+            "type": [Function],
+          },
+          ":
+ ",
+          Object {
+            "instance": null,
+            "key": "1",
+            "nodeType": "class",
+            "props": Object {
+              "__expr__": Object {
+                "var": "x",
+              },
+              "children": Array [],
+              "var": "x",
+            },
+            "ref": null,
+            "rendered": Array [],
+            "type": [Function],
+          },
+        ],
+        "type": "p",
+      },
+      Object {
+        "instance": null,
+        "key": "16",
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <Equation>
+              x^2
+</Equation>,
+            ":
+ ",
+            <Display
+              __expr__={
+                            Object {
+                                          "var": "xSquared",
+                                        }
+              }
+              var="xSquared"
+>
+              
+</Display>,
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": "0",
+            "nodeType": "class",
+            "props": Object {
+              "children": Array [
+                "x^2",
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              "x^2",
+            ],
+            "type": [Function],
+          },
+          ":
+ ",
+          Object {
+            "instance": null,
+            "key": "1",
+            "nodeType": "class",
+            "props": Object {
+              "__expr__": Object {
+                "var": "xSquared",
+              },
+              "children": Array [],
+              "var": "xSquared",
+            },
+            "ref": null,
+            "rendered": Array [],
+            "type": [Function],
+          },
+        ],
+        "type": "p",
+      },
+      Object {
+        "instance": null,
+        "key": "17",
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            "Here is an example of how you could use a variable to control the frequency of a sine wave:",
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          "Here is an example of how you could use a variable to control the frequency of a sine wave:",
+        ],
+        "type": "p",
+      },
+      Object {
+        "instance": null,
+        "key": "18",
+        "nodeType": "class",
+        "props": Object {
+          "__expr__": Object {
+            "domain": "[0, 2 * Math.PI]",
+            "equation": "(t) => Math.sin(t * frequency)",
+          },
+          "children": Array [],
+          "domain": "[0, 2 * Math.PI]",
+          "domainPadding": 0,
+          "equation": "(t) => Math.sin(t * frequency)",
+          "range": Array [
+            -1,
+            1,
+          ],
+          "samplePoints": 1000,
+          "type": "line",
+        },
+        "ref": null,
+        "rendered": Array [],
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": "19",
+        "nodeType": "class",
+        "props": Object {
+          "__expr__": Object {
+            "max": "2 * Math.PI",
+          },
+          "__vars__": Object {
+            "value": "frequency",
+          },
+          "children": Array [],
+          "max": "2 * Math.PI",
+          "min": 0.5,
+          "step": 0.0001,
+          "value": "frequency",
+        },
+        "ref": null,
+        "rendered": Array [],
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": "20",
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            "Read more about Idyll at ",
+            <a
+              href="https://idyll-lang.github.io/"
+>
+              https://idyll-lang.github.io/
+</a>,
+            ", and come say “Hi!” in our ",
+            <a
+              href="https://gitter.im/idyll-lang/Lobby"
+>
+              chatroom on gitter
+</a>,
+            ".",
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          "Read more about Idyll at ",
+          Object {
+            "instance": null,
+            "key": "0",
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                "https://idyll-lang.github.io/",
+              ],
+              "href": "https://idyll-lang.github.io/",
+            },
+            "ref": null,
+            "rendered": Array [
+              "https://idyll-lang.github.io/",
+            ],
+            "type": "a",
+          },
+          ", and come say “Hi!” in our ",
+          Object {
+            "instance": null,
+            "key": "1",
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                "chatroom on gitter",
+              ],
+              "href": "https://gitter.im/idyll-lang/Lobby",
+            },
+            "ref": null,
+            "rendered": Array [
+              "chatroom on gitter",
+            ],
+            "type": "a",
+          },
+          ".",
+        ],
+        "type": "p",
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": null,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <h1>
+            Welcome to Idyll
+</h1>,
+          <h3>
+            Idyll is a language for creating interactive documents on the web.
+</h3>,
+          <p>
+            This document is being rendered from 
+            <strong>
+                        Idyll markup
+            </strong>
+            . If you’ve used 
+            <a
+                        href="https://daringfireball.net/projects/markdown/"
+            >
+                        markdown
+            </a>
+            , Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.
+</p>,
+          <p>
+            To make things a little more interesting you can add JavaScript components to your text.
+            For example, a 
+            <code>
+                        [Chart /]
+            </code>
+             component can be used to render a simple visualization:
+</p>,
+          <Chart
+            domain={
+                        Array [
+                                    -1,
+                                    1,
+                                  ]
+            }
+            domainPadding={0}
+            range={
+                        Array [
+                                    -1,
+                                    1,
+                                  ]
+            }
+            samplePoints={100}
+            type="scatter"
+>
+            
+</Chart>,
+          <p>
+            Try changing the chart’s type from 
+            <code>
+                        scatter
+            </code>
+             to 
+            <code>
+                        line
+            </code>
+            , 
+            <code>
+                        area
+            </code>
+            , or 
+            <code>
+                        pie
+            </code>
+            .
+</p>,
+          <p>
+            A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (
+            <code>
+                        \`2 * Math.PI\`
+            </code>
+            ).
+</p>,
+          <p>
+            There are a number of components available — see 
+            <a
+                        href="https://idyll-lang.github.io/components-built-in"
+            >
+                        Idyll’s documentation
+            </a>
+             for a full list — Additional components can be installed via 
+            <code>
+                        npm
+            </code>
+             (any React component should work), and if you are comfortable with JavaScript you can write 
+            <a
+                        href="https://idyll-lang.github.io/components-custom"
+            >
+                        custom components
+            </a>
+             as well.
+</p>,
+          <p>
+            Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.
+</p>,
+          <p>
+            Instantiating a variable is similar to instantiating a component:
+</p>,
+          <code>
+            [var name:"x" value:1 /]
+</code>,
+          <p>
+            Once you’ve created a variable, it can be displayed inline with text
+            (x = 
+            <Display
+                        __vars__={
+                                    Object {
+                                                "var": "x",
+                                              }
+                        }
+                        var="x"
+            >
+                        
+            </Display>
+            ),
+            or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:
+</p>,
+          <code>
+            [derived name:"xSquared" value:\`x * x\` /]
+</code>,
+          <p>
+            Here I bind the value of 
+            <code>
+                        x
+            </code>
+             to a range slider. Move the slider and watch the variables update.
+</p>,
+          <Range
+            __vars__={
+                        Object {
+                                    "value": "x",
+                                  }
+            }
+            max={100}
+            min={0}
+            step={1}
+            value="x"
+>
+            
+</Range>,
+          <p>
+            <Equation>
+                        x
+            </Equation>
+            :
+             
+            <Display
+                        __expr__={
+                                    Object {
+                                                "var": "x",
+                                              }
+                        }
+                        var="x"
+            >
+                        
+            </Display>
+</p>,
+          <p>
+            <Equation>
+                        x^2
+            </Equation>
+            :
+             
+            <Display
+                        __expr__={
+                                    Object {
+                                                "var": "xSquared",
+                                              }
+                        }
+                        var="xSquared"
+            >
+                        
+            </Display>
+</p>,
+          <p>
+            Here is an example of how you could use a variable to control the frequency of a sine wave:
+</p>,
+          <Chart
+            __expr__={
+                        Object {
+                                    "domain": "[0, 2 * Math.PI]",
+                                    "equation": "(t) => Math.sin(t * frequency)",
+                                  }
+            }
+            domain="[0, 2 * Math.PI]"
+            domainPadding={0}
+            equation="(t) => Math.sin(t * frequency)"
+            range={
+                        Array [
+                                    -1,
+                                    1,
+                                  ]
+            }
+            samplePoints={1000}
+            type="line"
+>
+            
+</Chart>,
+          <Range
+            __expr__={
+                        Object {
+                                    "max": "2 * Math.PI",
+                                  }
+            }
+            __vars__={
+                        Object {
+                                    "value": "frequency",
+                                  }
+            }
+            max="2 * Math.PI"
+            min={0.5}
+            step={0.0001}
+            value="frequency"
+>
+            
+</Range>,
+          <p>
+            Read more about Idyll at 
+            <a
+                        href="https://idyll-lang.github.io/"
+            >
+                        https://idyll-lang.github.io/
+            </a>
+            , and come say “Hi!” in our 
+            <a
+                        href="https://gitter.im/idyll-lang/Lobby"
+            >
+                        chatroom on gitter
+            </a>
+            .
+</p>,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": "0",
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              "Welcome to Idyll",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            "Welcome to Idyll",
+          ],
+          "type": "h1",
+        },
+        Object {
+          "instance": null,
+          "key": "1",
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              "Idyll is a language for creating interactive documents on the web.",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            "Idyll is a language for creating interactive documents on the web.",
+          ],
+          "type": "h3",
+        },
+        Object {
+          "instance": null,
+          "key": "2",
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              "This document is being rendered from ",
+              <strong>
+                Idyll markup
+</strong>,
+              ". If you’ve used ",
+              <a
+                href="https://daringfireball.net/projects/markdown/"
+>
+                markdown
+</a>,
+              ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            "This document is being rendered from ",
+            Object {
+              "instance": null,
+              "key": "0",
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  "Idyll markup",
+                ],
+              },
+              "ref": null,
+              "rendered": Array [
+                "Idyll markup",
+              ],
+              "type": "strong",
+            },
+            ". If you’ve used ",
+            Object {
+              "instance": null,
+              "key": "1",
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  "markdown",
+                ],
+                "href": "https://daringfireball.net/projects/markdown/",
+              },
+              "ref": null,
+              "rendered": Array [
+                "markdown",
+              ],
+              "type": "a",
+            },
+            ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.",
+          ],
+          "type": "p",
+        },
+        Object {
+          "instance": null,
+          "key": "3",
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              "To make things a little more interesting you can add JavaScript components to your text.
+For example, a ",
+              <code>
+                [Chart /]
+</code>,
+              " component can be used to render a simple visualization:",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            "To make things a little more interesting you can add JavaScript components to your text.
+For example, a ",
+            Object {
+              "instance": null,
+              "key": "0",
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  "[Chart /]",
+                ],
+              },
+              "ref": null,
+              "rendered": Array [
+                "[Chart /]",
+              ],
+              "type": "code",
+            },
+            " component can be used to render a simple visualization:",
+          ],
+          "type": "p",
+        },
+        Object {
+          "instance": null,
+          "key": "4",
+          "nodeType": "class",
+          "props": Object {
+            "children": Array [],
+            "domain": Array [
+              -1,
+              1,
+            ],
+            "domainPadding": 0,
+            "range": Array [
+              -1,
+              1,
+            ],
+            "samplePoints": 100,
+            "type": "scatter",
+          },
+          "ref": null,
+          "rendered": Array [],
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": "5",
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              "Try changing the chart’s type from ",
+              <code>
+                scatter
+</code>,
+              " to ",
+              <code>
+                line
+</code>,
+              ", ",
+              <code>
+                area
+</code>,
+              ", or ",
+              <code>
+                pie
+</code>,
+              ".",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            "Try changing the chart’s type from ",
+            Object {
+              "instance": null,
+              "key": "0",
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  "scatter",
+                ],
+              },
+              "ref": null,
+              "rendered": Array [
+                "scatter",
+              ],
+              "type": "code",
+            },
+            " to ",
+            Object {
+              "instance": null,
+              "key": "1",
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  "line",
+                ],
+              },
+              "ref": null,
+              "rendered": Array [
+                "line",
+              ],
+              "type": "code",
+            },
+            ", ",
+            Object {
+              "instance": null,
+              "key": "2",
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  "area",
+                ],
+              },
+              "ref": null,
+              "rendered": Array [
+                "area",
+              ],
+              "type": "code",
+            },
+            ", or ",
+            Object {
+              "instance": null,
+              "key": "3",
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  "pie",
+                ],
+              },
+              "ref": null,
+              "rendered": Array [
+                "pie",
+              ],
+              "type": "code",
+            },
+            ".",
+          ],
+          "type": "p",
+        },
+        Object {
+          "instance": null,
+          "key": "6",
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (",
+              <code>
+                \`2 * Math.PI\`
+</code>,
+              ").",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (",
+            Object {
+              "instance": null,
+              "key": "0",
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  "\`2 * Math.PI\`",
+                ],
+              },
+              "ref": null,
+              "rendered": Array [
+                "\`2 * Math.PI\`",
+              ],
+              "type": "code",
+            },
+            ").",
+          ],
+          "type": "p",
+        },
+        Object {
+          "instance": null,
+          "key": "7",
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              "There are a number of components available — see ",
+              <a
+                href="https://idyll-lang.github.io/components-built-in"
+>
+                Idyll’s documentation
+</a>,
+              " for a full list — Additional components can be installed via ",
+              <code>
+                npm
+</code>,
+              " (any React component should work), and if you are comfortable with JavaScript you can write ",
+              <a
+                href="https://idyll-lang.github.io/components-custom"
+>
+                custom components
+</a>,
+              " as well.",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            "There are a number of components available — see ",
+            Object {
+              "instance": null,
+              "key": "0",
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  "Idyll’s documentation",
+                ],
+                "href": "https://idyll-lang.github.io/components-built-in",
+              },
+              "ref": null,
+              "rendered": Array [
+                "Idyll’s documentation",
+              ],
+              "type": "a",
+            },
+            " for a full list — Additional components can be installed via ",
+            Object {
+              "instance": null,
+              "key": "1",
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  "npm",
+                ],
+              },
+              "ref": null,
+              "rendered": Array [
+                "npm",
+              ],
+              "type": "code",
+            },
+            " (any React component should work), and if you are comfortable with JavaScript you can write ",
+            Object {
+              "instance": null,
+              "key": "2",
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  "custom components",
+                ],
+                "href": "https://idyll-lang.github.io/components-custom",
+              },
+              "ref": null,
+              "rendered": Array [
+                "custom components",
+              ],
+              "type": "a",
+            },
+            " as well.",
+          ],
+          "type": "p",
+        },
+        Object {
+          "instance": null,
+          "key": "8",
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              "Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            "Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.",
+          ],
+          "type": "p",
+        },
+        Object {
+          "instance": null,
+          "key": "9",
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              "Instantiating a variable is similar to instantiating a component:",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            "Instantiating a variable is similar to instantiating a component:",
+          ],
+          "type": "p",
+        },
+        Object {
+          "instance": null,
+          "key": "10",
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              "[var name:\\"x\\" value:1 /]",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            "[var name:\\"x\\" value:1 /]",
+          ],
+          "type": "code",
+        },
+        Object {
+          "instance": null,
+          "key": "11",
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              "Once you’ve created a variable, it can be displayed inline with text
+(x = ",
+              <Display
+                __vars__={
+                                Object {
+                                                "var": "x",
+                                              }
+                }
+                var="x"
+>
+                
+</Display>,
+              "),
+or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            "Once you’ve created a variable, it can be displayed inline with text
+(x = ",
+            Object {
+              "instance": null,
+              "key": "0",
+              "nodeType": "class",
+              "props": Object {
+                "__vars__": Object {
+                  "var": "x",
+                },
+                "children": Array [],
+                "var": "x",
+              },
+              "ref": null,
+              "rendered": Array [],
+              "type": [Function],
+            },
+            "),
+or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:",
+          ],
+          "type": "p",
+        },
+        Object {
+          "instance": null,
+          "key": "12",
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              "[derived name:\\"xSquared\\" value:\`x * x\` /]",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            "[derived name:\\"xSquared\\" value:\`x * x\` /]",
+          ],
+          "type": "code",
+        },
+        Object {
+          "instance": null,
+          "key": "13",
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              "Here I bind the value of ",
+              <code>
+                x
+</code>,
+              " to a range slider. Move the slider and watch the variables update.",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            "Here I bind the value of ",
+            Object {
+              "instance": null,
+              "key": "0",
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  "x",
+                ],
+              },
+              "ref": null,
+              "rendered": Array [
+                "x",
+              ],
+              "type": "code",
+            },
+            " to a range slider. Move the slider and watch the variables update.",
+          ],
+          "type": "p",
+        },
+        Object {
+          "instance": null,
+          "key": "14",
+          "nodeType": "class",
+          "props": Object {
+            "__vars__": Object {
+              "value": "x",
+            },
+            "children": Array [],
+            "max": 100,
+            "min": 0,
+            "step": 1,
+            "value": "x",
+          },
+          "ref": null,
+          "rendered": Array [],
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": "15",
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <Equation>
+                x
+</Equation>,
+              ":
+ ",
+              <Display
+                __expr__={
+                                Object {
+                                                "var": "x",
+                                              }
+                }
+                var="x"
+>
+                
+</Display>,
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": "0",
+              "nodeType": "class",
+              "props": Object {
+                "children": Array [
+                  "x",
+                ],
+              },
+              "ref": null,
+              "rendered": Array [
+                "x",
+              ],
+              "type": [Function],
+            },
+            ":
+ ",
+            Object {
+              "instance": null,
+              "key": "1",
+              "nodeType": "class",
+              "props": Object {
+                "__expr__": Object {
+                  "var": "x",
+                },
+                "children": Array [],
+                "var": "x",
+              },
+              "ref": null,
+              "rendered": Array [],
+              "type": [Function],
+            },
+          ],
+          "type": "p",
+        },
+        Object {
+          "instance": null,
+          "key": "16",
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <Equation>
+                x^2
+</Equation>,
+              ":
+ ",
+              <Display
+                __expr__={
+                                Object {
+                                                "var": "xSquared",
+                                              }
+                }
+                var="xSquared"
+>
+                
+</Display>,
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": "0",
+              "nodeType": "class",
+              "props": Object {
+                "children": Array [
+                  "x^2",
+                ],
+              },
+              "ref": null,
+              "rendered": Array [
+                "x^2",
+              ],
+              "type": [Function],
+            },
+            ":
+ ",
+            Object {
+              "instance": null,
+              "key": "1",
+              "nodeType": "class",
+              "props": Object {
+                "__expr__": Object {
+                  "var": "xSquared",
+                },
+                "children": Array [],
+                "var": "xSquared",
+              },
+              "ref": null,
+              "rendered": Array [],
+              "type": [Function],
+            },
+          ],
+          "type": "p",
+        },
+        Object {
+          "instance": null,
+          "key": "17",
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              "Here is an example of how you could use a variable to control the frequency of a sine wave:",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            "Here is an example of how you could use a variable to control the frequency of a sine wave:",
+          ],
+          "type": "p",
+        },
+        Object {
+          "instance": null,
+          "key": "18",
+          "nodeType": "class",
+          "props": Object {
+            "__expr__": Object {
+              "domain": "[0, 2 * Math.PI]",
+              "equation": "(t) => Math.sin(t * frequency)",
+            },
+            "children": Array [],
+            "domain": "[0, 2 * Math.PI]",
+            "domainPadding": 0,
+            "equation": "(t) => Math.sin(t * frequency)",
+            "range": Array [
+              -1,
+              1,
+            ],
+            "samplePoints": 1000,
+            "type": "line",
+          },
+          "ref": null,
+          "rendered": Array [],
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": "19",
+          "nodeType": "class",
+          "props": Object {
+            "__expr__": Object {
+              "max": "2 * Math.PI",
+            },
+            "__vars__": Object {
+              "value": "frequency",
+            },
+            "children": Array [],
+            "max": "2 * Math.PI",
+            "min": 0.5,
+            "step": 0.0001,
+            "value": "frequency",
+          },
+          "ref": null,
+          "rendered": Array [],
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": "20",
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              "Read more about Idyll at ",
+              <a
+                href="https://idyll-lang.github.io/"
+>
+                https://idyll-lang.github.io/
+</a>,
+              ", and come say “Hi!” in our ",
+              <a
+                href="https://gitter.im/idyll-lang/Lobby"
+>
+                chatroom on gitter
+</a>,
+              ".",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            "Read more about Idyll at ",
+            Object {
+              "instance": null,
+              "key": "0",
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  "https://idyll-lang.github.io/",
+                ],
+                "href": "https://idyll-lang.github.io/",
+              },
+              "ref": null,
+              "rendered": Array [
+                "https://idyll-lang.github.io/",
+              ],
+              "type": "a",
+            },
+            ", and come say “Hi!” in our ",
+            Object {
+              "instance": null,
+              "key": "1",
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  "chatroom on gitter",
+                ],
+                "href": "https://gitter.im/idyll-lang/Lobby",
+              },
+              "ref": null,
+              "rendered": Array [
+                "chatroom on gitter",
+              ],
+              "type": "a",
+            },
+            ".",
+          ],
+          "type": "p",
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;

--- a/packages/idyll-document/test/component.js
+++ b/packages/idyll-document/test/component.js
@@ -1,20 +1,52 @@
+import fs from 'fs';
+import { join } from 'path';
 import React from 'react';
 import Enzyme, { mount, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 Enzyme.configure({ adapter: new Adapter() });
 
 import * as components from 'idyll-components';
-
 import IdyllDocument from '../src/';
-import { translate } from '../src/utils'
-import ReactJsonSchema from '../src/utils/schema2element';
-import ast from './fixtures/ast.json'
-import schema from './fixtures/schema.json'
+
+const fixture = f => fs.readFileSync(join(__dirname, `fixtures/${f}`), 'utf8');
 
 describe('IdyllDocument', () => {
-  it('creates an IdyllDocument', () => {
-    expect(shallow(
-      <IdyllDocument ast={ast} components={components} />
-    ).contains(<h1>Welcome to Idyll</h1>)).toBe(true);
+  let src, srcDoc, ast, astDoc;
+
+  beforeEach(() => {
+    src = fixture('src.idl');
+    ast = JSON.parse(fixture('ast.json'));
+    srcDoc = shallow(<IdyllDocument src={src} components={components} />);
+    astDoc = shallow(<IdyllDocument ast={ast} components={components} />);
+  });
+
+  it('can be constructed with ast prop', () => {
+    const doc = new IdyllDocument({ ast, components });
+    expect(doc.props.ast).toBeDefined();
+  });
+
+  it('can be constructed with src prop', () => {
+    const doc = new IdyllDocument({ src, components });
+    expect(doc.props.src).toBeDefined();
+  });
+
+  // TODO: compare docs directly once Victory is deterministic
+  it('treats src and ast props equivalently', () => {
+    const header = <h1>Welcome to Idyll</h1>;
+    const code = <code>[var name:"x" value:1 /]</code>;
+
+    expect(srcDoc.contains(header)).toBe(true);
+    expect(srcDoc.contains(code)).toBe(true);
+
+    expect(astDoc.contains(header)).toBe(true);
+    expect(astDoc.contains(code)).toBe(true);
+  });
+
+  it('wraps the right components', () => {
+    expect(astDoc.find('Wrapper').length).toBe(7);
+  });
+
+  it('wraps both of the charts', () => {
+    expect(srcDoc.find('Wrapper Chart').length).toBe(2);
   });
 });

--- a/packages/idyll-document/test/schema2element.js
+++ b/packages/idyll-document/test/schema2element.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import Enzyme, { mount, shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import * as components from 'idyll-components';
+import ReactJsonSchema from '../src/utils/schema2element';
+import schema from './fixtures/schema.json';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('ReactJsonSchema', () => {
+
+  it('can be created without arguments', () => {
+    const rjs = new ReactJsonSchema();
+    expect(rjs).toBeDefined();
+  });
+
+  it('can accept a componentMap in the constructor', () => {
+    const rjs = new ReactJsonSchema(components);
+    expect(rjs.getComponentMap()).toBe(components);
+  });
+
+  it('can set the componentMap after the constructor', () => {
+    const rjs = new ReactJsonSchema();
+    rjs.setComponentMap(components);
+    expect(rjs.getComponentMap()).toBe(components);
+  });
+
+  it('can parse a schema', () => {
+    const rjs = new ReactJsonSchema(components);
+    const tree = rjs.parseSchema({component: 'div', children: schema});
+    expect(shallow(tree)).toMatchSnapshot();
+  });
+
+});


### PR DESCRIPTION
This ended up being a mixed bag, not just tests :/

Edit: to clarify, this includes two "features".

- https://github.com/idyll-lang/idyll/pull/191/commits/748054ce0422d13de3ada78c572885fb8d9b3aeb ensures all custom components (as detected by a capitalized name) are wrapped. Previously, custom components that did not reference state, like `[Chart type:"scatter" /]`, were not wrapped. In order to provide an error boundary we have to wrap them.
- https://github.com/idyll-lang/idyll/pull/191/commits/eb31eff38304a094c928b06bb4832f86d6727acc adds support for a `src` prop to `IdyllDocument`. If an `ast` prop is not provided and a `src` prop is, `IdyllDocument` will compile the source on its own.