### PR TITLE
Feature/fix grab bag

### DIFF
--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import scrollMonitor from 'scrollmonitor';
-import compile from 'idyll-compiler';
 import ReactJsonSchema from './utils/schema2element';
 import entries from 'object.entries';
 import values from 'object.values';
@@ -179,19 +178,12 @@ class IdyllDocument extends React.PureComponent {
     this.scrollListener = this.scrollListener.bind(this);
     this.initScrollListener = this.initScrollListener.bind(this);
 
-    if (!props.ast && !props.src) {
-      this.kids = null;
-      return;
-    }
-
-    const ast = props.ast || compile(props.src);
-
     const {
       vars,
       derived,
       data,
       elements,
-    } = splitAST(ast);
+    } = splitAST(props.ast);
 
     const initialState = {
       ...getVars(vars),
@@ -205,7 +197,7 @@ class IdyllDocument extends React.PureComponent {
     };
 
     const rjs = new ReactJsonSchema({...props.components, Wrapper});
-    const schema = translate(ast);
+    const schema = translate(props.ast);
 
     const wrapTargets = findWrapTargets(schema, this.state);
 

--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -7,6 +7,7 @@ import values from 'object.values';
 import {
   getData,
   getVars,
+  filterASTForDocument,
   splitAST,
   translate,
   findWrapTargets,
@@ -178,12 +179,14 @@ class IdyllDocument extends React.PureComponent {
     this.scrollListener = this.scrollListener.bind(this);
     this.initScrollListener = this.initScrollListener.bind(this);
 
+    const ast = filterASTForDocument(props.ast, n => n, ([name]) => name !== 'meta');
+
     const {
       vars,
       derived,
       data,
       elements,
-    } = splitAST(props.ast);
+    } = splitAST(ast);
 
     const initialState = {
       ...getVars(vars),

--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -179,7 +179,7 @@ class IdyllDocument extends React.PureComponent {
     this.scrollListener = this.scrollListener.bind(this);
     this.initScrollListener = this.initScrollListener.bind(this);
 
-    const ast = filterASTForDocument(props.ast, n => n, ([name]) => name !== 'meta');
+    const ast = filterASTForDocument(props.ast);
 
     const {
       vars,
@@ -200,7 +200,7 @@ class IdyllDocument extends React.PureComponent {
     };
 
     const rjs = new ReactJsonSchema({...props.components, Wrapper});
-    const schema = translate(props.ast);
+    const schema = translate(ast);
 
     const wrapTargets = findWrapTargets(schema, this.state);
 

--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -177,21 +177,27 @@ export const translate = (arr) => {
   return splitAST(arr).elements.map(tNode)
 }
 
-export const mapTree = (tree, mapFn) => {
+export const mapTree = (tree, mapFn, filterFn = () => true) => {
   const walkFn = (acc, node) => {
     if (typeof node !== 'string') {
-      node.children = node.children.reduce(walkFn, [])
+      if (node.children) {
+        // translated schema
+        node.children = node.children.reduce(walkFn, []);
+      } else {
+        // compiler AST
+        node[2] = node[2].reduce(walkFn, []);
+      }
     }
 
-    acc.push(mapFn(node))
+    if (filterFn(node)) acc.push(mapFn(node));
     return acc;
-  }
+  };
 
   return tree.reduce(
     walkFn,
     []
-  )
-}
+  );
+};
 
 export const findWrapTargets = (schema, state) => {
   const targets = [];

--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -32,8 +32,10 @@ export const evalExpression = (acc, expr) => {
 
 export const getVars = (arr, context = {}) => {
   const pluck = (acc, val) => {
-    const [ , attrs, ] = val
+    const [ , attrs = [], ] = val
+
     const [nameArr, valueArr] = attrs;
+    if (!nameArr || !valueArr) return acc;
 
     const [, [, nameValue]] = nameArr
     const [, [valueType, valueValue]] = valueArr;

--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -178,6 +178,10 @@ export const mapTree = (tree, mapFn, filterFn = () => true) => {
   );
 };
 
+export const filterASTForDocument = (ast) => {
+  return mapTree(ast, n => n, ([name]) => name !== 'meta')
+};
+
 export const findWrapTargets = (schema, state) => {
   const targets = [];
   const stateKeys = Object.keys(state);

--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -1,27 +1,6 @@
 const values = require('object.values');
 const entries = require('object.entries');
 
-const getNodesByName = (name, tree) => {
-  const predicate = typeof name === 'string' ? (s) => s === name : name;
-
-  const byName = (acc, val) => {
-    if (typeof val === 'string') return acc;
-
-    const [ name, attrs, children ] = val;
-
-    if (predicate(name)) acc.push(val)
-
-    if (children.length > 0) children.reduce(byName, acc)
-
-    return acc;
-  }
-
-  return tree.reduce(
-    byName,
-    []
-  )
-}
-
 export const evalExpression = (acc, expr) => {
   const e = `
     (() => {

--- a/packages/idyll-document/test/component.js
+++ b/packages/idyll-document/test/component.js
@@ -9,12 +9,10 @@ import IdyllDocument from '../src/';
 const fixture = f => fs.readFileSync(join(__dirname, `fixtures/${f}`), 'utf8');
 
 describe('IdyllDocument', () => {
-  let src, srcDoc, ast, astDoc;
+  let ast, astDoc;
 
   beforeEach(() => {
-    src = fixture('src.idl');
     ast = JSON.parse(fixture('ast.json'));
-    srcDoc = shallow(<IdyllDocument src={src} components={components} />);
     astDoc = shallow(<IdyllDocument ast={ast} components={components} />);
   });
 
@@ -23,28 +21,11 @@ describe('IdyllDocument', () => {
     expect(doc.props.ast).toBeDefined();
   });
 
-  it('can be constructed with src prop', () => {
-    const doc = new IdyllDocument({ src, components });
-    expect(doc.props.src).toBeDefined();
-  });
-
-  // TODO: compare docs directly once Victory is deterministic
-  it('treats src and ast props equivalently', () => {
-    const header = <h1>Welcome to Idyll</h1>;
-    const code = <code>[var name:"x" value:1 /]</code>;
-
-    expect(srcDoc.contains(header)).toBe(true);
-    expect(srcDoc.contains(code)).toBe(true);
-
-    expect(astDoc.contains(header)).toBe(true);
-    expect(astDoc.contains(code)).toBe(true);
-  });
-
   it('wraps the right components', () => {
     expect(astDoc.find('Wrapper').length).toBe(13);
   });
 
   it('wraps both of the charts', () => {
-    expect(srcDoc.find('Wrapper Chart').length).toBe(2);
+    expect(astDoc.find('Wrapper Chart').length).toBe(2);
   });
 });


### PR DESCRIPTION
- Removes support for a `src` prop from `IdyllDocument`
- `IdyllDocument` filters out `meta` tags

Resolves #194 