### PR TITLE
remove arrow function from compiler

### DIFF
--- a/packages/idyll-compiler/.babelrc
+++ b/packages/idyll-compiler/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["./.babelrc.js"]
+}

--- a/packages/idyll-compiler/.babelrc.js
+++ b/packages/idyll-compiler/.babelrc.js
@@ -1,0 +1,13 @@
+const { BABEL_ENV, NODE_ENV } = process.env;
+
+module.exports = {
+  presets: [
+    [
+      'env',
+      {
+        loose: true,
+        modules: 'commonjs',
+      },
+    ],
+  ],
+};

--- a/packages/idyll-compiler/package.json
+++ b/packages/idyll-compiler/package.json
@@ -2,10 +2,15 @@
   "name": "idyll-compiler",
   "version": "2.0.0-beta.0",
   "description": "Compiler for idyll",
-  "main": "index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/es/index.js",
   "scripts": {
-    "build": "nearleyc src/grammar.ne -o src/grammar.js",
-    "test": "npm run build && mocha",
+    "prebuild": "rimraf dist",
+    "build:cjs": "cross-env BABEL_ENV=cjs babel src -d dist/cjs",
+    "build:es": "cross-env BABEL_ENV=es babel src -d dist/es",
+    "compile": "nearleyc src/grammar.ne -o src/grammar.js",
+    "build": "npm run compile && npm run build:es && npm run build:cjs",
+    "test": "npm run compile && mocha",
     "prepublishOnly": "npm run build"
   },
   "repository": {
@@ -23,8 +28,12 @@
   },
   "homepage": "https://github.com/idyll-lang/idyll-compiler#readme",
   "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-preset-env": "^1.6.0",
+    "cross-env": "^5.0.5",
     "expect.js": "^0.3.1",
-    "mocha": "^3.2.0"
+    "mocha": "^3.2.0",
+    "rimraf": "^2.6.2"
   },
   "dependencies": {
     "lex": "^1.7.9",

--- a/packages/idyll-compiler/src/grammar.ne
+++ b/packages/idyll-compiler/src/grammar.ne
@@ -102,7 +102,7 @@ Paragraph -> (ParagraphItem __):* ParagraphItem  {%
     // children merge them to avoid issues with
     // Equation and other components that
     // consume their children programatically.
-    children = children.reduce((acc, c) => {
+    children = children.reduce(function (acc, c) {
       if (typeof c === 'string' && lastWasString) {
         acc[acc.length - 1] += c;
         lastWasString = true;

--- a/packages/idyll-compiler/src/grammar.ne
+++ b/packages/idyll-compiler/src/grammar.ne
@@ -102,7 +102,7 @@ Paragraph -> (ParagraphItem __):* ParagraphItem  {%
     // children merge them to avoid issues with
     // Equation and other components that
     // consume their children programatically.
-    children = children.reduce(function (acc, c) {
+    children = children.reduce((acc, c) => {
       if (typeof c === 'string' && lastWasString) {
         acc[acc.length - 1] += c;
         lastWasString = true;

--- a/packages/idyll-compiler/src/index.js
+++ b/packages/idyll-compiler/src/index.js
@@ -1,6 +1,6 @@
 
-var parse = require('./src/parser');
-var Lexer = require('./src/lexer');
+var parse = require('./parser');
+var Lexer = require('./lexer');
 
 module.exports = function(input, options) {
   options = Object.assign({}, { spellcheck: false, smartquotes: true }, options || {});


### PR DESCRIPTION
cc @bclinkinbeard 

Can you comment on whether this was blowing up because (1) uglify doesn't like arrow functions and the rest of the code that uses them works because it is transpiled or (2) the nearly library doesn't like arrow funcs for some reason