### PR TITLE
dynamically pick hydrate vs render

### DIFF
--- a/packages/idyll-cli/src/client/build.js
+++ b/packages/idyll-cli/src/client/build.js
@@ -9,7 +9,10 @@ const components = require('__IDYLL_COMPONENTS__');
 const datasets = require('__IDYLL_DATA__');
 require('__IDYLL_SYNTAX_HIGHLIGHT__');
 
-ReactDOM.render(
+const opts = require('__IDYLL_OPTS__');
+
+const mountMethod = opts.ssr ? 'hydrate' : 'render';
+ReactDOM[mountMethod](
   React.createElement(IdyllDocument, { ast, components, datasets }),
   mountNode
 );

--- a/packages/idyll-cli/src/pipeline/bundle-js.js
+++ b/packages/idyll-cli/src/pipeline/bundle-js.js
@@ -12,7 +12,7 @@ const stream = require('stream');
 const toStream = (k, o) => {
   let src;
 
-  if (k === 'ast' || k === 'data') {
+  if (['ast', 'data', 'opts'].indexOf(k) > -1) {
     src = `module.exports = ${JSON.stringify(o)}`;
   } else if (k === 'syntaxHighlighting') {
     src = `module.exports = (function (){${o}})()`;
@@ -64,12 +64,14 @@ module.exports = function (opts, paths, output) {
           ast: '__IDYLL_AST__',
           components: '__IDYLL_COMPONENTS__',
           data: '__IDYLL_DATA__',
-          syntaxHighlighting: '__IDYLL_SYNTAX_HIGHLIGHT__'
+          syntaxHighlighting: '__IDYLL_SYNTAX_HIGHLIGHT__',
+          opts: '__IDYLL_OPTS__'
         };
 
         for (const key in aliases) {
+          const data = output[key];
           b.exclude(aliases[key]);
-          b.require(toStream(key, output[key]), {
+          b.require(toStream(key, data), {
             expose: aliases[key],
             basedir: paths.TMP_DIR
           })

--- a/packages/idyll-cli/src/pipeline/index.js
+++ b/packages/idyll-cli/src/pipeline/index.js
@@ -34,7 +34,10 @@ const build = (opts, paths, inputConfig) => {
         components: getComponentsJS(ast, paths, inputConfig),
         css: css(opts),
         data: getDataJS(ast, paths.DATA_DIR),
-        syntaxHighlighting: getHighlightJS(ast, paths)
+        syntaxHighlighting: getHighlightJS(ast, paths),
+        opts: {
+          ssr: opts.ssr
+        }
       };
       if (!opts.ssr) {
         output.html = getBaseHTML(ast, template);


### PR DESCRIPTION
Eliminate react warnings about using `hydrate()` -  this adds logic to pick between hydrate or render based on the `ssr` option