### PR TITLE
Fix compilation of comments

### DIFF
--- a/packages/idyll-compiler/src/lexer.js
+++ b/packages/idyll-compiler/src/lexer.js
@@ -148,11 +148,18 @@ const lex = function(options) {
     return ['LINK'].concat(formatToken(text)).concat(formatToken(link));
   });
 
-  lexer.addRule(/^\s?\/\/[^\n]*$/gm, function(lexeme) {
+  lexer.addRule(/\s?\/\/[^\n]*/gm, function(lexeme) {
     updatePosition(lexeme);
   });
 
-  lexer.addRule(/(\n?[^`\*\[\n\]!\d_])+/, function(lexeme) {
+  lexer.addRule(/\/(\n?[^`\*\[\/\n\]!\d_])*/gm, function(lexeme) {
+    this.reject = inComponent || lexeme.trim() === '';
+    if (this.reject) return;
+    updatePosition(lexeme);
+    return ['WORDS'].concat(formatToken(lexeme));
+  });
+
+  lexer.addRule(/(\n?[^`\*\[\/\n\]!\d_])+/, function(lexeme) {
     this.reject = inComponent || lexeme.trim() === '';
     if (this.reject) return;
     updatePosition(lexeme);

--- a/packages/idyll-compiler/test/test.js
+++ b/packages/idyll-compiler/test/test.js
@@ -78,6 +78,18 @@ describe('compiler', function() {
       expect(results.tokens.join(' ')).to.eql('OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "i" TOKEN_VALUE_END CLOSE_BRACKET WORDS TOKEN_VALUE_START "not even em" TOKEN_VALUE_END OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "i" TOKEN_VALUE_END CLOSE_BRACKET EOF');
     });
 
+    it('should ignore comments', function() {
+      var lex = Lexer();
+      var results = lex(`
+        Text. / Not a comment.
+        // Comment
+        // Second comment
+        [component]
+          // comment inside components
+        [/component]
+      `);
+      expect(results.tokens.join(' ')).to.eql('WORDS TOKEN_VALUE_START "Text. " TOKEN_VALUE_END WORDS TOKEN_VALUE_START "/ Not a comment.\n        " TOKEN_VALUE_END OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "component" TOKEN_VALUE_END CLOSE_BRACKET OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "component" TOKEN_VALUE_END CLOSE_BRACKET EOF');
+    });
   });
 
   describe('parser', function() {


### PR DESCRIPTION
This adds a unit test to the lexer specifically for comments, and updates of the behavior of the compiler to work as expected.