### PR TITLE
fix variable initialization with expression values

### DIFF
--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -70,7 +70,6 @@ export const evalExpression = (acc, expr, key, context) => {
 export const getVars = (arr, context = {}, evalContext) => {
   const pluck = (acc, val) => {
     const [ variableType, attrs = [], ] = val;
-    console.log(variableType);
 
     const [nameArr, valueArr] = attrs;
     if (!nameArr || !valueArr) return acc;
@@ -90,7 +89,6 @@ export const getVars = (arr, context = {}, evalContext) => {
         }
         break;
       case 'expression':
-        console.log('setting expression name ', nameValue, 'value', valueValue);
         const expr = valueValue;
         if (variableType === 'var') {
           acc[nameValue] = evalExpression(context, expr);

--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -69,7 +69,8 @@ export const evalExpression = (acc, expr, key, context) => {
 
 export const getVars = (arr, context = {}, evalContext) => {
   const pluck = (acc, val) => {
-    const [ , attrs = [], ] = val
+    const [ variableType, attrs = [], ] = val;
+    console.log(variableType);
 
     const [nameArr, valueArr] = attrs;
     if (!nameArr || !valueArr) return acc;
@@ -89,11 +90,16 @@ export const getVars = (arr, context = {}, evalContext) => {
         }
         break;
       case 'expression':
+        console.log('setting expression name ', nameValue, 'value', valueValue);
         const expr = valueValue;
-        acc[nameValue] = {
-          value: evalExpression(context, expr),
-          update: (newState, oldState) => {
-            return evalExpression(Object.assign({}, oldState, newState), expr)
+        if (variableType === 'var') {
+          acc[nameValue] = evalExpression(context, expr);
+        } else {
+          acc[nameValue] = {
+            value: evalExpression(context, expr),
+            update: (newState, oldState) => {
+              return evalExpression(Object.assign({}, oldState, newState), expr)
+            }
           }
         }
     }


### PR DESCRIPTION
This fixes a bug where variables with initial values like `[var name:"x" value:`[0, 1, 2]` /]` would be incorrectly initialized.