### PR TITLE
Fix bug with bare variable parsing

### DIFF
--- a/packages/idyll-document/package.json
+++ b/packages/idyll-document/package.json
@@ -15,7 +15,9 @@
     "build": "npm run build:cjs && npm run build:es",
     "dev": "yarn run build:es --watch",
     "prepublishOnly": "npm run build",
-    "test": "jest"
+    "test": "jest",
+    "update-fixtures": "npm run build && node scripts/idl2ast",
+    "update-snapshot": " jest --updateSnapshot"
   },
   "jest": {
     "setupFiles": [

--- a/packages/idyll-document/scripts/idl2ast.js
+++ b/packages/idyll-document/scripts/idl2ast.js
@@ -1,14 +1,13 @@
 const compiler = require('idyll-compiler')
 const fs = require('fs')
 const { join } = require('path')
-const { translate } = require('./index')
+const { translate } = require('../dist/cjs/utils/index')
 
 const fixtures = join(
   __dirname,
   '..',
-  '..',
   'test',
-  'fixtures',
+  'fixtures'
 )
 
 fs.writeFileSync(

--- a/packages/idyll-document/test/__snapshots__/schema2element.js.snap
+++ b/packages/idyll-document/test/__snapshots__/schema2element.js.snap
@@ -166,7 +166,6 @@ ShallowWrapper {
             x^2
         </Equation>
         :
-         
         <Display
             __expr__={
                 Object {
@@ -244,6 +243,28 @@ ShallowWrapper {
         }
         id="dataDisplay"
         value="myData"
+    >
+        
+    </Display>
+    <Display
+        __vars__={
+            Object {
+                "value": "myData",
+              }
+        }
+        id="bareDataDisplay"
+        value="myData"
+    >
+        
+    </Display>
+    <Display
+        __vars__={
+            Object {
+                "value": "varDisplay",
+              }
+        }
+        id="bareVarDisplay"
+        value="varDisplay"
     >
         
     </Display>
@@ -479,7 +500,6 @@ ShallowWrapper {
                     x^2
           </Equation>
           :
-           
           <Display
                     __expr__={
                               Object {
@@ -557,6 +577,28 @@ ShallowWrapper {
           }
           id="dataDisplay"
           value="myData"
+>
+          
+</Display>,
+        <Display
+          __vars__={
+                    Object {
+                              "value": "myData",
+                            }
+          }
+          id="bareDataDisplay"
+          value="myData"
+>
+          
+</Display>,
+        <Display
+          __vars__={
+                    Object {
+                              "value": "varDisplay",
+                            }
+          }
+          id="bareVarDisplay"
+          value="varDisplay"
 >
           
 </Display>,
@@ -1207,8 +1249,7 @@ or be used to parameterize components. Derived variables can be used to create v
             <Equation>
               x^2
 </Equation>,
-            ":
- ",
+            ":",
             <Display
               __expr__={
                             Object {
@@ -1238,8 +1279,7 @@ or be used to parameterize components. Derived variables can be used to create v
             ],
             "type": [Function],
           },
-          ":
- ",
+          ":",
           Object {
             "instance": null,
             "key": "1",
@@ -1372,6 +1412,38 @@ or be used to parameterize components. Derived variables can be used to create v
       Object {
         "instance": null,
         "key": "24",
+        "nodeType": "class",
+        "props": Object {
+          "__vars__": Object {
+            "value": "myData",
+          },
+          "children": Array [],
+          "id": "bareDataDisplay",
+          "value": "myData",
+        },
+        "ref": null,
+        "rendered": Array [],
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": "25",
+        "nodeType": "class",
+        "props": Object {
+          "__vars__": Object {
+            "value": "varDisplay",
+          },
+          "children": Array [],
+          "id": "bareVarDisplay",
+          "value": "varDisplay",
+        },
+        "ref": null,
+        "rendered": Array [],
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": "26",
         "nodeType": "host",
         "props": Object {
           "children": Array [
@@ -1386,7 +1458,7 @@ or be used to parameterize components. Derived variables can be used to create v
       },
       Object {
         "instance": null,
-        "key": "25",
+        "key": "27",
         "nodeType": "class",
         "props": Object {
           "__expr__": Object {
@@ -1410,7 +1482,7 @@ or be used to parameterize components. Derived variables can be used to create v
       },
       Object {
         "instance": null,
-        "key": "26",
+        "key": "28",
         "nodeType": "class",
         "props": Object {
           "__expr__": Object {
@@ -1431,7 +1503,7 @@ or be used to parameterize components. Derived variables can be used to create v
       },
       Object {
         "instance": null,
-        "key": "27",
+        "key": "29",
         "nodeType": "host",
         "props": Object {
           "children": Array [
@@ -1661,7 +1733,6 @@ or be used to parameterize components. Derived variables can be used to create v
                         x^2
             </Equation>
             :
-             
             <Display
                         __expr__={
                                     Object {
@@ -1739,6 +1810,28 @@ or be used to parameterize components. Derived variables can be used to create v
             }
             id="dataDisplay"
             value="myData"
+>
+            
+</Display>,
+          <Display
+            __vars__={
+                        Object {
+                                    "value": "myData",
+                                  }
+            }
+            id="bareDataDisplay"
+            value="myData"
+>
+            
+</Display>,
+          <Display
+            __vars__={
+                        Object {
+                                    "value": "varDisplay",
+                                  }
+            }
+            id="bareVarDisplay"
+            value="varDisplay"
 >
             
 </Display>,
@@ -2389,8 +2482,7 @@ or be used to parameterize components. Derived variables can be used to create v
               <Equation>
                 x^2
 </Equation>,
-              ":
- ",
+              ":",
               <Display
                 __expr__={
                                 Object {
@@ -2420,8 +2512,7 @@ or be used to parameterize components. Derived variables can be used to create v
               ],
               "type": [Function],
             },
-            ":
- ",
+            ":",
             Object {
               "instance": null,
               "key": "1",
@@ -2554,6 +2645,38 @@ or be used to parameterize components. Derived variables can be used to create v
         Object {
           "instance": null,
           "key": "24",
+          "nodeType": "class",
+          "props": Object {
+            "__vars__": Object {
+              "value": "myData",
+            },
+            "children": Array [],
+            "id": "bareDataDisplay",
+            "value": "myData",
+          },
+          "ref": null,
+          "rendered": Array [],
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": "25",
+          "nodeType": "class",
+          "props": Object {
+            "__vars__": Object {
+              "value": "varDisplay",
+            },
+            "children": Array [],
+            "id": "bareVarDisplay",
+            "value": "varDisplay",
+          },
+          "ref": null,
+          "rendered": Array [],
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": "26",
           "nodeType": "host",
           "props": Object {
             "children": Array [
@@ -2568,7 +2691,7 @@ or be used to parameterize components. Derived variables can be used to create v
         },
         Object {
           "instance": null,
-          "key": "25",
+          "key": "27",
           "nodeType": "class",
           "props": Object {
             "__expr__": Object {
@@ -2592,7 +2715,7 @@ or be used to parameterize components. Derived variables can be used to create v
         },
         Object {
           "instance": null,
-          "key": "26",
+          "key": "28",
           "nodeType": "class",
           "props": Object {
             "__expr__": Object {
@@ -2613,7 +2736,7 @@ or be used to parameterize components. Derived variables can be used to create v
         },
         Object {
           "instance": null,
-          "key": "27",
+          "key": "29",
           "nodeType": "host",
           "props": Object {
             "children": Array [

--- a/packages/idyll-document/test/__snapshots__/schema2element.js.snap
+++ b/packages/idyll-document/test/__snapshots__/schema2element.js.snap
@@ -260,11 +260,44 @@ ShallowWrapper {
     <Display
         __vars__={
             Object {
-                "value": "varDisplay",
+                "value": "x",
               }
         }
         id="bareVarDisplay"
-        value="varDisplay"
+        value="x"
+    >
+        
+    </Display>
+    <Display
+        __vars__={
+            Object {
+                "value": "xSquared",
+              }
+        }
+        id="bareDerivedDisplay"
+        value="xSquared"
+    >
+        
+    </Display>
+    <Display
+        __expr__={
+            Object {
+                "value": " objectVar ",
+              }
+        }
+        id="objectVarDisplay"
+        value=" objectVar "
+    >
+        
+    </Display>
+    <Display
+        __vars__={
+            Object {
+                "value": "objectVar",
+              }
+        }
+        id="bareObjectVarDisplay"
+        value="objectVar"
     >
         
     </Display>
@@ -594,11 +627,44 @@ ShallowWrapper {
         <Display
           __vars__={
                     Object {
-                              "value": "varDisplay",
+                              "value": "x",
                             }
           }
           id="bareVarDisplay"
-          value="varDisplay"
+          value="x"
+>
+          
+</Display>,
+        <Display
+          __vars__={
+                    Object {
+                              "value": "xSquared",
+                            }
+          }
+          id="bareDerivedDisplay"
+          value="xSquared"
+>
+          
+</Display>,
+        <Display
+          __expr__={
+                    Object {
+                              "value": " objectVar ",
+                            }
+          }
+          id="objectVarDisplay"
+          value=" objectVar "
+>
+          
+</Display>,
+        <Display
+          __vars__={
+                    Object {
+                              "value": "objectVar",
+                            }
+          }
+          id="bareObjectVarDisplay"
+          value="objectVar"
 >
           
 </Display>,
@@ -1431,11 +1497,11 @@ or be used to parameterize components. Derived variables can be used to create v
         "nodeType": "class",
         "props": Object {
           "__vars__": Object {
-            "value": "varDisplay",
+            "value": "x",
           },
           "children": Array [],
           "id": "bareVarDisplay",
-          "value": "varDisplay",
+          "value": "x",
         },
         "ref": null,
         "rendered": Array [],
@@ -1444,6 +1510,54 @@ or be used to parameterize components. Derived variables can be used to create v
       Object {
         "instance": null,
         "key": "26",
+        "nodeType": "class",
+        "props": Object {
+          "__vars__": Object {
+            "value": "xSquared",
+          },
+          "children": Array [],
+          "id": "bareDerivedDisplay",
+          "value": "xSquared",
+        },
+        "ref": null,
+        "rendered": Array [],
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": "27",
+        "nodeType": "class",
+        "props": Object {
+          "__expr__": Object {
+            "value": " objectVar ",
+          },
+          "children": Array [],
+          "id": "objectVarDisplay",
+          "value": " objectVar ",
+        },
+        "ref": null,
+        "rendered": Array [],
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": "28",
+        "nodeType": "class",
+        "props": Object {
+          "__vars__": Object {
+            "value": "objectVar",
+          },
+          "children": Array [],
+          "id": "bareObjectVarDisplay",
+          "value": "objectVar",
+        },
+        "ref": null,
+        "rendered": Array [],
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": "29",
         "nodeType": "host",
         "props": Object {
           "children": Array [
@@ -1458,7 +1572,7 @@ or be used to parameterize components. Derived variables can be used to create v
       },
       Object {
         "instance": null,
-        "key": "27",
+        "key": "30",
         "nodeType": "class",
         "props": Object {
           "__expr__": Object {
@@ -1482,7 +1596,7 @@ or be used to parameterize components. Derived variables can be used to create v
       },
       Object {
         "instance": null,
-        "key": "28",
+        "key": "31",
         "nodeType": "class",
         "props": Object {
           "__expr__": Object {
@@ -1503,7 +1617,7 @@ or be used to parameterize components. Derived variables can be used to create v
       },
       Object {
         "instance": null,
-        "key": "29",
+        "key": "32",
         "nodeType": "host",
         "props": Object {
           "children": Array [
@@ -1827,11 +1941,44 @@ or be used to parameterize components. Derived variables can be used to create v
           <Display
             __vars__={
                         Object {
-                                    "value": "varDisplay",
+                                    "value": "x",
                                   }
             }
             id="bareVarDisplay"
-            value="varDisplay"
+            value="x"
+>
+            
+</Display>,
+          <Display
+            __vars__={
+                        Object {
+                                    "value": "xSquared",
+                                  }
+            }
+            id="bareDerivedDisplay"
+            value="xSquared"
+>
+            
+</Display>,
+          <Display
+            __expr__={
+                        Object {
+                                    "value": " objectVar ",
+                                  }
+            }
+            id="objectVarDisplay"
+            value=" objectVar "
+>
+            
+</Display>,
+          <Display
+            __vars__={
+                        Object {
+                                    "value": "objectVar",
+                                  }
+            }
+            id="bareObjectVarDisplay"
+            value="objectVar"
 >
             
 </Display>,
@@ -2664,11 +2811,11 @@ or be used to parameterize components. Derived variables can be used to create v
           "nodeType": "class",
           "props": Object {
             "__vars__": Object {
-              "value": "varDisplay",
+              "value": "x",
             },
             "children": Array [],
             "id": "bareVarDisplay",
-            "value": "varDisplay",
+            "value": "x",
           },
           "ref": null,
           "rendered": Array [],
@@ -2677,6 +2824,54 @@ or be used to parameterize components. Derived variables can be used to create v
         Object {
           "instance": null,
           "key": "26",
+          "nodeType": "class",
+          "props": Object {
+            "__vars__": Object {
+              "value": "xSquared",
+            },
+            "children": Array [],
+            "id": "bareDerivedDisplay",
+            "value": "xSquared",
+          },
+          "ref": null,
+          "rendered": Array [],
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": "27",
+          "nodeType": "class",
+          "props": Object {
+            "__expr__": Object {
+              "value": " objectVar ",
+            },
+            "children": Array [],
+            "id": "objectVarDisplay",
+            "value": " objectVar ",
+          },
+          "ref": null,
+          "rendered": Array [],
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": "28",
+          "nodeType": "class",
+          "props": Object {
+            "__vars__": Object {
+              "value": "objectVar",
+            },
+            "children": Array [],
+            "id": "bareObjectVarDisplay",
+            "value": "objectVar",
+          },
+          "ref": null,
+          "rendered": Array [],
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": "29",
           "nodeType": "host",
           "props": Object {
             "children": Array [
@@ -2691,7 +2886,7 @@ or be used to parameterize components. Derived variables can be used to create v
         },
         Object {
           "instance": null,
-          "key": "27",
+          "key": "30",
           "nodeType": "class",
           "props": Object {
             "__expr__": Object {
@@ -2715,7 +2910,7 @@ or be used to parameterize components. Derived variables can be used to create v
         },
         Object {
           "instance": null,
-          "key": "28",
+          "key": "31",
           "nodeType": "class",
           "props": Object {
             "__expr__": Object {
@@ -2736,7 +2931,7 @@ or be used to parameterize components. Derived variables can be used to create v
         },
         Object {
           "instance": null,
-          "key": "29",
+          "key": "32",
           "nodeType": "host",
           "props": Object {
             "children": Array [

--- a/packages/idyll-document/test/component.js
+++ b/packages/idyll-document/test/component.js
@@ -22,7 +22,7 @@ describe('IdyllDocument', () => {
   });
 
   it('wraps the right components', () => {
-    expect(astDoc.find('Wrapper').length).toBe(13);
+    expect(astDoc.find('Wrapper').length).toBe(15);
   });
 
   it('wraps both of the charts', () => {

--- a/packages/idyll-document/test/component.js
+++ b/packages/idyll-document/test/component.js
@@ -22,7 +22,7 @@ describe('IdyllDocument', () => {
   });
 
   it('wraps the right components', () => {
-    expect(astDoc.find('Wrapper').length).toBe(15);
+    expect(astDoc.find('Wrapper').length).toBe(18);
   });
 
   it('wraps both of the charts', () => {

--- a/packages/idyll-document/test/fixtures/ast.json
+++ b/packages/idyll-document/test/fixtures/ast.json
@@ -539,7 +539,87 @@
         "value",
         [
           "variable",
-          "varDisplay"
+          "x"
+        ]
+      ]
+    ],
+    []
+  ],
+  [
+    "Display",
+    [
+      [
+        "id",
+        [
+          "value",
+          "bareDerivedDisplay"
+        ]
+      ],
+      [
+        "value",
+        [
+          "variable",
+          "xSquared"
+        ]
+      ]
+    ],
+    []
+  ],
+  [
+    "var",
+    [
+      [
+        "name",
+        [
+          "value",
+          "objectVar"
+        ]
+      ],
+      [
+        "value",
+        [
+          "expression",
+          " { an: \"object\" } "
+        ]
+      ]
+    ],
+    []
+  ],
+  [
+    "Display",
+    [
+      [
+        "id",
+        [
+          "value",
+          "objectVarDisplay"
+        ]
+      ],
+      [
+        "value",
+        [
+          "expression",
+          " objectVar "
+        ]
+      ]
+    ],
+    []
+  ],
+  [
+    "Display",
+    [
+      [
+        "id",
+        [
+          "value",
+          "bareObjectVarDisplay"
+        ]
+      ],
+      [
+        "value",
+        [
+          "variable",
+          "objectVar"
         ]
       ]
     ],

--- a/packages/idyll-document/test/fixtures/ast.json
+++ b/packages/idyll-document/test/fixtures/ast.json
@@ -362,7 +362,7 @@
           "x^2"
         ]
       ],
-      ":\n ",
+      ":",
       [
         "Display",
         [
@@ -500,6 +500,46 @@
         [
           "expression",
           "myData"
+        ]
+      ]
+    ],
+    []
+  ],
+  [
+    "Display",
+    [
+      [
+        "id",
+        [
+          "value",
+          "bareDataDisplay"
+        ]
+      ],
+      [
+        "value",
+        [
+          "variable",
+          "myData"
+        ]
+      ]
+    ],
+    []
+  ],
+  [
+    "Display",
+    [
+      [
+        "id",
+        [
+          "value",
+          "bareVarDisplay"
+        ]
+      ],
+      [
+        "value",
+        [
+          "variable",
+          "varDisplay"
         ]
       ]
     ],

--- a/packages/idyll-document/test/fixtures/schema.json
+++ b/packages/idyll-document/test/fixtures/schema.json
@@ -301,9 +301,36 @@
     "component": "Display",
     "id": "bareVarDisplay",
     "__vars__": {
-      "value": "varDisplay"
+      "value": "x"
     },
-    "value": "varDisplay",
+    "value": "x",
+    "children": []
+  },
+  {
+    "component": "Display",
+    "id": "bareDerivedDisplay",
+    "__vars__": {
+      "value": "xSquared"
+    },
+    "value": "xSquared",
+    "children": []
+  },
+  {
+    "component": "Display",
+    "id": "objectVarDisplay",
+    "__expr__": {
+      "value": " objectVar "
+    },
+    "value": " objectVar ",
+    "children": []
+  },
+  {
+    "component": "Display",
+    "id": "bareObjectVarDisplay",
+    "__vars__": {
+      "value": "objectVar"
+    },
+    "value": "objectVar",
     "children": []
   },
   {

--- a/packages/idyll-document/test/fixtures/schema.json
+++ b/packages/idyll-document/test/fixtures/schema.json
@@ -217,7 +217,7 @@
           "x^2"
         ]
       },
-      ":\n ",
+      ":",
       {
         "component": "Display",
         "__expr__": {
@@ -286,6 +286,24 @@
       "value": "myData"
     },
     "value": "myData",
+    "children": []
+  },
+  {
+    "component": "Display",
+    "id": "bareDataDisplay",
+    "__vars__": {
+      "value": "myData"
+    },
+    "value": "myData",
+    "children": []
+  },
+  {
+    "component": "Display",
+    "id": "bareVarDisplay",
+    "__vars__": {
+      "value": "varDisplay"
+    },
+    "value": "varDisplay",
     "children": []
   },
   {

--- a/packages/idyll-document/test/fixtures/src.idl
+++ b/packages/idyll-document/test/fixtures/src.idl
@@ -57,8 +57,10 @@ Test expression, displays:
 [Display id:"dynamicObjectDisplay" value:`{ dynamic: x }` /]
 [Display id:"dataDisplay" value:`myData` /]
 
-Here is an example of how you could use a variable to control the frequency of a sine wave:
+[Display id:"bareDataDisplay" value:myData /]
+[Display id:"bareVarDisplay" value:varDisplay /]
 
+Here is an example of how you could use a variable to control the frequency of a sine wave:
 
 [var name:"frequency" value:1 /]
 

--- a/packages/idyll-document/test/fixtures/src.idl
+++ b/packages/idyll-document/test/fixtures/src.idl
@@ -58,7 +58,12 @@ Test expression, displays:
 [Display id:"dataDisplay" value:`myData` /]
 
 [Display id:"bareDataDisplay" value:myData /]
-[Display id:"bareVarDisplay" value:varDisplay /]
+[Display id:"bareVarDisplay" value:x /]
+[Display id:"bareDerivedDisplay" value:xSquared /]
+
+[var name:"objectVar" value:` { an: "object" } `  /]
+[Display id:"objectVarDisplay" value:` objectVar `  /]
+[Display id:"bareObjectVarDisplay" value:objectVar  /]
 
 Here is an example of how you could use a variable to control the frequency of a sine wave:
 

--- a/packages/idyll-document/test/vars.js
+++ b/packages/idyll-document/test/vars.js
@@ -58,6 +58,12 @@ describe('Component state initialization', () => {
     }, {
       id: 'dataDisplay',
       html: `<span>${FAKE_DATA}</span>`
+    }, {
+      id: 'bareDataDisplay',
+      html: `<span>${FAKE_DATA}</span>`
+    }, {
+      id: 'bareVarDisplay',
+      html: '<span>2.00</span>'
     }];
 
     checks.forEach((check) => {
@@ -106,6 +112,12 @@ describe('Component state initialization', () => {
     }, {
       id: 'dataDisplay',
       html: `<span>${FAKE_DATA}</span>`
+    }, {
+      id: 'bareDataDisplay',
+      html: `<span>${FAKE_DATA}</span>`
+    }, {
+      id: 'bareVarDisplay',
+      html: '<span>4.00</span>'
     }];
 
     checks.forEach((check) => {

--- a/packages/idyll-document/test/vars.js
+++ b/packages/idyll-document/test/vars.js
@@ -19,7 +19,8 @@ describe('Component state initialization', () => {
       x: 2,
       frequency: 1,
       xSquared: 4,
-      myData: FAKE_DATA
+      myData: FAKE_DATA,
+      objectVar: {an: "object"}
     });
   });
 
@@ -64,6 +65,15 @@ describe('Component state initialization', () => {
     }, {
       id: 'bareVarDisplay',
       html: '<span>2.00</span>'
+    }, {
+      id: 'bareDerivedDisplay',
+      html: '<span>4.00</span>'
+    }, {
+      id: 'objectVarDisplay',
+      html: `<span>${JSON.stringify({an: "object"})}</span>`
+    }, {
+      id: 'bareObjectVarDisplay',
+      html: `<span>${JSON.stringify({an: "object"})}</span>`
     }];
 
     checks.forEach((check) => {
@@ -86,7 +96,8 @@ describe('Component state initialization', () => {
       x: 4,
       frequency: 1,
       xSquared: 16,
-      myData: FAKE_DATA
+      myData: FAKE_DATA,
+      objectVar: {an: "object"}
     });
   });
 
@@ -116,8 +127,17 @@ describe('Component state initialization', () => {
       id: 'bareDataDisplay',
       html: `<span>${FAKE_DATA}</span>`
     }, {
+      id: 'bareDerivedDisplay',
+      html: '<span>16.00</span>'
+    }, {
       id: 'bareVarDisplay',
       html: '<span>4.00</span>'
+    }, {
+      id: 'objectVarDisplay',
+      html: `<span>${JSON.stringify({an: "object"})}</span>`
+    }, {
+      id: 'bareObjectVarDisplay',
+      html: `<span>${JSON.stringify({an: "object"})}</span>`
     }];
 
     checks.forEach((check) => {


### PR DESCRIPTION
This fixes a bug where something like 

```
[var name:"x" value:0 /]
[var name:"y" value:1 /]

[component prop:x /]
[component prop:y /]

[display var:x /]
[display var:y /]
```

would be parsed incorrectly by the runtime. It also adds more unit tests to idyll-document to watch for things like this.