### PR TITLE
make sure to parse nested var declarations

### DIFF
--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -137,17 +137,24 @@ export const splitAST = (ast) => {
     elements: [],
   }
 
-  ast.forEach(node => {
-    const [ name ] = node;
-    if (name === 'var') {
-      state.vars.push(node);
-    } else if (state[name]) {
-      state[name].push(node);
-    } else {
-      state.elements.push(node);
+  const handleNode = (storeElements) => {
+    return (node) => {
+      const [ name, props, children ] = node;
+      if (name === 'var') {
+        state.vars.push(node);
+      } else if (state[name]) {
+        state[name].push(node);
+      } else if (storeElements) {
+        state.elements.push(node);
+      }
+      if (!children || typeof children === 'string') {
+        return;
+      }
+      children.forEach(handleNode(false));
     }
-  })
+  }
 
+  ast.forEach(handleNode(true));
   return state;
 }
 

--- a/packages/idyll-document/src/utils/schema2element.js
+++ b/packages/idyll-document/src/utils/schema2element.js
@@ -83,8 +83,7 @@ class ReactJsonSchema {
   }
 
   resolveComponentChildren(schema) {
-    const children = (schema.hasOwnProperty('children')) ?
-    this.parseSchema(schema.children) : [];
+    const children = (schema.hasOwnProperty('children')) ? this.parseSchema(schema.children) : [];
     return children.length ? children : undefined;
   }
 

--- a/packages/idyll-document/test/__snapshots__/schema2element.js.snap
+++ b/packages/idyll-document/test/__snapshots__/schema2element.js.snap
@@ -309,6 +309,34 @@ ShallowWrapper {
         value="frequency"
     />
     <p>
+        <var
+            name="lateVar"
+            value={50}
+        />
+        <Display
+            __vars__={
+                Object {
+                    "value": "lateVar",
+                  }
+            }
+            id="lateVarDisplay"
+            value="lateVar"
+        />
+        
+        Late Var Range:
+    </p>
+    <Range
+        __vars__={
+            Object {
+                "value": "lateVar",
+              }
+        }
+        max={100}
+        min={2}
+        step={1}
+        value="lateVar"
+    />
+    <p>
         Read more about Idyll at 
         <a
             href="https://idyll-lang.github.io/"
@@ -639,6 +667,34 @@ ShallowWrapper {
           min={0.5}
           step={0.0001}
           value="frequency"
+/>,
+        <p>
+          <var
+                    name="lateVar"
+                    value={50}
+          />
+          <Display
+                    __vars__={
+                              Object {
+                                        "value": "lateVar",
+                                      }
+                    }
+                    id="lateVarDisplay"
+                    value="lateVar"
+          />
+          
+          Late Var Range:
+</p>,
+        <Range
+          __vars__={
+                    Object {
+                              "value": "lateVar",
+                            }
+          }
+          max={100}
+          min={2}
+          step={1}
+          value="lateVar"
 />,
         <p>
           Read more about Idyll at 
@@ -1556,6 +1612,83 @@ or be used to parameterize components. Derived variables can be used to create v
         "nodeType": "host",
         "props": Object {
           "children": Array [
+            <var
+              name="lateVar"
+              value={50}
+/>,
+            <Display
+              __vars__={
+                            Object {
+                                          "value": "lateVar",
+                                        }
+              }
+              id="lateVarDisplay"
+              value="lateVar"
+/>,
+            "
+Late Var Range:",
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": "0",
+            "nodeType": "host",
+            "props": Object {
+              "children": undefined,
+              "name": "lateVar",
+              "value": 50,
+            },
+            "ref": null,
+            "rendered": null,
+            "type": "var",
+          },
+          Object {
+            "instance": null,
+            "key": "1",
+            "nodeType": "class",
+            "props": Object {
+              "__vars__": Object {
+                "value": "lateVar",
+              },
+              "children": undefined,
+              "id": "lateVarDisplay",
+              "value": "lateVar",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          "
+Late Var Range:",
+        ],
+        "type": "p",
+      },
+      Object {
+        "instance": null,
+        "key": "34",
+        "nodeType": "class",
+        "props": Object {
+          "__vars__": Object {
+            "value": "lateVar",
+          },
+          "children": undefined,
+          "max": 100,
+          "min": 2,
+          "step": 1,
+          "value": "lateVar",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": "35",
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
             "Read more about Idyll at ",
             <a
               href="https://idyll-lang.github.io/"
@@ -1923,6 +2056,34 @@ or be used to parameterize components. Derived variables can be used to create v
             min={0.5}
             step={0.0001}
             value="frequency"
+/>,
+          <p>
+            <var
+                        name="lateVar"
+                        value={50}
+            />
+            <Display
+                        __vars__={
+                                    Object {
+                                                "value": "lateVar",
+                                              }
+                        }
+                        id="lateVarDisplay"
+                        value="lateVar"
+            />
+            
+            Late Var Range:
+</p>,
+          <Range
+            __vars__={
+                        Object {
+                                    "value": "lateVar",
+                                  }
+            }
+            max={100}
+            min={2}
+            step={1}
+            value="lateVar"
 />,
           <p>
             Read more about Idyll at 
@@ -2837,6 +2998,83 @@ or be used to parameterize components. Derived variables can be used to create v
         Object {
           "instance": null,
           "key": "33",
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <var
+                name="lateVar"
+                value={50}
+/>,
+              <Display
+                __vars__={
+                                Object {
+                                                "value": "lateVar",
+                                              }
+                }
+                id="lateVarDisplay"
+                value="lateVar"
+/>,
+              "
+Late Var Range:",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": "0",
+              "nodeType": "host",
+              "props": Object {
+                "children": undefined,
+                "name": "lateVar",
+                "value": 50,
+              },
+              "ref": null,
+              "rendered": null,
+              "type": "var",
+            },
+            Object {
+              "instance": null,
+              "key": "1",
+              "nodeType": "class",
+              "props": Object {
+                "__vars__": Object {
+                  "value": "lateVar",
+                },
+                "children": undefined,
+                "id": "lateVarDisplay",
+                "value": "lateVar",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            "
+Late Var Range:",
+          ],
+          "type": "p",
+        },
+        Object {
+          "instance": null,
+          "key": "34",
+          "nodeType": "class",
+          "props": Object {
+            "__vars__": Object {
+              "value": "lateVar",
+            },
+            "children": undefined,
+            "max": 100,
+            "min": 2,
+            "step": 1,
+            "value": "lateVar",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": "35",
           "nodeType": "host",
           "props": Object {
             "children": Array [

--- a/packages/idyll-document/test/component.js
+++ b/packages/idyll-document/test/component.js
@@ -23,7 +23,7 @@ describe('IdyllDocument', () => {
   });
 
   it('wraps the right components', () => {
-    expect(astDoc.find('Wrapper').length).toBe(18);
+    expect(astDoc.find('Wrapper').length).toBe(20);
   });
 
   it('wraps both of the charts', () => {

--- a/packages/idyll-document/test/fixtures/ast.json
+++ b/packages/idyll-document/test/fixtures/ast.json
@@ -722,6 +722,80 @@
     "p",
     [],
     [
+      [
+        "var",
+        [
+          [
+            "name",
+            [
+              "value",
+              "lateVar"
+            ]
+          ],
+          [
+            "value",
+            [
+              "value",
+              50
+            ]
+          ]
+        ],
+        []
+      ],
+      [
+        "Display",
+        [
+          [
+            "id",
+            [
+              "value",
+              "lateVarDisplay"
+            ]
+          ],
+          [
+            "value",
+            [
+              "variable",
+              "lateVar"
+            ]
+          ]
+        ],
+        []
+      ],
+      "\nLate Var Range:"
+    ]
+  ],
+  [
+    "Range",
+    [
+      [
+        "value",
+        [
+          "variable",
+          "lateVar"
+        ]
+      ],
+      [
+        "min",
+        [
+          "value",
+          2
+        ]
+      ],
+      [
+        "max",
+        [
+          "value",
+          100
+        ]
+      ]
+    ],
+    []
+  ],
+  [
+    "p",
+    [],
+    [
       "Read more about Idyll at ",
       [
         "a",

--- a/packages/idyll-document/test/fixtures/schema.json
+++ b/packages/idyll-document/test/fixtures/schema.json
@@ -371,6 +371,37 @@
   {
     "component": "p",
     "children": [
+      {
+        "component": "var",
+        "name": "lateVar",
+        "value": 50,
+        "children": []
+      },
+      {
+        "component": "Display",
+        "id": "lateVarDisplay",
+        "__vars__": {
+          "value": "lateVar"
+        },
+        "value": "lateVar",
+        "children": []
+      },
+      "\nLate Var Range:"
+    ]
+  },
+  {
+    "component": "Range",
+    "__vars__": {
+      "value": "lateVar"
+    },
+    "value": "lateVar",
+    "min": 2,
+    "max": 100,
+    "children": []
+  },
+  {
+    "component": "p",
+    "children": [
       "Read more about Idyll at ",
       {
         "component": "a",

--- a/packages/idyll-document/test/fixtures/src.idl
+++ b/packages/idyll-document/test/fixtures/src.idl
@@ -82,5 +82,12 @@ Here is an example of how you could use a variable to control the frequency of a
   max:`2 * Math.PI`
   step:0.0001 /]
 
+[var name:"lateVar" value:50 /]
+[Display id:"lateVarDisplay" value:lateVar /]
+Late Var Range:
+
+[Range value:lateVar min:2 max:100 /]
+
+
 Read more about Idyll at [https://idyll-lang.github.io/](https://idyll-lang.github.io/), and come say "Hi!" in our [chatroom on gitter](https://gitter.im/idyll-lang/Lobby).
 

--- a/packages/idyll-document/test/vars.js
+++ b/packages/idyll-document/test/vars.js
@@ -20,7 +20,8 @@ describe('Component state initialization', () => {
       frequency: 1,
       xSquared: 4,
       myData: FAKE_DATA,
-      objectVar: {an: "object"}
+      objectVar: {an: "object"},
+      lateVar: 50
     });
   });
 
@@ -97,7 +98,8 @@ describe('Component state initialization', () => {
       frequency: 1,
       xSquared: 16,
       myData: FAKE_DATA,
-      objectVar: {an: "object"}
+      objectVar: {an: "object"},
+      lateVar: 50
     });
   });
 
@@ -138,6 +140,9 @@ describe('Component state initialization', () => {
     }, {
       id: 'bareObjectVarDisplay',
       html: `<span>${JSON.stringify({an: "object"})}</span>`
+    }, {
+      id: 'lateVarDisplay',
+      html: `<span>50.00</span>`
     }];
 
     checks.forEach((check) => {


### PR DESCRIPTION
This fixes https://github.com/idyll-lang/idyll/issues/222, an issue where nested variable declarations weren't being properly initialized. It adds a test.