### PR TITLE
be more selective with the props we pass to components

### DIFF
--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -142,8 +142,9 @@ class Wrapper extends React.PureComponent {
       );
     }
 
+    const { __expr__, __vars__, hasError, ...state } = this.state;
     return React.Children.map(this.props.children, (c, i) => {
-      return React.cloneElement(c, {key: `${this.key}-${i}`, ...this.state});
+      return React.cloneElement(c, {key: `${this.key}-${i}`, ...state});
     });
   }
 }


### PR DESCRIPTION
This fixes https://github.com/idyll-lang/idyll/issues/221. It strips certain props from being injected into the child component.