### PR TITLE
fix for winows

### DIFF
--- a/packages/idyll-cli/src/node-config.js
+++ b/packages/idyll-cli/src/node-config.js
@@ -2,10 +2,12 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
 const Module = require('module');
+const os = require('os');
 
 module.exports = (paths) => {
   const transformFolders = [paths.COMPONENTS_DIR, paths.DEFAULT_COMPONENTS_DIR];
   const originalLoad = Module._load;
+  const isWindows = os.platform().includes('win');
   Module._load = function (path) {
     switch (path) {
       case 'react':
@@ -20,6 +22,6 @@ module.exports = (paths) => {
   require('babel-register')({
       presets: ['env', 'stage-2', 'react'],
       babelrc: false,
-      only: new RegExp(`(${transformFolders.join('|')})`)
+      only: isWindows ? undefined : new RegExp(`(${transformFolders.join('|')})`)
   });
 }

--- a/packages/idyll-cli/src/pipeline/css.js
+++ b/packages/idyll-cli/src/pipeline/css.js
@@ -8,12 +8,16 @@ const isPath = (str) => {
   return (str.indexOf('/') > -1 || str.indexOf('\\') > -1);
 };
 
+const cleanPath = (str) => {
+  return str.replace(/;/g, '');
+}
+
 module.exports = function (options) {
   const { layout, theme, css } = options;
   const pathPrefix = css && isAbsolute(css) ? '' : process.cwd();
-  const layoutCSS = readFileSync(isPath(layout) ? resolve(layout) : join(LAYOUTS_DIR, layout + '.css'));
-  const themeCSS = readFileSync(isPath(theme) ? resolve(theme) : join(THEMES_DIR, theme + '.css'));
-  const customCSS = css ? readFileSync(join(pathPrefix, css)) : '';
+  const layoutCSS = readFileSync(isPath(layout) ? resolve(cleanPath(layout)) : join(LAYOUTS_DIR, layout + '.css'));
+  const themeCSS = readFileSync(isPath(theme) ? resolve(cleanPath(theme)) : join(THEMES_DIR, theme + '.css'));
+  const customCSS = css ? readFileSync(join(pathPrefix, cleanPath(css))) : '';
 
   return [layoutCSS, themeCSS, customCSS].join('\n');
 }


### PR DESCRIPTION
This fixes two issues:

* On windows the babel-register `only` option wasn't working, so I've disabled that for now so things don't blow up. It could cause issues for some specific API-related use cases on windows, but I figure this is better than it failing for everyone. 
* Fixes paths where the option parser would include a trailing semicolon. 