### PR TITLE
fix newlines on windows

### DIFF
--- a/packages/idyll-compiler/src/index.js
+++ b/packages/idyll-compiler/src/index.js
@@ -2,7 +2,12 @@
 var parse = require('./parser');
 var Lexer = require('./lexer');
 
+const cleanNewlines = (input) => {
+  return input.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
 module.exports = function(input, options) {
+  input = cleanNewlines(input);
   options = Object.assign({}, { spellcheck: false, smartquotes: true }, options || {});
   var lex = Lexer();
   var lexResults = lex(input);


### PR DESCRIPTION
This removes all windows newline weirdness from input strings before we send them to the compiler.