### PR TITLE
Pass props through to wrapped components

### DIFF
--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -142,10 +142,15 @@ class Wrapper extends React.PureComponent {
       );
     }
 
-    const { __expr__, __vars__, hasError, ...state } = this.state;
-    return React.Children.map(this.props.children, (c, i) => {
-      return React.cloneElement(c, {key: `${this.key}-${i}`, ...state});
-    });
+    const { __expr__, __vars__, hasError, ...state } = this.state
+    const { children, ...passThruProps } = this.props
+    return React.Children.map(children, (c, i) => {
+      return React.cloneElement(c, {
+        key: `${this.key}-${i}`,
+        ...state,
+        ...passThruProps,
+      })
+    })
   }
 }
 


### PR DESCRIPTION
This is necessary to support components that modify/pass props to their children via `React.cloneElement()`.