### PR TITLE
fix regexs for detecting keys that look like callbacks

### DIFF
--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -3,7 +3,7 @@ const entries = require('object.entries');
 
 export const evalExpression = (acc, expr, key, context) => {
   let e;
-  if (key && (key.match(/on[A-Z].*/) || key.match(/handle[A-Z].*/))) {
+  if (key && (key.match(/^on[A-Z].*/) || key.match(/^handle[A-Z].*/))) {
     let setState = setState;
     e = `
       (() => {


### PR DESCRIPTION
`"_regionOfInterest".match(/on[A-Z].*/)` returns a match.
`"_regionOfInterest".match(/^on[A-Z].*/)` doesn't.
Hooray!