### PR TITLE
Fix bug with passing props down to <button>

### DIFF
--- a/packages/idyll-components/src/button.js
+++ b/packages/idyll-components/src/button.js
@@ -2,8 +2,9 @@ import React from 'react';
 
 class Button extends React.PureComponent {
   render() {
+    const { onClick, updateProps, ...props } = this.props;
     return (
-      <button {...props} onClick={this.props.onClick.bind(this)}>
+      <button {...props} onClick={onClick.bind(this)}>
         {this.props.children}
       </button>
     );


### PR DESCRIPTION
Fix small `ReferenceError: props is not defined` bug introduced by previous commit to Button component.