### PR TITLE
Get builds passing with github dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 
 node_js:
+  - "7"
+  - "8"
   - "9"
 
 env:
@@ -14,9 +16,8 @@ env:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.0.1
   - export PATH="$HOME/.yarn/bin:$PATH"
-  - npm install --global lerna@2
 
 install:
-  - lerna bootstrap
+  - yarn install
 
 script: cd packages/$PACKAGE && npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 
 node_js:
-  - "7"
-  - "8"
   - "9"
 
 env:
@@ -16,8 +14,9 @@ env:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.0.1
   - export PATH="$HOME/.yarn/bin:$PATH"
+  - yarn add lerna
 
 install:
-  - yarn install
+  - lerna bootstrap
 
 script: cd packages/$PACKAGE && npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.0.1
   - export PATH="$HOME/.yarn/bin:$PATH"
-  - yarn add lerna
+  - npm install --global lerna@2
 
 install:
   - lerna bootstrap

--- a/packages/idyll-components/package.json
+++ b/packages/idyll-components/package.json
@@ -44,7 +44,7 @@
     "d3-selection": "^1.1.0",
     "prop-types": "^15.5.10",
     "react-inlinesvg": "^0.7.5",
-    "react-latex": "mathisonian/react-latex",
+    "react-latex": "github:mathisonian/react-latex",
     "react-syntax-highlighter": "^5.7.0",
     "react-table": "^6.6.0",
     "victory": "^0.23.0"

--- a/packages/idyll-components/package.json
+++ b/packages/idyll-components/package.json
@@ -44,7 +44,7 @@
     "d3-selection": "^1.1.0",
     "prop-types": "^15.5.10",
     "react-inlinesvg": "^0.7.5",
-    "react-latex": "github:mathisonian/react-latex",
+    "react-latex-patched": "^1.1.1",
     "react-syntax-highlighter": "^5.7.0",
     "react-table": "^6.6.0",
     "victory": "^0.23.0"

--- a/packages/idyll-components/src/equation.js
+++ b/packages/idyll-components/src/equation.js
@@ -1,6 +1,6 @@
 import React from 'react';
 const ReactDOM = require('react-dom');
-const Latex = require('react-latex');
+const Latex = require('react-latex-patched');
 const select = require('d3-selection').select;
 const format = require('d3-format').format;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6728,9 +6728,9 @@ react-inlinesvg@^0.7.5:
     httpplease "^0.16.4"
     once "^1.4.0"
 
-"react-latex@github:mathisonian/react-latex":
+react-latex-patched@^1.1.1:
   version "1.1.1"
-  resolved "https://codeload.github.com/mathisonian/react-latex/tar.gz/c593221f827f595afaa0aaf856404f4196388244"
+  resolved "https://registry.yarnpkg.com/react-latex-patched/-/react-latex-patched-1.1.1.tgz#d6a36c070c6d32feeb6e5625d9b44b306c920b71"
   dependencies:
     katex "^0.9.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6728,9 +6728,9 @@ react-inlinesvg@^0.7.5:
     httpplease "^0.16.4"
     once "^1.4.0"
 
-react-latex@mathisonian/react-latex:
-  version "1.1.0"
-  resolved "https://codeload.github.com/mathisonian/react-latex/tar.gz/b336fcf5de6f8c40ea9ad6231f5ca64b6cc45b27"
+"react-latex@github:mathisonian/react-latex":
+  version "1.1.1"
+  resolved "https://codeload.github.com/mathisonian/react-latex/tar.gz/c593221f827f595afaa0aaf856404f4196388244"
   dependencies:
     katex "^0.9.0"
 


### PR DESCRIPTION
It seems that depending on a github fork of `react-latex` is causing the idyll-component tests to fail. I'm going to PR my changes back to that project, so hopefully we don't have this dependency for long, but in the meantime I'm working here to try to understand why this causes tests to fail.
