### PR TITLE
Serialization

### DIFF
--- a/packages/idyll-components/src/chart.js
+++ b/packages/idyll-components/src/chart.js
@@ -29,10 +29,17 @@ class Chart extends React.PureComponent {
     if (props.equation) {
       const d = domain;
       data = d3Arr.range(d[0], d[1], (d[1] - d[0]) / props.samplePoints).map((x) => {
-        return {
-          x: x,
-          y: props.equation(x)
-        };
+        try {
+          return {
+            x: x,
+            y: props.equation(x)
+          };
+        } catch(err) {
+          return {
+            x: x,
+            y: 0
+          }
+        }
       });
     }
 

--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -104,7 +104,7 @@ class Wrapper extends React.PureComponent {
     });
     // trigger a re-render of this component
     // and more importantly, its wrapped component
-    this.setState(nextState);
+    this.setState(Object.assign({ hasError: false }, nextState));
   }
 
   onUpdateRefs(newState) {


### PR DESCRIPTION
The following code (without this change) will throw an error that `func` is not defined. This updates the way that we are populating the local context during expression evaluation so that functions are kept in scope properly.

```
[var name:"func" value:`Math.sin` /]

[Chart
  equation:`(t) => func(t)`
  domain:`[0, 2 * Math.PI]`
  samplePoints:1000 /]
```