### PR TITLE
fix typo in scroll event dictionary

### DIFF
--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -167,7 +167,7 @@ export const hooks = [
 
 export const scrollMonitorEvents = {
   'onEnterView': 'enterViewport',
-  'onExitViewFully': 'fullyEnterViewport',
+  'onEnterViewFully': 'fullyEnterViewport',
   'onExitView': 'partiallyExitViewport',
   'onExitViewFully': 'exitViewport'
 }


### PR DESCRIPTION
Re #259. This fixes a bug where invoking the onEnterViewFully event would cause a hard crash .