### PR TITLE
add option to launch server on a specific port

### DIFF
--- a/packages/idyll-cli/bin/idyll.js
+++ b/packages/idyll-cli/bin/idyll.js
@@ -16,6 +16,7 @@ var argv = require('yargs')
     l: 'layout',
     n: 'no-minify',
     o: 'output',
+    p: 'port',
     r: 'no-ssr',
     t: 'template',
     e: 'theme',
@@ -41,6 +42,7 @@ var argv = require('yargs')
   .array('transform')
   .describe('transform', 'Custom browserify transforms to apply.')
   .default('transform', [])
+  .describe('port', 'Custom port to bind the local server to.')
   .describe('theme', 'Name of (or path to) the theme to use')
   .default('theme', 'idyll')
   .boolean('watch')

--- a/packages/idyll-cli/src/index.js
+++ b/packages/idyll-cli/src/index.js
@@ -22,6 +22,7 @@ const idyll = (options = {}, cb) => {
       defaultComponents: dirname(require.resolve('idyll-components')),
       layout: 'blog',
       output: 'build',
+      port: process.env.PORT || 3000,
       temp: '.idyll',
       template: join(
         __dirname,
@@ -93,13 +94,15 @@ const idyll = (options = {}, cb) => {
               });
             });
 
+            console.log('INITING PORT ', opts.port)
             bs.init({
               cors: true,
               logLevel: 'warn',
               logPrefix: 'Idyll',
               notify: false,
               server: [paths.OUTPUT_DIR, paths.INPUT_DIR],
-              ui: false
+              ui: false,
+              port: opts.port
             });
           }
         })

--- a/packages/idyll-cli/src/index.js
+++ b/packages/idyll-cli/src/index.js
@@ -94,7 +94,6 @@ const idyll = (options = {}, cb) => {
               });
             });
 
-            console.log('INITING PORT ', opts.port)
             bs.init({
               cors: true,
               logLevel: 'warn',

--- a/packages/idyll-cli/test/test-project/test.js
+++ b/packages/idyll-cli/test/test-project/test.js
@@ -88,6 +88,7 @@ test('options work as expected', () => {
     template: resolve(join(__dirname, '/../../src/client/_index.html')),
     datasets: join(PROJECT_DIR, 'data'),
     transform: [],
+    port: 3000,
     compilerOptions: {
       spellcheck: false
     },


### PR DESCRIPTION
It defaults to 3000, and will also use `process.env.PORT` if that is defined (a node.js standard env variable)