### PR TITLE
Fix CSS content escaping in github theme

### DIFF
--- a/packages/idyll-themes/src/github/styles.js
+++ b/packages/idyll-themes/src/github/styles.js
@@ -79,7 +79,7 @@ body {
 }
 
 .pl-c2::before {
-  content: "^M";
+  content: "\\000d";
 }
 
 .pl-sr .pl-cce {
@@ -624,7 +624,7 @@ code {
 code::before,
 code::after {
   letter-spacing: -0.2em;
-  content: "\00a0";
+  content: "\\00a0";
 }
 
 pre {


### PR DESCRIPTION
The github CSS theme had a couple `content` rules with improperly escaped characters. The result was stray characters. For example, this idyll

```markdown
This file is named `index.idl`
```

was rendered as:

<img width="292" alt="screen shot 2018-03-10 at 11 35 27 am" src="https://user-images.githubusercontent.com/572717/37246077-54b27578-2457-11e8-957a-e7f06c1e7a92.png">

This fix renders it as:

<img width="262" alt="screen shot 2018-03-10 at 11 35 21 am" src="https://user-images.githubusercontent.com/572717/37246078-5a19e3c0-2457-11e8-9fcf-744d3659c9c7.png">

I also changed `.pl-c2::before` to the unicode character for `^M`, though I don't know what sort of markdown actually triggers this rule. I suspect it was supposed to be the special character sequence for a carriage return but accidentally got flattened into a caret followed by a capital M, which is something different.