### PR TITLE
Prevent smart quote substitution in CodeHighlight blocks

### DIFF
--- a/packages/idyll-compiler/src/parser.js
+++ b/packages/idyll-compiler/src/parser.js
@@ -120,7 +120,7 @@ module.exports = function(input, tokens, positions, options) {
     }
 
     // don't apply cleaning to codeblocks
-    if (['pre', 'code'].indexOf(node[0].toLowerCase()) > -1) {
+    if (['pre', 'code', 'codehighlight'].indexOf(node[0].toLowerCase()) > -1) {
       return node;
     }
     return [node[0], node[1], node[2].map(cleanResults)];


### PR DESCRIPTION
Code blocks with a language specified are of type `CodeHighlight` and so weren't properly avoided by smartquote substitution. This PR fixes that by adding `codehighlight` to the type of elements which smart quote substitution avoids.