### PR TITLE
add initial state property

### DIFF
--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -199,10 +199,10 @@ class IdyllDocument extends React.PureComponent {
     const Wrapper = createWrapper({ theme: props.theme, layout: props.layout });
 
 
-    const initialState = {
+    const initialState = Object.assign({}, {
       ...getVars(vars),
       ...getData(data, props.datasets),
-    };
+    }, props.initialState ? props.initialState : {});
     const derivedVars = this.derivedVars = getVars(derived, initialState);
 
     let state = this.state = {

--- a/packages/idyll-document/test/vars.js
+++ b/packages/idyll-document/test/vars.js
@@ -14,6 +14,8 @@ beforeAll(() => {
 })
 
 describe('Component state initialization', () => {
+
+
   it('creates the expected state', () => {
     expect(component.state()).toEqual({
       x: 2,
@@ -83,6 +85,20 @@ describe('Component state initialization', () => {
       expect(display.html()).toBe(check.html);
     });
   });
+
+
+  it('handles custom initial state', () => {
+    component = mount(<IdyllDocument ast={ast} initialState={{ x: 4 }} components={components} datasets={{myData: FAKE_DATA}} />);
+
+    expect(component.state()).toEqual({
+      x: 4,
+      frequency: 1,
+      xSquared: 16,
+      myData: FAKE_DATA,
+      objectVar: {an: "object"},
+      lateVar: 50
+    });
+  })
 
   it('can update the vars and derived vars', () => {
     const rangeComponents = component.findWhere((n) => {return n.type() === components.Range;});


### PR DESCRIPTION
This lets `IdyllDocument` users specify an initial state programatically. This is useful for cases like persisting document state across editor updates (or pulling from a stateful url, etc) where you want the document to initialize in a way that differs from the initial values specified in the idyll layout itself.

Example:

```
[var name:"x" value:1 /]
[derived name:"xSquared" value:`x * x` /]

[display var:x /],  [display var:xSquared /]
```
// output -> 1, 1

but if you initialized idyll's state programatically:

```js
<IdyllDocument initialState={{x: 2}} />
```

then the output will be `2, 4` on initial render.

