### PR TITLE
fix bug in scrollmonitor initialization

### DIFF
--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -350,10 +350,13 @@ class IdyllDocument extends React.PureComponent {
     if (!el) return;
 
     let scroller = scrollparent(el);
-    if (scroller === document.documentElement) {
-      scroller = document.body;
+    let scrollContainer;
+    if (scroller === document.documentElement || scroller === document.body || scroller === window) {
+      scroller = window;
+      scrollContainer = scrollMonitor;
+    } else {
+      scrollContainer = scrollMonitor.createContainer(scroller);
     }
-    scrollContainer = scrollMonitor.createContainer(scroller);
     Object.keys(refCache).forEach((key) => {
       const { props, domNode } = refCache[key];
       const watcher = scrollContainer.create(domNode, scrollOffsets[key]);
@@ -366,9 +369,6 @@ class IdyllDocument extends React.PureComponent {
       })
       scrollWatchers.push(watcher);
     });
-    if (scroller === document.body) {
-      scroller = window;
-    }
     scroller.addEventListener('scroll', this.scrollListener);
   }
 


### PR DESCRIPTION
This fixes a bug where scroll events weren't firing properly if the reader reloads the page with their browser scrolled down into the article. See #265 