### PR TITLE
add support for single quotes around string-type props

### DIFF
--- a/packages/idyll-compiler/src/lexer.js
+++ b/packages/idyll-compiler/src/lexer.js
@@ -310,6 +310,12 @@ const lex = function(options) {
     updatePosition(lexeme);
     return ['STRING'].concat(formatToken(lexeme));
   });
+  lexer.addRule(/'([^']*)'/, function(lexeme, str) {
+    this.reject = !inComponent;
+    if (this.reject) return;
+    updatePosition(lexeme);
+    return ['STRING'].concat(formatToken('"' + str + '"'));
+  });
 
   lexer.addRule(/:/, function(lexeme) {
     this.reject = !inComponent;

--- a/packages/idyll-compiler/test/test.js
+++ b/packages/idyll-compiler/test/test.js
@@ -18,6 +18,11 @@ describe('compiler', function() {
       var results = lex("Hello \n\nWorld \n\n [VarDisplay var:v work:\"no\" /]");
       expect(results.tokens.join(' ')).to.eql("WORDS TOKEN_VALUE_START \"Hello \" TOKEN_VALUE_END BREAK WORDS TOKEN_VALUE_START \"World \" TOKEN_VALUE_END BREAK OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START \"VarDisplay\" TOKEN_VALUE_END COMPONENT_WORD TOKEN_VALUE_START \"var\" TOKEN_VALUE_END PARAM_SEPARATOR COMPONENT_WORD TOKEN_VALUE_START \"v\" TOKEN_VALUE_END COMPONENT_WORD TOKEN_VALUE_START \"work\" TOKEN_VALUE_END PARAM_SEPARATOR STRING TOKEN_VALUE_START \"&quot;no&quot;\" TOKEN_VALUE_END FORWARD_SLASH CLOSE_BRACKET EOF");
     });
+    it('should support single quotes around strings', function() {
+      var lex = Lexer();
+      var results = lex("Hello \n\nWorld \n\n [VarDisplay var:v work:'no' /]");
+      expect(results.tokens.join(' ')).to.eql("WORDS TOKEN_VALUE_START \"Hello \" TOKEN_VALUE_END BREAK WORDS TOKEN_VALUE_START \"World \" TOKEN_VALUE_END BREAK OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START \"VarDisplay\" TOKEN_VALUE_END COMPONENT_WORD TOKEN_VALUE_START \"var\" TOKEN_VALUE_END PARAM_SEPARATOR COMPONENT_WORD TOKEN_VALUE_START \"v\" TOKEN_VALUE_END COMPONENT_WORD TOKEN_VALUE_START \"work\" TOKEN_VALUE_END PARAM_SEPARATOR STRING TOKEN_VALUE_START \"&quot;no&quot;\" TOKEN_VALUE_END FORWARD_SLASH CLOSE_BRACKET EOF");
+    });
 
     it('should recognize headings', function() {
       var lex = Lexer();


### PR DESCRIPTION
So that both are valid:

```
[var name:'singleQuoteName' value:'singleQuoteValue' /]
[var name:"doubleQuoteValue" value:"doubleQuoteValue" /]
```


Re https://github.com/idyll-lang/idyll/issues/132 /cc @rreusser 