### PR TITLE
Updated Babelify config to ignore node_modules.

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4406,15 +4406,6 @@ iconv-lite@0.4, iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-idyll-compiler@^2.5.5:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/idyll-compiler/-/idyll-compiler-2.5.5.tgz#e0a0a3c15441595631f92f8ae2ceec03dca734a4"
-  dependencies:
-    gray-matter "^3.1.1"
-    lex "^1.7.9"
-    nearley "^2.7.12"
-    smartquotes "^2.0.0"
-
 idyll-component@^1.1.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/idyll-component/-/idyll-component-1.2.2.tgz#0a314657839492a98f414e5763a564c275a62328"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4406,6 +4406,15 @@ iconv-lite@0.4, iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
+idyll-compiler@^2.5.5:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/idyll-compiler/-/idyll-compiler-2.5.5.tgz#e0a0a3c15441595631f92f8ae2ceec03dca734a4"
+  dependencies:
+    gray-matter "^3.1.1"
+    lex "^1.7.9"
+    nearley "^2.7.12"
+    smartquotes "^2.0.0"
+
 idyll-component@^1.1.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/idyll-component/-/idyll-component-1.2.2.tgz#0a314657839492a98f414e5763a564c275a62328"


### PR DESCRIPTION
Hey Idyllers,

Adding this teeny bit of configuration to Babelify should get it to ignore any packages in all relevant `node_modules` directories. As of now, it's processing large files in the initial build (as described in #250). This does seem to speed up the first build quite a bit, but we should test this on a handful of projects to make sure Implicit Babelification of node_modules can be safely removed.

Also, I'll use this PR opportunity to introduce myself to @bclinkinbeard and @rreusser! I've quietly followed Idyll development since the beginning -- super cool to see how far it's come. Excited to contribute!