### PR TITLE
Component metadata

### DIFF
--- a/packages/idyll-components/src/action.js
+++ b/packages/idyll-components/src/action.js
@@ -3,7 +3,7 @@ import React from 'react';
 class Action extends React.PureComponent {
   render() {
     return (
-      <span {...this.props} className={'action'}>{this.props.children}</span>
+      <span {...this.props} className={'idyll-action'}>{this.props.children}</span>
     );
   }
 }

--- a/packages/idyll-components/src/action.js
+++ b/packages/idyll-components/src/action.js
@@ -8,4 +8,25 @@ class Action extends React.PureComponent {
   }
 }
 
+Action._idyll = {
+  name: "Action",
+  tagType: "open",
+  children: [
+    "action text"
+  ],
+  props: [{
+    name: "onClick",
+    type: 'event',
+    example: '`x = !x`'
+  }, {
+    name: "onMouseEnter",
+    type: 'event',
+    example: '`x = true`'
+  }, {
+    name: "onMouseLeave",
+    type: 'event',
+    example: '`x = false`'
+  }]
+}
+
 export default Action;

--- a/packages/idyll-components/src/analytics.js
+++ b/packages/idyll-components/src/analytics.js
@@ -22,4 +22,16 @@ class Analytics extends React.PureComponent {
 }
 
 
+Analytics._idyll = {
+  name: "Analytics",
+  tagType: "closed",
+  props: [{
+    name: "google",
+    type: 'string',
+    example: '"UA-XXXXXXX"'
+  }]
+}
+
+
+
 export default Analytics;

--- a/packages/idyll-components/src/aside.js
+++ b/packages/idyll-components/src/aside.js
@@ -12,4 +12,10 @@ class Aside extends React.PureComponent {
   }
 }
 
+
+Aside._idyll = {
+  name: "Aside",
+  tagType: "open"
+}
+
 export default Aside;

--- a/packages/idyll-components/src/boolean.js
+++ b/packages/idyll-components/src/boolean.js
@@ -23,4 +23,15 @@ Boolean.defaultProps = {
   value: false
 };
 
+
+Boolean._idyll = {
+  name: "Boolean",
+  tagType: "closed",
+  props: [{
+    name: "value",
+    type: "boolean",
+    example: "x"
+  }]
+}
+
 export default Boolean;

--- a/packages/idyll-components/src/button.js
+++ b/packages/idyll-components/src/button.js
@@ -15,4 +15,14 @@ Button.defaultProps = {
   onClick: function() {}
 };
 
+Boolean._idyll = {
+  name: "Boolean",
+  tagType: "open",
+  children: ['Click Me.'],
+  props: [{
+    name: "onClick",
+    type: "event",
+    example: "`x += 1`"
+  }]
+}
 export default Button;

--- a/packages/idyll-components/src/chart.js
+++ b/packages/idyll-components/src/chart.js
@@ -85,33 +85,13 @@ Chart._idyll = {
   name: "Chart",
   tagType: "closed",
   props: [{
-    name: "domain",
-    type: "array",
-    example: "`[-1, 1]`"
-  },{
-    name: "range",
-    type: "array",
-    example: "`[-1, 1]`"
-  },{
-    name: "domainPadding",
-    type: "array",
-    example: "`[-1, 1]`"
-  },{
-    name: "samplePoints",
-    type: "array",
-    example: "`[-1, 1]`"
-  },{
     name: "type",
-    type: "array",
-    example: "`[-1, 1]`"
+    type: "string",
+    example: '"scatter"'
   },{
     name: "data",
     type: "array",
     example: "`[{x: 1, y: 1}, { x: 2, y: 2 }]`"
-  },{
-    name: "equation",
-    type: "function",
-    example: "`(x) => x * x`"
   }]
 }
 

--- a/packages/idyll-components/src/chart.js
+++ b/packages/idyll-components/src/chart.js
@@ -80,4 +80,39 @@ Chart.defaultProps = {
   type: 'line'
 };
 
+
+Chart._idyll = {
+  name: "Chart",
+  tagType: "closed",
+  props: [{
+    name: "domain",
+    type: "array",
+    example: "`[-1, 1]`"
+  },{
+    name: "range",
+    type: "array",
+    example: "`[-1, 1]`"
+  },{
+    name: "domainPadding",
+    type: "array",
+    example: "`[-1, 1]`"
+  },{
+    name: "samplePoints",
+    type: "array",
+    example: "`[-1, 1]`"
+  },{
+    name: "type",
+    type: "array",
+    example: "`[-1, 1]`"
+  },{
+    name: "data",
+    type: "array",
+    example: "`[{x: 1, y: 1}, { x: 2, y: 2 }]`"
+  },{
+    name: "equation",
+    type: "function",
+    example: "`(x) => x * x`"
+  }]
+}
+
 export default Chart;

--- a/packages/idyll-components/src/display.js
+++ b/packages/idyll-components/src/display.js
@@ -31,4 +31,19 @@ class Display extends React.PureComponent {
   }
 }
 
+
+Display._idyll = {
+  name: "Display",
+  tagType: "closed",
+  props: [{
+    name: "value",
+    type: "number",
+    example: "x"
+  }, {
+    name: "format",
+    type: "string",
+    example: '"0.2f"'
+  }]
+}
+
 export default Display;

--- a/packages/idyll-components/src/dynamic.js
+++ b/packages/idyll-components/src/dynamic.js
@@ -41,4 +41,27 @@ Dynamic.defaultProps = {
   interval: 1
 };
 
+
+Dynamic._idyll = {
+  name: "Dynamic",
+  tagType: "closed",
+  props: [{
+    name: "value",
+    type: "number",
+    example: "x"
+  }, {
+    name: "format",
+    type: "string",
+    example: '"0.2f"'
+  }, {
+    name: "min",
+    type: "number",
+    example: '-100'
+  }, {
+    name: "max",
+    type: "number",
+    example: '100'
+  }]
+}
+
 export default Dynamic;

--- a/packages/idyll-components/src/dynamic.js
+++ b/packages/idyll-components/src/dynamic.js
@@ -16,8 +16,8 @@ class Dynamic extends React.PureComponent {
     }
     this.drag = Drag.drag().on('drag', () => {
       const dx = Selection.event.dx;
-      const { interval, value } = this.props;
-      const newValue = Math.max(Math.min(value + interval * dx, this.props.max), this.props.min);
+      const { step, value, interval } = this.props;
+      const newValue = Math.max(Math.min(value + step || interval * dx, this.props.max), this.props.min);
       this.props.updateProps({ value: newValue });
     });
     this.drag(Selection.select(node));
@@ -38,7 +38,7 @@ Dynamic.defaultProps = {
   format: '.2f',
   min: Number.NEGATIVE_INFINITY,
   max: Number.POSITIVE_INFINITY,
-  interval: 1
+  step: 1
 };
 
 
@@ -50,9 +50,9 @@ Dynamic._idyll = {
     type: "number",
     example: "x"
   }, {
-    name: "format",
+    name: "step",
     type: "string",
-    example: '"0.2f"'
+    example: '1'
   }, {
     name: "min",
     type: "number",

--- a/packages/idyll-components/src/equation.js
+++ b/packages/idyll-components/src/equation.js
@@ -140,4 +140,15 @@ class Equation extends React.PureComponent {
   }
 }
 
+Equation._idyll = {
+  name: "Equation",
+  tagType: "open",
+  children: "y = x^2",
+  props: [{
+    name: "display",
+    type: "boolean",
+    example: "true"
+  }]
+}
+
 export default Equation;

--- a/packages/idyll-components/src/feature.js
+++ b/packages/idyll-components/src/feature.js
@@ -156,4 +156,16 @@ Feature.defaultProps = {
   children: []
 };
 
+
+
+Feature._idyll = {
+  name: "Feature",
+  tagType: "open",
+  props: [{
+    name: "value",
+    type: "number",
+    example: "x"
+  }]
+}
+
 export { Content, Feature as default };

--- a/packages/idyll-components/src/fixed.js
+++ b/packages/idyll-components/src/fixed.js
@@ -10,4 +10,10 @@ class Fixed extends React.PureComponent {
   }
 }
 
+
+Fixed._idyll = {
+  name: "Fixed",
+  tagType: "open"
+}
+
 export default Fixed;

--- a/packages/idyll-components/src/float.js
+++ b/packages/idyll-components/src/float.js
@@ -10,4 +10,19 @@ class Float extends React.PureComponent {
   }
 }
 
+
+Float._idyll = {
+  name: "Float",
+  tagType: "open",
+  props: [{
+    name: "position",
+    type: "string",
+    example: '"left"'
+  }, {
+    name: 'width',
+    type: 'string',
+    example: '"50%"'
+  }]
+}
+
 export default Float;

--- a/packages/idyll-components/src/gist.js
+++ b/packages/idyll-components/src/gist.js
@@ -78,5 +78,18 @@ EmbeddedGist.defaultProps = {
   gist: 'mathisonian/689614257cb1af6b15de3344da6cdc7a'
 }
 
+Gist._idyll = {
+  name: "Gist",
+  tagType: "closed",
+  props: [{
+    name: "gist",
+    type: "string",
+    example: '"0f83a12e29b268ffca39f471ecf39e91"'
+  }, {
+    name: 'file',
+    type: 'string',
+    example: '"particles.idl"'
+  }]
+}
 export default EmbeddedGist;
 

--- a/packages/idyll-components/src/header.js
+++ b/packages/idyll-components/src/header.js
@@ -27,4 +27,26 @@ class Header extends React.PureComponent {
   }
 }
 
+Header._idyll = {
+  name: "Header",
+  tagType: "closed",
+  props: [{
+    name: "title",
+    type: "string",
+    example: '"Article Title"'
+  }, {
+    name: 'subtitle',
+    type: 'string',
+    example: '"Article subtitle."'
+  }, {
+    name: 'author',
+    type: 'string',
+    example: '"Author Name"'
+  }, {
+    name: 'authorLink',
+    type: 'string',
+    example: '"author.website"'
+  }]
+}
+
 export default Header;

--- a/packages/idyll-components/src/inline.js
+++ b/packages/idyll-components/src/inline.js
@@ -10,4 +10,10 @@ class Inline extends React.PureComponent {
   }
 }
 
+Inline._idyll = {
+  name: "Inline",
+  tagType: "open"
+}
+
+
 export default Inline;

--- a/packages/idyll-components/src/link.js
+++ b/packages/idyll-components/src/link.js
@@ -6,7 +6,7 @@ class Link extends React.PureComponent {
   }
 
   render() {
-    let props = this.props;
+    let props = {...this.props};
     if (props.url) {
       props.href = props.url;
     }
@@ -16,6 +16,20 @@ class Link extends React.PureComponent {
       </a>
     );
   }
+}
+
+Link._idyll = {
+  name: "Link",
+  tagType: "closed",
+  props: [{
+    name: "text",
+    type: "string",
+    example: '"Link Text"'
+  }, {
+    name: 'url',
+    type: 'string',
+    example: '"https://some.url/"'
+  }]
 }
 
 export default Link;

--- a/packages/idyll-components/src/radio.js
+++ b/packages/idyll-components/src/radio.js
@@ -31,4 +31,19 @@ Radio.defaultProps = {
   options: []
 };
 
+
+Radio._idyll = {
+  name: "Radio",
+  tagType: "closed",
+  props: [{
+    name: "value",
+    type: "string",
+    example: "x"
+  }, {
+    name: "options",
+    type: "array",
+    example: '`["option1", "option2"]`'
+  }]
+}
+
 export default Radio;

--- a/packages/idyll-components/src/range.js
+++ b/packages/idyll-components/src/range.js
@@ -26,4 +26,26 @@ Range.defaultProps = {
   step: 1
 };
 
+Range._idyll = {
+  name: "Range",
+  tagType: "closed",
+  props: [{
+    name: "value",
+    type: "number",
+    example: "x"
+  }, {
+    name: "min",
+    type: "number",
+    example: '0'
+  }, {
+    name: "max",
+    type: "number",
+    example: '100'
+  }, {
+    name: "step",
+    type: "number",
+    example: '1'
+  }]
+}
+
 export default Range;

--- a/packages/idyll-components/src/select.js
+++ b/packages/idyll-components/src/select.js
@@ -29,4 +29,17 @@ Select.defaultProps = {
   options: []
 }
 
+Select._idyll = {
+  name: "Select",
+  tagType: "closed",
+  props: [{
+    name: "value",
+    type: "string",
+    example: "x"
+  }, {
+    name: "options",
+    type: "array",
+    example: '`["option1", "option2"]`'
+  }]
+}
 export default Select;

--- a/packages/idyll-components/src/slideshow.js
+++ b/packages/idyll-components/src/slideshow.js
@@ -31,4 +31,17 @@ Slideshow.defaultProps = {
   currentSlide: 1
 };
 
+Slideshow._idyll = {
+  name: "Slideshow",
+  tagType: "open",
+  children: [`
+[slide]This is the content for slide 1[/slide]
+[slide]This is the content for slide 2[/slide]
+[slide]This is the content for slide 3[/slide]`],
+  props: [{
+    name: "currentSlide",
+    type: "number",
+    example: 'x'
+  }]
+}
 export default Slideshow;

--- a/packages/idyll-components/src/svg.js
+++ b/packages/idyll-components/src/svg.js
@@ -13,5 +13,15 @@ SVG.defaultProps = {
   src: ''
 }
 
+SVG._idyll = {
+  name: "SVG",
+  tagType: "closed",
+  props: [{
+    name: "src",
+    type: "string",
+    example: '"https://path/to/file.svg"'
+  }]
+}
+
 export default SVG;
 

--- a/packages/idyll-components/src/table.js
+++ b/packages/idyll-components/src/table.js
@@ -45,4 +45,26 @@ TableComponent.defaultProps = {
   showPageJump: false
 }
 
+TableComponent._idyll = {
+  name: "Table",
+  tagType: "closed",
+  props: [{
+    name: "data",
+    type: "array",
+    example: 'x'
+  }, {
+    name: "showPagination",
+    type: "boolean",
+    example: 'false'
+  }, {
+    name: "showPageSizeOptions",
+    type: "boolean",
+    example: 'false'
+  }, {
+    name: "showPageJump",
+    type: "boolean",
+    example: 'false'
+  }]
+}
+
 module.exports = TableComponent;

--- a/packages/idyll-components/src/text-input.js
+++ b/packages/idyll-components/src/text-input.js
@@ -18,4 +18,14 @@ class TextInput extends React.PureComponent {
   }
 }
 
+TextInput._idyll = {
+  name: "TextInput",
+  tagType: "closed",
+  props: [{
+    name: "value",
+    type: "string",
+    example: '"Hello"'
+  }]
+}
+
 export default TextInput;

--- a/packages/idyll-components/src/waypoint.js
+++ b/packages/idyll-components/src/waypoint.js
@@ -13,4 +13,14 @@ class Waypoint extends React.PureComponent {
 
 }
 
+Waypoint._idyll = {
+  name: "Waypoint",
+  tagType: "open",
+  props: [{
+    name: "onEnterView",
+    type: "event",
+    example: "`x = true`"
+  }]
+}
+
 export default Waypoint;

--- a/packages/idyll-docs/idyll-components/contents.js
+++ b/packages/idyll-docs/idyll-components/contents.js
@@ -135,7 +135,7 @@ const components = [
                 "min": "The minimum value."
               },
               {
-                "interval": "The granularity of the changes."
+                "step": "The granularity of the changes."
               }
             ]
           }
@@ -272,7 +272,7 @@ const components = [
         {
           "Table": {
             "thumbnail": "table.png",
-            "description": "Display tabular data. Uses https://github.com/glittershark/reactable under the hood to render the table.",
+            "description": "Display tabular data. Uses https://github.com/react-tools/react-table under the hood to render the table.",
             "image": "table.png"
           }
         }
@@ -336,7 +336,7 @@ const components = [
 
 function slugify(text)
 {
-  return text.toString().toLowerCase()
+  return text.toString().split(/([A-Z][a-z]+)/).join('-').toLowerCase()
     .replace(/\s+/g, '-')           // Replace spaces with -
     .replace(/[^\w\-]+/g, '')       // Remove all non-word chars
     .replace(/\-\-+/g, '-')         // Replace multiple - with single -

--- a/packages/idyll-docs/pages/docs/component.js
+++ b/packages/idyll-docs/pages/docs/component.js
@@ -87,10 +87,7 @@ export default class IdyllComponentPage extends React.PureComponent {
 
   render() {
     const { url } = this.props;
-    console.log(Object.keys(indexedComponents))
-    // console.log(url.query.slug.split('-').map(capitalizeFirstLetter).join(''))
     const comp = indexedComponents[url.query.slug];
-    console.log(comp);
     return (
       <Layout url={ url }>
         <div>

--- a/packages/idyll-docs/pages/docs/component.js
+++ b/packages/idyll-docs/pages/docs/component.js
@@ -16,6 +16,11 @@ function md2html(md, naked = false) {
   return Parser(html)
 }
 
+function capitalizeFirstLetter(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+
 class IdyllComponentDoc extends React.Component {
   render() {
     const {
@@ -82,7 +87,10 @@ export default class IdyllComponentPage extends React.PureComponent {
 
   render() {
     const { url } = this.props;
+    console.log(Object.keys(indexedComponents))
+    // console.log(url.query.slug.split('-').map(capitalizeFirstLetter).join(''))
     const comp = indexedComponents[url.query.slug];
+    console.log(comp);
     return (
       <Layout url={ url }>
         <div>

--- a/packages/idyll-docs/pages/index.js
+++ b/packages/idyll-docs/pages/index.js
@@ -98,11 +98,7 @@ The value of x is [Display value:x format:"d" /].
 
               <div className="label">Output</div>
               <div className="output">
-              {
-                ast ?
-                <IdyllDocument layout='centered' markup={exampleValue} components={IdyllComponents} key={ exampleValue }  />
-                : null
-              }
+                <IdyllDocument layout='centered' markup={exampleValue} components={IdyllComponents} />
               {
                 error ? (
                   <pre>

--- a/packages/idyll-themes/src/github/styles.js
+++ b/packages/idyll-themes/src/github/styles.js
@@ -719,4 +719,12 @@ hr {
   border-bottom-color: #eee;
 }
 
+.idyll-dynamic {
+  text-decoration: underline;
+  text-decoration-style: dotted;
+}
+
+.idyll-action {
+  text-decoration: underline;
+}
 `

--- a/packages/idyll-themes/src/idyll/styles.js
+++ b/packages/idyll-themes/src/idyll/styles.js
@@ -117,5 +117,9 @@ span.action {
   cursor: pointer;
 }
 
+.idyll-dynamic {
+  text-decoration: underline;
+  text-decoration-style: dotted;
+}
 
 `

--- a/packages/idyll-themes/src/tufte/styles.js
+++ b/packages/idyll-themes/src/tufte/styles.js
@@ -281,4 +281,14 @@ label.margin-toggle:not(.sidenote-number) { display: none; }
                             div.table-wrapper, table { width: 85%; }
                             img { width: 100%; } }
 
+
+
+.idyll-dynamic {
+  text-decoration: underline;
+  text-decoration-style: dotted;
+}
+
+.idyll-action {
+  text-decoration: underline;
+}
 `


### PR DESCRIPTION
This PR adds metadata to the standard library of components, so that Idyll authoring tools can provide better guidance, feedback, and error messages. It also fixes a handful of bugs and inaccuracies in the documentation that I found along the way.