### PR TITLE
Enhance idyll-document logic

### DIFF
--- a/packages/idyll-compiler/src/index.js
+++ b/packages/idyll-compiler/src/index.js
@@ -17,14 +17,14 @@ module.exports = function(input, options, callback) {
   try {
     lexResults = lex(content);
   } catch(err) {
-    console.warn('Error parsing Idyll markup:\n');
-    console.error(err.message);
+    console.warn(`\nError parsing Idyll markup:\n${err.message}`);
+    return new Promise((resolve, reject) => reject(err));
   }
   try {
     output = parse(content, lexResults.tokens.join(' '), lexResults.positions, options);
   } catch(err) {
-    console.warn('\n\n\nError parsing Idyll markup:\n');
-    console.error(err.message);
+    console.warn(`\nError parsing Idyll markup:\n${err.message}`);
+    return new Promise((resolve, reject) => reject(err));
   }
 
   let astTransform = Processor(output, options)

--- a/packages/idyll-docs/components/editor/index.js
+++ b/packages/idyll-docs/components/editor/index.js
@@ -21,7 +21,8 @@ class LiveIdyllEditor extends React.PureComponent {
   }
 
   componentDidCatch(error, info) {
-    // console.log(error);
+
+    console.log(error);
     this.setState({ error: error.message });
   }
 

--- a/packages/idyll-docs/components/editor/renderer.js
+++ b/packages/idyll-docs/components/editor/renderer.js
@@ -25,7 +25,7 @@ class Renderer extends React.PureComponent {
   }
 
   render() {
-    const { ast, idyllHash } = this.props;
+    const { markup } = this.props;
     return (
       <div className={`renderer `}>
         <div className={`renderer-container ${scopedStyles.className}`}>
@@ -34,11 +34,9 @@ class Renderer extends React.PureComponent {
             <pre>{this.state.error.toString()}</pre>
           ) :
           <IdyllDocument
-            ast={ ast }
+            markup={ markup }
             components={ Object.assign({}, components, { 'vega-lite': VegaLite }) }
-            key={ idyllHash }
             layout={ 'centered' }
-            __persistStateAcrossUpdates={true}
             context={(context) => {
               window.IDYLL_CONTEXT = context;
             }}

--- a/packages/idyll-docs/pages/docs/publishing/embedding.js
+++ b/packages/idyll-docs/pages/docs/publishing/embedding.js
@@ -15,7 +15,7 @@ export default ({ url }) => (
 
       <p>To do this, you must first install the dependencies:</p>
 
-      <pre><code class="sh language-sh">$ npm i --save idyll-document idyll-compiler idyll-components
+      <pre><code class="sh language-sh">$ npm i --save idyll-document idyll-components
       </code></pre>
 
       <p>then, add it to your page. If you are already using React, you
@@ -23,7 +23,6 @@ export default ({ url }) => (
 
       <pre><code class="javascript language-javascript">
 {`import IdyllDocument from 'idyll-document';
-import compile from 'idyll-compiler';
 import * as components from 'idyll-components';
 
 // An example functional component
@@ -49,7 +48,6 @@ import * as components from 'idyll-components';
 {`import React from 'react';
 import ReactDOM from 'react-dom';
 import IdyllDocument from 'idyll-document';
-import compile from 'idyll-compiler';
 import * as components from 'idyll-components';
 
 // You must provide idyllMarkup

--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -62,7 +62,7 @@ class IdyllDocument extends React.Component {
       <Runtime
         {...this.props}
         key={ this.state.hash }
-        context={(context) => { this.idyllContext = context; return this.props.context(context); }}
+        context={(context) => { this.idyllContext = context; this.props.context && this.props.context(context); }}
         initialState={this.props.initialState || (this.idyllContext ? this.idyllContext.data() : {})}
         ast={ this.props.ast || this.state.ast }
          />

--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -6,8 +6,8 @@ import compile from 'idyll-compiler';
 export const hashCode = (str) => {
   var hash = 0, i, chr;
   if (str.length === 0) return hash;
-  for (i = 0; i < str.length; i++) {``
-    chr   = str.charCodeAt(i);``
+  for (i = 0; i < str.length; i++) {
+    chr   = str.charCodeAt(i);
     hash  = ((hash << 5) - hash) + chr;
     hash |= 0; // Convert to 32bit integer
   }
@@ -20,7 +20,9 @@ class IdyllDocument extends React.Component {
     super(props);
     this.state = {
       ast: props.ast || [],
-      hash: ''
+      previousAST: props.ast || [],
+      hash: '',
+      error: null
     }
   }
 
@@ -33,6 +35,11 @@ class IdyllDocument extends React.Component {
     }
   }
 
+  componentDidCatch(error, info) {
+    this.props.onError && this.props.onError(error);
+    this.setState({ error: error.message });
+  }
+
   componentWillReceiveProps(newProps) {
     if (newProps.ast) {
       return;
@@ -40,18 +47,23 @@ class IdyllDocument extends React.Component {
 
     const hash = hashCode(newProps.markup);
     if (hash !== this.state.hash) {
+      this.setState({ previousAST: this.state.ast });
       compile(newProps.markup)
         .then((ast) => {
-          this.setState({ ast, hash });
+          this.setState({ previousAST: ast, ast, hash });
         })
+        .catch(this.componentDidCatch.bind(this));
     }
   }
+
 
   render() {
     return (
       <Runtime
         {...this.props}
         key={ this.state.hash }
+        context={(context) => { this.idyllContext = context; return this.props.context(context); }}
+        initialState={this.props.initialState || (this.idyllContext ? this.idyllContext.data() : {})}
         ast={ this.props.ast || this.state.ast }
          />
     )


### PR DESCRIPTION
This PR

* adds logic to `idyll-document` to persist state across markup updates
* it also adds logic to persist the previous output in the case of a compiler error
* fixes a bug in the editor on the docs site