### PR TITLE
Equation duplication

### DIFF
--- a/packages/idyll-cli/src/client/_index.html
+++ b/packages/idyll-cli/src/client/_index.html
@@ -36,6 +36,9 @@
     {{#twitterHandle}}
       <meta property="twitter:creator" content="{{twitterHandle}}">
     {{/twitterHandle}}
+    {{#usesTex}}
+      <link rel="stylesheet" href="styles.css">
+    {{/usesTex}}
     <link rel="stylesheet" href="styles.css">
   </head>
   <body>

--- a/packages/idyll-cli/src/pipeline/parse.js
+++ b/packages/idyll-cli/src/pipeline/parse.js
@@ -246,7 +246,7 @@ exports.getHTML = (paths, ast, _components, datasets, template, opts) => {
       layout: opts.layout
     })
   ).trim();
-  return mustache.render(template, meta);
+  return mustache.render(template, Object.assign({ usesTex: components.equation }, meta));
 }
 
 exports.getASTJSON = (ast) => {

--- a/packages/idyll-components/src/equation.js
+++ b/packages/idyll-components/src/equation.js
@@ -24,15 +24,16 @@ class Equation extends React.PureComponent {
     let dom;
 
     const cssId = 'idyll-equation-css';  // you could encode the css path itself to generate id..
-    if (document && !document.getElementById(cssId) && !this.props.skipCSS && !select("link[href='/path/to.css']").size()) {
+    const cssURL = '//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0/katex.min.css'
+    if (document && !document.getElementById(cssId) && !this.props.skipCSS && !select(`link[href='${cssURL}']`).size()) {
       const heads = document.getElementsByTagName('head')
       if (heads.length) {
         const head  = heads[0];
         const link  = document.createElement('link');
         link.id   = cssId;
+        link.href = cssURL;
         link.rel  = 'stylesheet';
         link.type = 'text/css';
-        link.href = '//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0/katex.min.css';
         link.media = 'all';
         head.appendChild(link);
       }

--- a/packages/idyll-components/src/equation.js
+++ b/packages/idyll-components/src/equation.js
@@ -24,7 +24,7 @@ class Equation extends React.PureComponent {
     let dom;
 
     const cssId = 'idyll-equation-css';  // you could encode the css path itself to generate id..
-    if (document && !document.getElementById(cssId)) {
+    if (document && !document.getElementById(cssId) && !this.props.skipCSS && !select("link[href='/path/to.css']").size()) {
       const heads = document.getElementsByTagName('head')
       if (heads.length) {
         const head  = heads[0];


### PR DESCRIPTION
This prevents the equation component from inserting the CSS tag if it has already been appended to the document. It also adds an option `skipCSS` to force the component to avoid inserting it.

It updates the HTML template that idyll uses to include the tex css file when necessary, to fix #138.