### PR TITLE
add event for context to listen for state changes

### DIFF
--- a/packages/idyll-document/src/runtime.js
+++ b/packages/idyll-document/src/runtime.js
@@ -200,7 +200,6 @@ class IdyllRuntime extends React.PureComponent {
 
     const Wrapper = createWrapper({ theme: props.theme, layout: props.layout });
 
-
     const initialState = Object.assign({}, {
       ...getVars(vars),
       ...getData(data, props.datasets),
@@ -233,6 +232,8 @@ class IdyllRuntime extends React.PureComponent {
       state = Object.assign(state, nextState);
       // pass the new doc state to all listeners aka component wrappers
       updatePropsCallbacks.forEach(f => f(state, changedKeys));
+
+      this._onUpdateState && this._onUpdateState(state);
     };
 
     evalContext.update = this.updateState;
@@ -252,7 +253,7 @@ class IdyllRuntime extends React.PureComponent {
 
     Object.keys(internalComponents).forEach((key) => {
       if (props.components[key]) {
-        console.warn(`Warning! You are including a component named ${key}, but this conflicts with an internal component. Please rename your component.`);
+        console.warn(`Warning! You are including a component named ${key}, but this is a reserved Idyll component. Please rename your component.`);
       }
     })
 
@@ -396,7 +397,10 @@ class IdyllRuntime extends React.PureComponent {
     if (typeof this.props.context === 'function') {
       this.props.context({
         update: this.updateState.bind(this),
-        data: () => this.state
+        data: () => this.state,
+        onUpdate: (cb) => {
+          this._onUpdateState = cb;
+        }
       });
     }
   }

--- a/packages/idyll-document/test/vars.js
+++ b/packages/idyll-document/test/vars.js
@@ -117,8 +117,20 @@ describe('Component state initialization', () => {
     const updateProps = rangeComponents.first().prop('updateProps');
     expect(updateProps).toEqual(expect.any(Function));
 
-    updateProps({ value: 4 });
+    idyllContext.onUpdate((newState) => {
+      console.log('NEW STATE IN THE CONTEXT')
+      expect(newState).toEqual({
+        x: 4,
+        frequency: 1,
+        xSquared: 16,
+        myData: FAKE_DATA,
+        objectVar: {an: "object"},
+        arrayVar: [ "array" ],
+        lateVar: 50
+      })
+    })
 
+    updateProps({ value: 4 });
     expect(idyllContext.data()).toEqual({
       x: 4,
       frequency: 1,

--- a/packages/idyll-document/test/vars.js
+++ b/packages/idyll-document/test/vars.js
@@ -118,7 +118,6 @@ describe('Component state initialization', () => {
     expect(updateProps).toEqual(expect.any(Function));
 
     idyllContext.onUpdate((newState) => {
-      console.log('NEW STATE IN THE CONTEXT')
       expect(newState).toEqual({
         x: 4,
         frequency: 1,


### PR DESCRIPTION
this adds an `onUpdate` method to the context object, which can be used to listen for state changes. this will be useful for building better analytics on top of idyll