### PR TITLE
Add options for specifying a custom runtime context to the CLI

### DIFF
--- a/packages/idyll-cli/src/client/build.js
+++ b/packages/idyll-cli/src/client/build.js
@@ -10,11 +10,8 @@ const datasets = require('__IDYLL_DATA__');
 require('__IDYLL_SYNTAX_HIGHLIGHT__');
 
 const opts = require('__IDYLL_OPTS__');
-console.log(opts);
 const { context, layout, theme } = opts;
 
-console.log('INITIALIZING WITH CONTEXT');
-console.log(context);
 const mountMethod = opts.ssr ? 'hydrate' : 'render';
 ReactDOM[mountMethod](
   React.createElement(IdyllDocument, { ast, components, context, datasets, layout, theme }),

--- a/packages/idyll-cli/src/client/build.js
+++ b/packages/idyll-cli/src/client/build.js
@@ -10,10 +10,13 @@ const datasets = require('__IDYLL_DATA__');
 require('__IDYLL_SYNTAX_HIGHLIGHT__');
 
 const opts = require('__IDYLL_OPTS__');
-const { theme, layout } = opts;
+console.log(opts);
+const { context, layout, theme } = opts;
 
+console.log('INITIALIZING WITH CONTEXT');
+console.log(context);
 const mountMethod = opts.ssr ? 'hydrate' : 'render';
 ReactDOM[mountMethod](
-  React.createElement(IdyllDocument, { ast, components, datasets, theme, layout }),
+  React.createElement(IdyllDocument, { ast, components, context, datasets, layout, theme }),
   mountNode
 );

--- a/packages/idyll-cli/src/index.js
+++ b/packages/idyll-cli/src/index.js
@@ -72,6 +72,7 @@ const idyll = (options = {}, cb) => {
   // Handle options that can be provided via options or via package.json
   opts.transform = options.transform || inputConfig.transform || opts.transform;
   opts.compiler = options.compiler || inputConfig.compiler || opts.compiler;
+  opts.context = options.context || inputConfig.context || opts.context;
 
   // Resolve compiler plugins:
   if (opts.compiler.postProcessors) {
@@ -84,6 +85,26 @@ const idyll = (options = {}, cb) => {
       }
     })
   }
+
+  // Resolve context:
+  if (opts.context) {
+    try {
+        const context = opts.context;
+        console.log('context', context);
+        if (context.indexOf('./') > -1) {
+          console.log('updating context');
+          opts.context = require(join(paths.INPUT_DIR, context));
+        } else {
+          opts.context = require(context);
+        }
+        console.log('context', opts.context);
+    } catch(e) {
+      console.log(e);
+      console.warn('\n\nCould not find context plugin: ', opts.context);
+    }
+  }
+
+  console.log(opts.context);
 
   let bs;
 

--- a/packages/idyll-cli/src/index.js
+++ b/packages/idyll-cli/src/index.js
@@ -90,21 +90,16 @@ const idyll = (options = {}, cb) => {
   if (opts.context) {
     try {
         const context = opts.context;
-        console.log('context', context);
         if (context.indexOf('./') > -1) {
-          console.log('updating context');
           opts.context = require(join(paths.INPUT_DIR, context));
         } else {
           opts.context = require(context);
         }
-        console.log('context', opts.context);
     } catch(e) {
       console.log(e);
       console.warn('\n\nCould not find context plugin: ', opts.context);
     }
   }
-
-  console.log(opts.context);
 
   let bs;
 

--- a/packages/idyll-cli/src/pipeline/bundle-js.js
+++ b/packages/idyll-cli/src/pipeline/bundle-js.js
@@ -13,7 +13,13 @@ const toStream = (k, o) => {
   let src;
 
   if (['ast', 'data', 'opts'].indexOf(k) > -1) {
-    src = `module.exports = ${JSON.stringify(o)}`;
+    if (k === 'opts') {
+      src = `module.exports = Object.assign(${JSON.stringify(o)}, {
+        context: ${(o.context || function() {}).toString()}
+      })`
+    } else {
+      src = `module.exports = ${JSON.stringify(o)}`;
+    }
   } else if (k === 'syntaxHighlighting') {
     src = `module.exports = (function (){${o}})()`;
   } else {
@@ -21,6 +27,7 @@ const toStream = (k, o) => {
     src = `module.exports = {\n\t${src}\n}\n`;
   }
 
+  console.log(src);
   const s = new stream.Readable;
   s.push(src);
   s.push(null);
@@ -87,6 +94,7 @@ module.exports = function (opts, paths, output) {
 
         for (const key in aliases) {
           const data = output[key];
+          console.log('DATA: ', data);
           b.exclude(aliases[key]);
           b.require(toStream(key, data), {
             expose: aliases[key],

--- a/packages/idyll-cli/src/pipeline/bundle-js.js
+++ b/packages/idyll-cli/src/pipeline/bundle-js.js
@@ -27,7 +27,6 @@ const toStream = (k, o) => {
     src = `module.exports = {\n\t${src}\n}\n`;
   }
 
-  console.log(src);
   const s = new stream.Readable;
   s.push(src);
   s.push(null);
@@ -94,7 +93,6 @@ module.exports = function (opts, paths, output) {
 
         for (const key in aliases) {
           const data = output[key];
-          console.log('DATA: ', data);
           b.exclude(aliases[key]);
           b.require(toStream(key, data), {
             expose: aliases[key],

--- a/packages/idyll-cli/src/pipeline/bundle-js.js
+++ b/packages/idyll-cli/src/pipeline/bundle-js.js
@@ -14,9 +14,11 @@ const toStream = (k, o) => {
 
   if (['ast', 'data', 'opts'].indexOf(k) > -1) {
     if (k === 'opts') {
-      src = `module.exports = Object.assign(${JSON.stringify(o)}, {
-        context: ${(o.context || function() {}).toString()}
-      })`
+
+      src = `
+      var out = ${JSON.stringify(o)};
+      out.context = ${(o.context || function() {}).toString()};
+      module.exports = out;`
     } else {
       src = `module.exports = ${JSON.stringify(o)}`;
     }

--- a/packages/idyll-cli/src/pipeline/index.js
+++ b/packages/idyll-cli/src/pipeline/index.js
@@ -56,6 +56,7 @@ const build = (opts, paths, resolvers) => {
           css,
           syntaxHighlighting: getHighlightJS(ast, paths),
           opts: {
+            context: opts.context,
             ssr: opts.ssr,
             theme: opts.theme,
             layout: opts.layout

--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -71,7 +71,10 @@ class IdyllDocument extends React.Component {
         <Runtime
           {...this.props}
           key={ this.state.hash }
-          context={(context) => { this.idyllContext = context; this.props.context && this.props.context(context); }}
+          context={(context) => {
+            this.idyllContext = context;
+            typeof this.props.context === 'function' && this.props.context(context);
+          }}
           initialState={this.props.initialState || (this.idyllContext ? this.idyllContext.data() : {})}
           ast={ this.props.ast || this.state.ast }
           />


### PR DESCRIPTION
This adds an option so that users can easily hook into the idyll `context` API (initially defined in https://github.com/idyll-lang/idyll/pull/273, and updated recently in https://github.com/idyll-lang/idyll/pull/304). 

It is exposed in a similar way to compiler postprocessors (see https://github.com/idyll-lang/idyll/pull/280), and supports loading local files or javascript modules. Usage is like:

*package.json*
```json
{
  "idyll": {
    "context": "./context.js"
  }
}
```

*context.js*
```javascript
module.exports = (context) => {
  const initialState = context.data();
  console.log('initialState', initialState);

  context.onUpdate((newState) => {
    console.log('Context updated', newState);
  });
}
```