### PR TITLE
more robust context import

### DIFF
--- a/packages/idyll-cli/src/client/build.js
+++ b/packages/idyll-cli/src/client/build.js
@@ -10,7 +10,10 @@ const datasets = require('__IDYLL_DATA__');
 require('__IDYLL_SYNTAX_HIGHLIGHT__');
 
 const opts = require('__IDYLL_OPTS__');
-const { context, layout, theme } = opts;
+const { layout, theme } = opts;
+
+const context = require('__IDYLL_CONTEXT__');
+
 
 const mountMethod = opts.ssr ? 'hydrate' : 'render';
 ReactDOM[mountMethod](

--- a/packages/idyll-cli/src/client/build.js
+++ b/packages/idyll-cli/src/client/build.js
@@ -14,7 +14,6 @@ const { layout, theme } = opts;
 
 const context = require('__IDYLL_CONTEXT__');
 
-
 const mountMethod = opts.ssr ? 'hydrate' : 'render';
 ReactDOM[mountMethod](
   React.createElement(IdyllDocument, { ast, components, context, datasets, layout, theme }),

--- a/packages/idyll-cli/src/client/context.js
+++ b/packages/idyll-cli/src/client/context.js
@@ -1,0 +1,4 @@
+
+module.exports = () => {
+
+}

--- a/packages/idyll-cli/src/index.js
+++ b/packages/idyll-cli/src/index.js
@@ -88,16 +88,8 @@ const idyll = (options = {}, cb) => {
 
   // Resolve context:
   if (opts.context) {
-    try {
-        const context = opts.context;
-        if (context.indexOf('./') > -1) {
-          opts.context = require(join(paths.INPUT_DIR, context));
-        } else {
-          opts.context = require(context);
-        }
-    } catch(e) {
-      console.log(e);
-      console.warn('\n\nCould not find context plugin: ', opts.context);
+    if (opts.context.indexOf('./') > -1) {
+      opts.context = join(paths.INPUT_DIR, opts.context);
     }
   }
 

--- a/packages/idyll-cli/src/pipeline/bundle-js.js
+++ b/packages/idyll-cli/src/pipeline/bundle-js.js
@@ -108,10 +108,7 @@ module.exports = function (opts, paths, output) {
             expose: '__IDYLL_CONTEXT__'
           })
         } else {
-          const s = new stream.Readable;
-          s.push(`module.exports = () => {}`);
-          s.push(null);
-          b.require(s, {
+          b.require(__dirname + '/../client/context', {
             expose: '__IDYLL_CONTEXT__'
           })
         }

--- a/packages/idyll-cli/src/pipeline/bundle-js.js
+++ b/packages/idyll-cli/src/pipeline/bundle-js.js
@@ -101,6 +101,20 @@ module.exports = function (opts, paths, output) {
             basedir: paths.TMP_DIR
           })
         }
+
+
+        if (opts.context) {
+          b.require(opts.context, {
+            expose: '__IDYLL_CONTEXT__'
+          })
+        } else {
+          const s = new stream.Readable;
+          s.push(`module.exports = () => {}`);
+          s.push(null);
+          b.require(s, {
+            expose: '__IDYLL_CONTEXT__'
+          })
+        }
       }
     ]
   });

--- a/packages/idyll-cli/src/pipeline/index.js
+++ b/packages/idyll-cli/src/pipeline/index.js
@@ -55,8 +55,8 @@ const build = (opts, paths, resolvers) => {
           data,
           css,
           syntaxHighlighting: getHighlightJS(ast, paths),
+          context: opts.context,
           opts: {
-            context: opts.context,
             ssr: opts.ssr,
             theme: opts.theme,
             layout: opts.layout

--- a/packages/idyll-document/src/runtime.js
+++ b/packages/idyll-document/src/runtime.js
@@ -219,13 +219,19 @@ class IdyllRuntime extends React.PureComponent {
         getVars(derived, newMergedState),
       );
       const nextState = {...newMergedState, ...newDerivedValues};
+
+      const changedMap = {};
       const changedKeys = Object.keys(state).reduce(
         (acc, k) => {
-          if (state[k] !== nextState[k]) acc.push(k);
+          if (state[k] !== nextState[k]) {
+            acc.push(k);
+            changedMap[k] = nextState[k];
+          }
           return acc;
         },
         []
       )
+
       // Update doc state reference.
       // We re-use the same object here so that
       // IdyllRuntime.state can be accurately checked in tests
@@ -233,7 +239,7 @@ class IdyllRuntime extends React.PureComponent {
       // pass the new doc state to all listeners aka component wrappers
       updatePropsCallbacks.forEach(f => f(state, changedKeys));
 
-      this._onUpdateState && this._onUpdateState(newState);
+      this._onUpdateState && this._onUpdateState(changedMap);
     };
 
     evalContext.update = this.updateState;
@@ -397,7 +403,9 @@ class IdyllRuntime extends React.PureComponent {
     if (typeof this.props.context === 'function') {
       this.props.context({
         update: this.updateState.bind(this),
-        data: () => this.state,
+        data: () => {
+          return this.state
+        },
         onUpdate: (cb) => {
           this._onUpdateState = cb;
         }

--- a/packages/idyll-document/src/runtime.js
+++ b/packages/idyll-document/src/runtime.js
@@ -233,7 +233,7 @@ class IdyllRuntime extends React.PureComponent {
       // pass the new doc state to all listeners aka component wrappers
       updatePropsCallbacks.forEach(f => f(state, changedKeys));
 
-      this._onUpdateState && this._onUpdateState(state);
+      this._onUpdateState && this._onUpdateState(newState);
     };
 
     evalContext.update = this.updateState;

--- a/packages/idyll-document/test/vars.js
+++ b/packages/idyll-document/test/vars.js
@@ -119,13 +119,7 @@ describe('Component state initialization', () => {
 
     idyllContext.onUpdate((newState) => {
       expect(newState).toEqual({
-        x: 4,
-        frequency: 1,
-        xSquared: 16,
-        myData: FAKE_DATA,
-        objectVar: {an: "object"},
-        arrayVar: [ "array" ],
-        lateVar: 50
+        x: 4
       })
     })
 

--- a/packages/idyll-document/test/vars.js
+++ b/packages/idyll-document/test/vars.js
@@ -119,15 +119,16 @@ describe('Component state initialization', () => {
 
     idyllContext.onUpdate((newState) => {
       expect(newState).toEqual({
-        x: 4
+        x: 8,
+        xSquared: 64
       })
     })
 
-    updateProps({ value: 4 });
+    updateProps({ value: 8 });
     expect(idyllContext.data()).toEqual({
-      x: 4,
+      x: 8,
       frequency: 1,
-      xSquared: 16,
+      xSquared: 64,
       myData: FAKE_DATA,
       objectVar: {an: "object"},
       arrayVar: [ "array" ],
@@ -141,10 +142,10 @@ describe('Component state initialization', () => {
 
     const checks = [{
       id: 'varDisplay',
-      html: '<span>4.00</span>'
+      html: '<span>8.00</span>'
     }, {
       id: 'derivedVarDisplay',
-      html: '<span>16.00</span>'
+      html: '<span>64.00</span>'
     }, {
       id: 'strDisplay',
       html: '<span>string</span>'
@@ -153,7 +154,7 @@ describe('Component state initialization', () => {
       html: `<span>${JSON.stringify({static: 'object'})}</span>`
     }, {
       id: 'dynamicObjectDisplay',
-      html: `<span>${JSON.stringify({dynamic: 4.0})}</span>`
+      html: `<span>${JSON.stringify({dynamic: 8.0})}</span>`
     }, {
       id: 'dataDisplay',
       html: `<span>${FAKE_DATA}</span>`
@@ -162,10 +163,10 @@ describe('Component state initialization', () => {
       html: `<span>${FAKE_DATA}</span>`
     }, {
       id: 'bareDerivedDisplay',
-      html: '<span>16.00</span>'
+      html: '<span>64.00</span>'
     }, {
       id: 'bareVarDisplay',
-      html: '<span>4.00</span>'
+      html: '<span>8.00</span>'
     }, {
       id: 'objectVarDisplay',
       html: `<span>${JSON.stringify({an: "object"})}</span>`


### PR DESCRIPTION
This changes the `context` import logic to rely on browserify directly to import the file rather than proxying it through a node require. It eliminates a host of issues that come from serialization/deserialization of functions.