### PR TITLE
Added fix for build process hanging

### DIFF
--- a/packages/idyll-cli/bin/idyll.js
+++ b/packages/idyll-cli/bin/idyll.js
@@ -84,5 +84,7 @@ Object.keys(argv).forEach((key) => {
 debug('Using CLI arguments:', argv)
 
 idyll(argv).build().then(() => {
-  process.exit(0);
+  if (!argv.watch) {
+    process.exit(0);
+  }
 });

--- a/packages/idyll-cli/bin/idyll.js
+++ b/packages/idyll-cli/bin/idyll.js
@@ -83,7 +83,7 @@ Object.keys(argv).forEach((key) => {
 
 debug('Using CLI arguments:', argv)
 
-idyll(argv).build().then(() => {
+idyll(argv).build().on('complete', () => {
   if (!argv.watch) {
     process.exit(0);
   }

--- a/packages/idyll-cli/bin/idyll.js
+++ b/packages/idyll-cli/bin/idyll.js
@@ -83,4 +83,6 @@ Object.keys(argv).forEach((key) => {
 
 debug('Using CLI arguments:', argv)
 
-idyll(argv).build();
+idyll(argv).build().then(() => {
+  process.exit(0);
+});

--- a/packages/idyll-cli/src/index.js
+++ b/packages/idyll-cli/src/index.js
@@ -126,7 +126,7 @@ const idyll = (options = {}, cb) => {
       // Leaving the following timing statement in for backwards-compatibility.
       if (opts.debug) console.time('Build Time');
 
-      pipeline.build(opts, paths, resolvers)
+      return pipeline.build(opts, paths, resolvers)
         .then((output) => {
           debug('Build completed');
           // Leaving the following timing statement in for backwards-compatibility.

--- a/packages/idyll-cli/src/index.js
+++ b/packages/idyll-cli/src/index.js
@@ -177,6 +177,9 @@ const idyll = (options = {}, cb) => {
             });
           }
         })
+        .then(() => {
+          this.emit('complete')
+        })
         .catch((error) => {
           // pass along errors if anyone is listening
           if (this.listenerCount('error')) {


### PR DESCRIPTION
It's unclear why the build process is currently hanging, but these changes should probably happen anyway:
1.`idyll.build()` should return the build Promise, instead of omitting a return value.
2. The CLI tool should explicitly exit when the build Promise is resolved.