### PR TITLE
Fix rows getting cut off in table

### DIFF
--- a/packages/idyll-components/src/table.js
+++ b/packages/idyll-components/src/table.js
@@ -30,8 +30,8 @@ class TableComponent extends React.PureComponent {
     return (
       <Table
         className={`table ${this.props.className || ''}`}
-        // minRows={(this.props.data || []).length}
         showPagination={this.props.data.length > this.props.defaultPageSize}
+        minRows={this.props.data.length <= this.props.defaultPageSize ? this.props.data.length}
         {...this.props}
         children={undefined}
         columns={this.getColumns()}

--- a/packages/idyll-components/src/table.js
+++ b/packages/idyll-components/src/table.js
@@ -31,7 +31,7 @@ class TableComponent extends React.PureComponent {
       <Table
         className={`table ${this.props.className || ''}`}
         showPagination={this.props.data.length > this.props.defaultPageSize}
-        minRows={this.props.data.length <= this.props.defaultPageSize ? this.props.data.length}
+        minRows={this.props.data.length <= this.props.defaultPageSize ? this.props.data.length : undefined}
         {...this.props}
         children={undefined}
         columns={this.getColumns()}

--- a/packages/idyll-components/src/table.js
+++ b/packages/idyll-components/src/table.js
@@ -30,7 +30,8 @@ class TableComponent extends React.PureComponent {
     return (
       <Table
         className={`table ${this.props.className || ''}`}
-        minRows={(this.props.data || []).length}
+        // minRows={(this.props.data || []).length}
+        showPagination={this.props.data.length > this.props.defaultPageSize}
         {...this.props}
         children={undefined}
         columns={this.getColumns()}
@@ -40,9 +41,10 @@ class TableComponent extends React.PureComponent {
 }
 
 TableComponent.defaultProps = {
-  showPagination: false,
+  data: [],
   showPageSizeOptions: false,
-  showPageJump: false
+  showPageJump: false,
+  defaultPageSize: 20
 }
 
 TableComponent._idyll = {


### PR DESCRIPTION
Thanks @fhightower for pointing this issue out -

This update fixes logic in the table component so that pagination is shown on tables when there is more data than rows being shown. The issue from #330 was happening because the table component was trying to paginate, but `showPagination` was being set to false in an unintuitive way.

This should make for a much more intuitive experience.