### PR TITLE
Explicitly bundle react

### DIFF
--- a/packages/idyll-cli/src/pipeline/bundle-js.js
+++ b/packages/idyll-cli/src/pipeline/bundle-js.js
@@ -84,6 +84,9 @@ module.exports = function (opts, paths, output) {
         if (opts.minify) {
           b.require('react/umd/react.production.min.js', { expose: 'react' });
           b.require('react-dom/umd/react-dom.production.min.js', { expose: 'react-dom' });
+        } else {
+          b.require('react', { expose: 'react' });
+          b.require('react-dom', { expose: 'react-dom' });
         }
         const aliases = {
           ast: '__IDYLL_AST__',


### PR DESCRIPTION
This tweaks how browserify includes react, so that there is always an explicit `require` that takes place during the bundle step. This change should eliminate problems that could occur when using Idyll with third-party react components installed via npm. 

I was seeing it when testing with `react-chartjs`. 