### PR TITLE
improved header component

### DIFF
--- a/packages/idyll-components/src/header.js
+++ b/packages/idyll-components/src/header.js
@@ -21,6 +21,35 @@ class Header extends React.PureComponent {
             </div>
           )
         }
+        {
+          this.props.authors ? (
+            <div className={'byline'}>
+              By: {
+                this.props.authors.map((author, i) => {
+                  if (typeof author === 'string') {
+                    return author;
+                  }
+                  return author.link ? (
+                    <span key={author.name}>
+                      <a href={author.link} >{author.name}</a>{
+                        i < this.props.authors.length -1 ? (
+                          i === this.props.authors.length - 2 ? ' and ' :  ', ' )
+                        : ''}
+                    </span>
+                  ) : author.name;
+                })
+              }
+              {}
+            </div>
+          ) : null
+        }
+        {
+          this.props.date && (
+          <div className={'idyll-pub-date'}>
+            {this.props.date}
+          </div>
+          )
+        }
 
       </div>
     );


### PR DESCRIPTION
Adds support for:

* Multiple authors and author links
* Date tag

Example:

```

[Header
  title:"Announcing idyll.pub"
  subtitle:"Publish interactive blog posts and explorable explanations with Idyll's new static hosting service."
  date:"June 25, 2018"
  authors:`[{
    name: "Matthew Conlen",
    link: "https://twitter.com/mathisonian"
  }, {
    name: "Andrew Osheroff",
    link: "https://github.com/andrewosh"
  }]` /]
```