### PR TITLE
Fix for backwards-compat issue

### DIFF
--- a/packages/idyll-cli/bin/idyll.js
+++ b/packages/idyll-cli/bin/idyll.js
@@ -12,7 +12,13 @@ var cmd
 if (!idyll) {
   cmd = p.join(__dirname, './cli.js');
 } else {
-  cmd = p.join(idyll, '..', '..', 'bin', 'cli.js');
+  var idyllBin = p.join(idyll, '..', '..', 'bin')
+  cmd = p.join(idyllBin, 'cli.js');
+  try {
+    p.statSync(cmd)
+  } catch (err) {
+    cmd = p.join(idyllBin, 'idyll.js')
+  }
 }
 spawnSync(cmd, process.argv.slice(2), {
   stdio: 'inherit'


### PR DESCRIPTION
The global Idyll CLI is not defaulting to the correct top-level CLI file if run locally inside older projects. This patch ensures that multiple files are attempted in the local installation before failing.

Fixes #345