### PR TITLE
Make sure that gitignore is included in generated projects

### DIFF
--- a/packages/idyll-template-projects/.npmignore
+++ b/packages/idyll-template-projects/.npmignore
@@ -1,0 +1,1 @@
+!.gitignore


### PR DESCRIPTION
It seems to be being removed from the npm package currently.