### PR TITLE
fix typo

### DIFF
--- a/packages/idyll-docs/pages/docs/components/custom.js
+++ b/packages/idyll-docs/pages/docs/components/custom.js
@@ -91,7 +91,7 @@ The \`Incrementer\` component could then be used as follows:
 [Display value:clickCount /]
 \`\`\`
 
-Notice that even thought the \`Incrementer\` component doesn't know
+Notice that even though the \`Incrementer\` component doesn't know
 anything about the variable \`clickCount\`, it will still correctly
 update.
 


### PR DESCRIPTION
This PR just fixes a typo on the custom component page

Page said "Even thought..." instead of "Even though"