### PR TITLE
Use object proxies in `evalExpression` to allow for asynchronous updates.

### DIFF
--- a/packages/idyll-document/package.json
+++ b/packages/idyll-document/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "change-case": "^3.0.1",
     "cross-env": "^5.0.5",
+    "falafel": "^2.1.0",
     "html-tags": "^2.0.0",
     "idyll-compiler": "^3.1.9",
     "idyll-layouts": "^2.5.4",

--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -5,6 +5,13 @@ const falafel = require('falafel');
 export const evalExpression = (acc, expr, key, context) => {
 
   let e;
+
+  // console.log(expr);
+  // try {
+  //   falafel(expr, () => {})
+  // } catch(e) {
+  //   console.log('couldn\'t parse', expr);
+  // }
   if (key && (key.match(/^on[A-Z].*/) || key.match(/^handle[A-Z].*/))) {
     let setState = setState;
     e = `
@@ -16,7 +23,7 @@ export const evalExpression = (acc, expr, key, context) => {
             set: (_, prop, value) => {
               var newState = {};
               newState[prop] = value;
-              context.update(newState);
+              return true;
             }
           })
           ${falafel(expr, (node) => {
@@ -29,6 +36,8 @@ export const evalExpression = (acc, expr, key, context) => {
       })()
     `;
 
+
+    // console.log(e);
     return (function() {
       eval(e);
     }).bind(Object.assign({}, acc, context || {}));
@@ -43,6 +52,7 @@ export const evalExpression = (acc, expr, key, context) => {
             var newState = {};
             newState[prop] = value;
             context.update(newState);
+            return true;
           }
         })
         return ${falafel(expr, (node) => {
@@ -55,6 +65,8 @@ export const evalExpression = (acc, expr, key, context) => {
       })(this)
     `;
   }
+
+  // console.log(e);
 
   try {
     return (function(evalString){

--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -2,7 +2,6 @@ const values = require('object.values');
 const entries = require('object.entries');
 const falafel = require('falafel');
 
-
 export const buildExpression = (acc, expr, key, context, isEventHandler) => {
   return `
     ((context) => {
@@ -17,7 +16,7 @@ export const buildExpression = (acc, expr, key, context, isEventHandler) => {
             return true;
           }
         })
-        ${falafel(isEventHandler ? expr : `var __idyllReturnValue = ${expr}`, (node) => {
+        ${falafel(isEventHandler ? expr : `var __idyllReturnValue = ${expr || 'undefined'}`, (node) => {
           switch(node.type) {
             case 'Identifier':
               if (Object.keys(acc).indexOf(node.name) > -1) {

--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -3,7 +3,7 @@ const entries = require('object.entries');
 const falafel = require('falafel');
 
 
-const buildExpression = (acc, expr, key, context, isEventHandler) => {
+export const buildExpression = (acc, expr, key, context, isEventHandler) => {
   return `
     ((context) => {
         var __idyllStateProxy = new Proxy({}, {

--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -21,7 +21,7 @@ export const evalExpression = (acc, expr, key, context) => {
           })
           ${falafel(expr, (node) => {
             if (node.type === 'Identifier') {
-              if (acc.indexOf(node.name) > -1) {
+              if (Object.keys(acc).indexOf(node.name) > -1) {
                 node.update('_idyllStateProxy.' + node.source());
               }
             }
@@ -47,7 +47,7 @@ export const evalExpression = (acc, expr, key, context) => {
         })
         return ${falafel(expr, (node) => {
           if (node.type === 'Identifier') {
-            if (acc.indexOf(node.name) > -1) {
+            if (Object.keys(acc).indexOf(node.name) > -1) {
               node.update('_idyllStateProxy.' + node.source());
             }
           }

--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -1,34 +1,31 @@
 const values = require('object.values');
 const entries = require('object.entries');
+const falafel = require('falafel');
 
 export const evalExpression = (acc, expr, key, context) => {
+
   let e;
   if (key && (key.match(/^on[A-Z].*/) || key.match(/^handle[A-Z].*/))) {
     let setState = setState;
     e = `
       (() => {
-          ${
-            Object.keys(acc)
-              .filter(key => expr.includes(key))
-              .map(key => {
-                if (key === 'refs') {
-                  // delete each ref's domNode property
-                  // because it can't be serialized
-                  values(acc[key]).forEach(v => {
-                    delete v.domNode;
-                  })
-                }
-                return `var ${key} = this.${key};`;
-              })
-              .join('\n')
-          }
-          ${expr};
-          context.update({ ${
-            Object.keys(acc)
-              .filter(key => expr.includes(key) && key !== 'refs')
-              .map(key => `${key}: ${key}`)
-              .join(', ')
-          }});
+          var _idyllStateProxy = new Proxy({}, {
+            get: (_, prop) => {
+              return context[prop];
+            },
+            set: (_, prop, value) => {
+              var newState = {};
+              newState[prop] = value;
+              context.update(newState);
+            }
+          })
+          ${falafel(expr, (node) => {
+            if (node.type === 'Identifier') {
+              if (acc.indexOf(node.name) > -1) {
+                node.update('_idyllStateProxy.' + node.source());
+              }
+            }
+          })};
       })()
     `;
 
@@ -38,22 +35,23 @@ export const evalExpression = (acc, expr, key, context) => {
   } else {
     e = `
       ((context) => {
-        ${
-          Object.keys(acc)
-            .filter(key => expr.includes(key))
-            .map(key => {
-              if (key === 'refs') {
-                // delete each ref's domNode property
-                // because it can't be serialized
-                values(acc[key]).forEach(v => {
-                  delete v.domNode;
-                })
-              }
-              return `var ${key} = context.${key};`;
-            })
-            .join('\n')
-        }
-        return ${expr};
+        var _idyllStateProxy = new Proxy({}, {
+          get: (_, prop) => {
+            return context[prop];
+          },
+          set: (_, prop, value) => {
+            var newState = {};
+            newState[prop] = value;
+            context.update(newState);
+          }
+        })
+        return ${falafel(expr, (node) => {
+          if (node.type === 'Identifier') {
+            if (acc.indexOf(node.name) > -1) {
+              node.update('_idyllStateProxy.' + node.source());
+            }
+          }
+        })};
       })(this)
     `;
   }

--- a/packages/idyll-document/test/eval.js
+++ b/packages/idyll-document/test/eval.js
@@ -1,35 +1,101 @@
 
-const falafel = require('falafel');
-const parseGlobals = require('acorn-globals');
+import { buildExpression, evalExpression } from '../src/utils';
+
+const context = {
+  setState: () => {
+    console.log('setting state');
+  }
+}
+
+const whitespace = (str) => {
+  return str.trim().replace(/[\s\n\t]+/g, ' ')
+}
 
 describe('Detect global variables', () => {
 
-  it('Uses falafel', () => {
-    const output = falafel(`y = x`, function (node) {
-      if (node.type === 'Identifier') {
-        if (node.name === 'x') {
-          node.update('p.' + node.source());
-        }
-      }
-    });
+  it('Handles a basic variable', () => {
+    const expression = buildExpression({ x: 10 }, `x`, 'key', context, false);
 
-    expect('' + output).toContain('p.x');
+    expect(whitespace(expression)).toBe(whitespace(`
+      ((context) => {
+        var __idyllStateProxy = new Proxy({}, {
+          get: (_, prop) => {
+            return context[prop];
+          },
+          set: (_, prop, value) => {
+            var newState = {};
+            newState[prop] = value;
+            context.update(newState);
+            return true;
+          }
+        })
+        var __idyllReturnValue = __idyllStateProxy.x;
+        return __idyllReturnValue;
+      })(this)
+    `));
   })
 
-  it('Handles ++ incrementer', () => {
-    const output = falafel(`x++; ++y`, function (node) {
-      if (node.type === 'Identifier') {
-        // if (node.name === 'x') {
-          node.update('p.' + node.source());
-        // }
-      }
-      // else if (node.type === 'UpdateExpression') {
-      //   console.log(node);
-      // }
-    });
-
-    console.log('transformed code: ', '' + output);
-    expect('' + output).toContain('p.x');
+  it('Evals a basic variable', () => {
+    const output = evalExpression({ x: 10 }, `x`, 'key', context);
+    expect(output).toBe(10);
   })
+
+  it('Handles an assignment to a variable ', () => {
+    const expression = buildExpression({ x: 10 }, `x = 20`, 'key', context, true);
+
+    expect(whitespace(expression)).toBe(whitespace(`
+      ((context) => {
+        var __idyllStateProxy = new Proxy({}, {
+          get: (_, prop) => {
+            return context[prop];
+          },
+          set: (_, prop, value) => {
+            var newState = {};
+            newState[prop] = value;
+            context.update(newState);
+            return true;
+          }
+        })
+        __idyllStateProxy.x = 20;
+      })(this)
+    `));
+  })
+
+  it('Handles incrementers', () => {
+    const expression = buildExpression({ x: 10, y: 20 }, `x++; ++y`, 'key', context, true);
+
+    expect(whitespace(expression)).toBe(whitespace(`
+      ((context) => {
+        var __idyllStateProxy = new Proxy({}, {
+          get: (_, prop) => {
+            return context[prop];
+          },
+          set: (_, prop, value) => {
+            var newState = {};
+            newState[prop] = value;
+            context.update(newState);
+            return true;
+          }
+        })
+        __idyllStateProxy.x++; ++__idyllStateProxy.y;
+      })(this)
+    `));
+  })
+
+  // it('Handles ++ incrementer', () => {
+  //   const output = falafel(`x++; ++y`, function (node) {
+  //     if (node.type === 'Identifier') {
+  //       // if (node.name === 'x') {
+  //         node.update('p.' + node.source());
+  //       // }
+  //     }
+  //     // else if (node.type === 'UpdateExpression') {
+  //     //   console.log(node);
+  //     // }
+  //   });
+
+  //   console.log('transformed code: ', '' + output);
+  //   expect('' + output).toContain('p.x');
+  // })
 
 });

--- a/packages/idyll-document/test/eval.js
+++ b/packages/idyll-document/test/eval.js
@@ -1,0 +1,18 @@
+const falafel = require('falafel');
+const parseGlobals = require('acorn-globals');
+
+describe('Detect global variables', () => {
+
+  it('Uses falafel', () => {
+    const output = falafel(`y = x`, function (node) {
+      if (node.type === 'Identifier') {
+        if (node.name === 'x') {
+          node.update('p.' + node.source());
+        }
+      }
+    });
+
+    expect('' + output).toContain('p.x');
+  })
+
+});

--- a/packages/idyll-document/test/eval.js
+++ b/packages/idyll-document/test/eval.js
@@ -16,18 +16,19 @@ describe('Detect global variables', () => {
     expect('' + output).toContain('p.x');
   })
 
-  it.only('Handles ++ incrementer', () => {
-    const output = falafel(`x++`, function (node) {
+  it('Handles ++ incrementer', () => {
+    const output = falafel(`x++; ++y`, function (node) {
       if (node.type === 'Identifier') {
-        if (node.name === 'x') {
+        // if (node.name === 'x') {
           node.update('p.' + node.source());
-        }
+        // }
       }
-      else if (node.type === 'UpdateExpression') {
-        console.log(node);
-      }
+      // else if (node.type === 'UpdateExpression') {
+      //   console.log(node);
+      // }
     });
 
+    console.log('transformed code: ', '' + output);
     expect('' + output).toContain('p.x');
   })
 

--- a/packages/idyll-document/test/eval.js
+++ b/packages/idyll-document/test/eval.js
@@ -35,6 +35,28 @@ describe('Detect global variables', () => {
     `));
   })
 
+  it('Handles an empty string', () => {
+    const expression = buildExpression({ x: 10 }, '', 'key', context, false);
+
+    expect(whitespace(expression)).toBe(whitespace(`
+      ((context) => {
+        var __idyllStateProxy = new Proxy({}, {
+          get: (_, prop) => {
+            return context[prop];
+          },
+          set: (_, prop, value) => {
+            var newState = {};
+            newState[prop] = value;
+            context.update(newState);
+            return true;
+          }
+        })
+        var __idyllReturnValue = undefined;
+        return __idyllReturnValue;
+      })(this)
+    `));
+  })
+
   it('Evals a basic variable', () => {
     const output = evalExpression({ x: 10 }, `x`, 'key', context);
     expect(output).toBe(10);

--- a/packages/idyll-document/test/eval.js
+++ b/packages/idyll-document/test/eval.js
@@ -1,3 +1,4 @@
+
 const falafel = require('falafel');
 const parseGlobals = require('acorn-globals');
 
@@ -9,6 +10,21 @@ describe('Detect global variables', () => {
         if (node.name === 'x') {
           node.update('p.' + node.source());
         }
+      }
+    });
+
+    expect('' + output).toContain('p.x');
+  })
+
+  it.only('Handles ++ incrementer', () => {
+    const output = falafel(`x++`, function (node) {
+      if (node.type === 'Identifier') {
+        if (node.name === 'x') {
+          node.update('p.' + node.source());
+        }
+      }
+      else if (node.type === 'UpdateExpression') {
+        console.log(node);
       }
     });
 

--- a/packages/idyll-document/test/eval.js
+++ b/packages/idyll-document/test/eval.js
@@ -104,20 +104,4 @@ describe('Detect global variables', () => {
     `));
   })
 
-  // it('Handles ++ incrementer', () => {
-  //   const output = falafel(`x++; ++y`, function (node) {
-  //     if (node.type === 'Identifier') {
-  //       // if (node.name === 'x') {
-  //         node.update('p.' + node.source());
-  //       // }
-  //     }
-  //     // else if (node.type === 'UpdateExpression') {
-  //     //   console.log(node);
-  //     // }
-  //   });
-
-  //   console.log('transformed code: ', '' + output);
-  //   expect('' + output).toContain('p.x');
-  // })
-
 });


### PR DESCRIPTION
This updates the logic used by the runtime to use [object proxies](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) rather than simply capturing the variables' values at a particular point in time.

This fixes async bugs in user provided expressions and fixes #299 and #339. 

This PR is a work-in-progress. ~~Still TODO~~:
- [x] add tests

