### PR TITLE
Fix range bug in Chart component

### DIFF
--- a/packages/idyll-components/src/chart.js
+++ b/packages/idyll-components/src/chart.js
@@ -66,7 +66,7 @@ class Chart extends React.PureComponent {
     return (
       <div className={props.className}>
         {type !== 'PIE' ? (
-          <V.VictoryChart domainPadding={10} {...formattedRange} animate={animate} scale={scale} containerId={`container-${id}`} clipId={`clip-${id}`} >
+          <V.VictoryChart domainPadding={domainPadding} {...formattedRange} animate={animate} scale={scale} containerId={`container-${id}`} clipId={`clip-${id}`} >
             <INNER_CHART
               data={data}
               x={props.x}

--- a/packages/idyll-components/src/chart.js
+++ b/packages/idyll-components/src/chart.js
@@ -1,3 +1,4 @@
+
 import React from 'react';
 const V = require('victory');
 const d3Arr = require('d3-array');
@@ -58,10 +59,14 @@ class Chart extends React.PureComponent {
         });
       });
     }
+
+    let formattedRange = { domain: { x: domain, y: range } };
+
+
     return (
       <div className={props.className}>
         {type !== 'PIE' ? (
-          <V.VictoryChart domainPadding={domainPadding} domain={domain} range={range} animate={animate} scale={scale} containerId={`container-${id}`} clipId={`clip-${id}`} >
+          <V.VictoryChart domainPadding={10} {...formattedRange} animate={animate} scale={scale} containerId={`container-${id}`} clipId={`clip-${id}`} >
             <INNER_CHART
               data={data}
               x={props.x}

--- a/packages/idyll-docs/idyll-components/contents.js
+++ b/packages/idyll-docs/idyll-components/contents.js
@@ -217,6 +217,12 @@ const components = [
               },
               {
                 "type": "The type of the chart to display, can be `line`, `scatter`, `bar`, `pie`, or `time`. The time type is a line chart that expects the `x` values in the data to be in the temporal domain."
+              },
+              {
+                "domain": "The chart extent along the x dimension."
+              }
+              {
+                "range": "The chart extent along the y dimension."
               }
             ]
           }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** 
Bug fix

* **What is the current behavior?**
The chart `domain` and `range` properties are being formatted incorrectly, causing the chart axes to be drawn incorrectly.

* **What is the new behavior?**
Domain and range behave as expected and defined in the updated docs. 

* **Does this PR introduce a breaking change?** 
No
