### PR TITLE
update travis config to work better with yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,9 @@ env:
   - PACKAGE=idyll-layouts
   - PACKAGE=idyll-themes
 
-before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.0.1
-  - export PATH="$HOME/.yarn/bin:$PATH"
-
 install:
   - yarn install
+
+cache: yarn
 
 script: cd packages/$PACKAGE && npm test


### PR DESCRIPTION
Travis now has yarn installed by default, so we don't need a custom install anymore.

It also caches yarn packages, so builds should be much faster, thanks @domoritz. 