### PR TITLE
update comment handling, don't identify links as comments

### DIFF
--- a/packages/idyll-compiler/src/lexer.js
+++ b/packages/idyll-compiler/src/lexer.js
@@ -203,7 +203,7 @@ const lex = function(options) {
     return ['LINK'].concat(formatToken(text)).concat(formatToken(link));
   });
 
-  lexer.addRule(/\s?\/\/[^\n]*/gm, function(lexeme) {
+  lexer.addRule(/(\n[\s]+\/\/[^\n]*|\/\/\s+[^\n]*)/, function(lexeme) {
     updatePosition(lexeme);
   });
 

--- a/packages/idyll-compiler/src/lexer.js
+++ b/packages/idyll-compiler/src/lexer.js
@@ -203,7 +203,7 @@ const lex = function(options) {
     return ['LINK'].concat(formatToken(text)).concat(formatToken(link));
   });
 
-  lexer.addRule(/(\n[\s]+\/\/[^\n]*|\/\/\s+[^\n]*)/, function(lexeme) {
+  lexer.addRule(/(\n\s*\/\/[^\n]*|\/\/\s+[^\n]*)/, function(lexeme) {
     updatePosition(lexeme);
   });
 

--- a/packages/idyll-compiler/test/test.js
+++ b/packages/idyll-compiler/test/test.js
@@ -102,13 +102,13 @@ describe('compiler', function() {
         Text. / Not a comment.
         // Comment
         // Second comment
-        [component]
+        [component]//not a comment
           // comment inside components
         [/component]// is a comment
 
         not a comment: https://stuff.com
       `);
-      expect(results.tokens.join(' ')).to.eql('WORDS TOKEN_VALUE_START "Text. " TOKEN_VALUE_END WORDS TOKEN_VALUE_START "/ Not a comment.\n        " TOKEN_VALUE_END OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "component" TOKEN_VALUE_END CLOSE_BRACKET OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "component" TOKEN_VALUE_END CLOSE_BRACKET BREAK WORDS TOKEN_VALUE_START "not a comment: https:" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "/" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "/stuff.com" TOKEN_VALUE_END EOF');
+      expect(results.tokens.join(' ')).to.eql('WORDS TOKEN_VALUE_START "Text. " TOKEN_VALUE_END WORDS TOKEN_VALUE_START "/ Not a comment.\n        " TOKEN_VALUE_END OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "component" TOKEN_VALUE_END CLOSE_BRACKET WORDS TOKEN_VALUE_START "/" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "/not a comment\n          " TOKEN_VALUE_END OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "component" TOKEN_VALUE_END CLOSE_BRACKET BREAK WORDS TOKEN_VALUE_START "not a comment: https:" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "/" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "/stuff.com" TOKEN_VALUE_END EOF');
     });
 
     it('ordered lists with a space after the bullet are parsed as a list', function() {
@@ -407,7 +407,7 @@ End text
         Text. / Not a comment.
         // Comment
         // Second comment
-        [component]
+        [component]//not a comment
           // comment inside components
         [/component]// is a comment
 
@@ -416,7 +416,7 @@ End text
       expect(compile(input, { async: false })).to.eql(
       [
         ['TextContainer', [], [
-          ['p', [], ["Text. / Not a comment.\n        ", ["component", [], []]]],
+          ['p', [], ["Text. / Not a comment.\n        ", ["component", [], ["//not a comment\n          "]]]],
           ['p', [], ["not a comment: https://stuff.com"]]
         ]]
       ]);

--- a/packages/idyll-compiler/test/test.js
+++ b/packages/idyll-compiler/test/test.js
@@ -104,9 +104,11 @@ describe('compiler', function() {
         // Second comment
         [component]
           // comment inside components
-        [/component]
+        [/component]// is a comment
+
+        not a comment: https://stuff.com
       `);
-      expect(results.tokens.join(' ')).to.eql('WORDS TOKEN_VALUE_START "Text. " TOKEN_VALUE_END WORDS TOKEN_VALUE_START "/ Not a comment.\n        " TOKEN_VALUE_END OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "component" TOKEN_VALUE_END CLOSE_BRACKET OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "component" TOKEN_VALUE_END CLOSE_BRACKET EOF');
+      expect(results.tokens.join(' ')).to.eql('WORDS TOKEN_VALUE_START "Text. " TOKEN_VALUE_END WORDS TOKEN_VALUE_START "/ Not a comment.\n        " TOKEN_VALUE_END OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "component" TOKEN_VALUE_END CLOSE_BRACKET OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "component" TOKEN_VALUE_END CLOSE_BRACKET BREAK WORDS TOKEN_VALUE_START "not a comment: https:" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "/" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "/stuff.com" TOKEN_VALUE_END EOF');
     });
 
     it('ordered lists with a space after the bullet are parsed as a list', function() {
@@ -398,6 +400,28 @@ End text
           ]]
         ]);
     });
+
+
+    it('should ignore comments', function() {
+      var input = `
+        Text. / Not a comment.
+        // Comment
+        // Second comment
+        [component]
+          // comment inside components
+        [/component]// is a comment
+
+        not a comment: https://stuff.com
+      `;
+      expect(compile(input, { async: false })).to.eql(
+      [
+        ['TextContainer', [], [
+          ['p', [], ["Text. / Not a comment.\n        ", ["component", [], []]]],
+          ['p', [], ["not a comment: https://stuff.com"]]
+        ]]
+      ]);
+    });
+
 
 
     it('should accept negative numbers', function() {


### PR DESCRIPTION
This fixes a bug in the current comment parsing where two slashes (`//`) anywhere in the text would be considered as a comment, even if it is fairly obviously not the intention of the user. 

For example, `https://idyll-lang.org` would be processed as `https:` followed by a comment. This updates the behavior so that that two slashes must have a space either before or after in order to be treated as a comment. This still isn't perfect but much better than the current behavior. 

```
        Text. / Not a comment.
        // Comment
        // Second comment
        [component]//not a comment
          // comment inside components
        [/component]// is a comment

        not a comment: https://stuff.com
```

this update is required before #354 gets merged.