### PR TITLE
add nojekyll file to basic project template

### DIFF
--- a/packages/idyll-cli/bin/cmds/create-project.js
+++ b/packages/idyll-cli/bin/cmds/create-project.js
@@ -124,6 +124,7 @@ async function createProject (answers) {
   async function copyFiles (proceed) {
     await fs.copy(getTemplatePath(template), dir);
     await fs.move(p.join(dir, 'gitignore'), p.join(dir, '.gitignore'));
+    await fs.move(p.join(dir, 'nojekyll'), p.join(dir, '.nojekyll'));
     await fs.copy(DEFAULT_COMPONENTS_DIR, p.join(dir, 'components', 'default'));
   }
 


### PR DESCRIPTION
This adds a `.nojekyll` file to the basic project template, so that Github Pages will serve files whose names start with an underscore correctly. This fixes #373. 