### PR TITLE
fix cli resolver for node < 8.9

### DIFF
--- a/packages/idyll-cli/bin/util.js
+++ b/packages/idyll-cli/bin/util.js
@@ -1,6 +1,8 @@
+const resolve = require('resolve');
+
 module.exports.getLocalIdyll = function () {
   try {
-    return require.resolve('idyll', { paths: [process.cwd()] });
+    return resolve.sync('idyll', { basedir: process.cwd() });
   } catch (err) {
     return null;
   }


### PR DESCRIPTION
This updates the resolution logic for using the local copy of idyll in a project's `node_modules` folder. It updates to use the `resolve` module rather than `require.resolve`, since the `paths` option in resolve is only supported in node 8.9 and greater (https://nodejs.org/api/modules.html#modules_require_resolve_request_options).