### PR TITLE
Graphic overflow

### DIFF
--- a/packages/idyll-components/src/scroller.js
+++ b/packages/idyll-components/src/scroller.js
@@ -12,7 +12,7 @@ const styles = {
     height: '100vh',
     width: '100%',
     transform: `translate3d(0, 0, 0)`,
-    zIndex: -1
+    zIndex: -1,
   },
 
   SCROLL_GRAPHIC_INNER: {
@@ -22,8 +22,7 @@ const styles = {
     right: 0,
     top: '50%',
     transform: 'translateY(-50%)',
-    objectFit: 'cover',
-    backgroundColor: 'blue', // for debugging,
+    objectFit: 'cover', // TODO might remove
   }
 }
 
@@ -122,7 +121,7 @@ class Scroller extends React.Component {
         style={Object.assign({ position: 'relative' })}>
         <div className="idyll-scroll-graphic"
           style={Object.assign({ height: graphicHeight }, styles.SCROLL_GRAPHIC)} >
-          <div style={Object.assign({ width: graphicWidth }, styles.SCROLL_GRAPHIC_INNER)}>
+          <div style={Object.assign({ width: graphicWidth}, styles.SCROLL_GRAPHIC_INNER)}>
             {filterChildren(
               children,
               (c) => {

--- a/packages/idyll-components/src/scroller.js
+++ b/packages/idyll-components/src/scroller.js
@@ -21,7 +21,7 @@ const styles = {
     left: 0,
     right: 0,
     top: '50%',
-    transform: 'translateY(-50%)',
+    transform: 'translateY(-50%)'
   }
 }
 

--- a/packages/idyll-components/src/scroller.js
+++ b/packages/idyll-components/src/scroller.js
@@ -12,7 +12,7 @@ const styles = {
     height: '100vh',
     width: '100%',
     transform: `translate3d(0, 0, 0)`,
-    zIndex: -1,
+    zIndex: -1
   },
 
   SCROLL_GRAPHIC_INNER: {
@@ -22,7 +22,6 @@ const styles = {
     right: 0,
     top: '50%',
     transform: 'translateY(-50%)',
-    objectFit: 'cover', // TODO might remove
   }
 }
 
@@ -121,7 +120,7 @@ class Scroller extends React.Component {
         style={Object.assign({ position: 'relative' })}>
         <div className="idyll-scroll-graphic"
           style={Object.assign({ height: graphicHeight }, styles.SCROLL_GRAPHIC)} >
-          <div style={Object.assign({ width: graphicWidth}, styles.SCROLL_GRAPHIC_INNER)}>
+          <div style={Object.assign({ width: graphicWidth }, styles.SCROLL_GRAPHIC_INNER)}>
             {filterChildren(
               children,
               (c) => {

--- a/packages/idyll-components/src/scroller.js
+++ b/packages/idyll-components/src/scroller.js
@@ -21,7 +21,9 @@ const styles = {
     left: 0,
     right: 0,
     top: '50%',
-    transform: 'translateY(-50%)'
+    transform: 'translateY(-50%)',
+    objectFit: 'cover',
+    backgroundColor: 'blue' // for debugging
   }
 }
 

--- a/packages/idyll-components/src/scroller.js
+++ b/packages/idyll-components/src/scroller.js
@@ -23,7 +23,7 @@ const styles = {
     top: '50%',
     transform: 'translateY(-50%)',
     objectFit: 'cover',
-    backgroundColor: 'blue' // for debugging
+    backgroundColor: 'blue', // for debugging,
   }
 }
 

--- a/packages/idyll-layouts/src/blog/styles.js
+++ b/packages/idyll-layouts/src/blog/styles.js
@@ -67,6 +67,10 @@ input {
   position: sticky;
 }
 
+.idyll-scroll-graphic img {
+  max-height: 100vh;
+}
+
 @media all and (max-width: 1600px) {
   .fixed {
     width: calc((85vw - 600px) - 50px);

--- a/packages/idyll-layouts/src/centered/styles.js
+++ b/packages/idyll-layouts/src/centered/styles.js
@@ -38,6 +38,10 @@ input {
   position: sticky;
 }
 
+.idyll-scroll-graphic {
+  max-height: 100vh;
+}
+
 @media all and (max-width: 1000px) {
 
   .idyll-root {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix

* **What is the current behavior?** (You can also link to an open issue here)
This PR seeks to improve that by scaling images to be 100% of the viewport.

* **What is the new behavior (if this is a feature change)?**
For Scroller, inside the Graphic component, images that are larger than the `idyll-scroll-graphic` div would maintain its own height and so didn't scale properly. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nah. It just affects images within a Scroller-Graphic component.