### PR TITLE
remove unimplemented command

### DIFF
--- a/packages/idyll-cli/bin/cmds/create-component.js
+++ b/packages/idyll-cli/bin/cmds/create-component.js
@@ -1,6 +1,0 @@
-#! /usr/bin/env node
-
-exports.command = 'create-component [component-name]'
-exports.description = 'Create a new component within your project'
-exports.builder = {}
-exports.handler = (yargs) => {}


### PR DESCRIPTION
It would be great to bring this pack at some point, but its just confusing right now because it shows up when running `idyll --help`, but isn't actually implemented.