### PR TITLE
update nearley version

### DIFF
--- a/packages/idyll-compiler/package.json
+++ b/packages/idyll-compiler/package.json
@@ -41,7 +41,7 @@
     "gray-matter": "^3.1.1",
     "idyll-ast": "^1.5.0",
     "lex": "^1.7.9",
-    "nearley": "^2.7.12",
+    "nearley": "^2.15.0",
     "smartquotes": "^2.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6027,6 +6027,10 @@ moment@^2.11.2, moment@^2.6.0:
   version "2.21.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.21.0.tgz#2a114b51d2a6ec9e6d83cf803f838a878d8a023a"
 
+moo@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"
+
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
@@ -6095,6 +6099,16 @@ natural-compare@^1.4.0:
 ncp@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+
+nearley@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.15.0.tgz#d1ff5406a58064615fe6eafb429cf06fbb1b7eab"
+  dependencies:
+    moo "^0.4.3"
+    nomnom "~1.6.2"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
+    semver "^5.4.1"
 
 nearley@^2.7.10:
   version "2.11.0"


### PR DESCRIPTION
This updates the nearley dependency. There were some warnings coming from an old sub-dep, so this should get rid of that issue.