### PR TITLE
add --version cli option

### DIFF
--- a/packages/idyll-cli/bin/cli.js
+++ b/packages/idyll-cli/bin/cli.js
@@ -5,4 +5,5 @@ require('yargs')
   .commandDir('cmds')
   .demandCommand()
   .help()
+  .version()
   .argv


### PR DESCRIPTION
Attempts to solve issues/381

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/idyll-lang/idyll/issues/381


* **What is the new behavior (if this is a feature change)?**
This adds the `--version` option to the idyll command as in `idyll --version` 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None


* **Other information**:
  * Right now it simply uses the built in yargs version() implementation so it only returns the cli version number, as of right now `3.6.1` and not the entire apps version. It would be better if it showed both versions. 
  * I thought about adding test but as it uses built in yargs function I think its outside the testable code with the current setup of the tests. 