### PR TITLE
Fix component error message

### DIFF
--- a/packages/idyll-document/src/utils/schema2element.js
+++ b/packages/idyll-document/src/utils/schema2element.js
@@ -74,7 +74,7 @@ class ReactJsonSchema {
       if (DOM.hasOwnProperty(name)) {
         Component = schema.component;
       } else {
-        console.warn(`Could not find an implementation for: {schema.component}`);
+        console.warn(`Could not find an implementation for: ${schema.component}`);
         return () => (
           <div style={{ color: 'black', border: 'solid 1px red'}}>
             <pre>Could not find an implementation for: {schema.component}</pre>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


* **What is the current behavior?** (You can also link to an open issue here)
If a component can not be found it should print an error message, including the name of the component. It prints the error message, but prints `{schema.component}` instead of the actual component name.

* **What is the new behavior (if this is a feature change)?**
The name is printed correctly.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
