### PR TITLE
Better Chart theme support

### DIFF
--- a/packages/idyll-components/src/chart.js
+++ b/packages/idyll-components/src/chart.js
@@ -32,7 +32,12 @@ class Chart extends React.PureComponent {
       range,
       domainPadding = 10,
       animate,
+      theme = 'grayscale',
       ...customProps } = props;
+
+    if (typeof theme === 'string') {
+      theme = V.VictoryTheme[theme];
+    }
 
     if (props.equation) {
       const d = domain;
@@ -66,7 +71,7 @@ class Chart extends React.PureComponent {
     return (
       <div className={props.className}>
         {type !== 'PIE' ? (
-          <V.VictoryChart domainPadding={domainPadding} {...formattedRange} animate={animate} scale={scale} containerId={`container-${id}`} clipId={`clip-${id}`} >
+          <V.VictoryChart domainPadding={domainPadding} {...formattedRange} animate={animate} scale={scale} containerId={`container-${id}`} clipId={`clip-${id}`} theme={theme} >
             <INNER_CHART
               data={data}
               x={props.x}

--- a/packages/idyll-docs/idyll-components/contents.js
+++ b/packages/idyll-docs/idyll-components/contents.js
@@ -226,6 +226,9 @@ const components = [
               },
               {
                 "range": "The chart extent along the y dimension."
+              },
+              {
+                "theme": "The theme to use, e.g. `grayscale` or `material` or a custom object (see [an example here](https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/victory-theme/grayscale.js))"
               }
             ]
           }


### PR DESCRIPTION
This adds the ability to pass in an object or a string to the theme prop for the Chart component.

E.g.

```
[Chart theme:"material" type:"bar" /]

[Chart theme:`{ axis: { style: { grid: { stroke: '#ddd'} }}}` type:"bar" /]
```

both work to produce styled charts and fixes #403 

/cc @KingCeolwulf.