### PR TITLE
make sure packagename is valid

### DIFF
--- a/packages/idyll-cli/bin/cmds/build.js
+++ b/packages/idyll-cli/bin/cmds/build.js
@@ -6,12 +6,12 @@ const fs = require('fs');
 const pathBuilder = require('../../src/path-builder');
 
 exports.command = 'build';
-exports.description = 'Turn index.idl into output';
+exports.description = 'Turn index.idyll into standalone output';
 
 exports.builder = (yargs) => {
   return buildOptions(yargs)
     .usage('Usage: idyll build')
-    .example('$0 build -i index.idl', 'Turn a .idl file or project into output');
+    .example('$0 build -i index.idyll', 'Turn a .idl file or project into output');
 }
 
 

--- a/packages/idyll-cli/bin/cmds/create-project.js
+++ b/packages/idyll-cli/bin/cmds/create-project.js
@@ -133,7 +133,7 @@ async function createProject (answers) {
     let packageJson = JSON.parse(await fs.readFile(packagePath));
     let indexIdyll = await fs.readFile(indexPath, { encoding: 'utf-8' });
 
-    packageJson.name = name;
+    packageJson.name = name.split(' ').join('-').toLowerCase();
     var title = name.split('-').join(' ').replace(/\b\w/g, l => l.toUpperCase())
 
     await fs.writeFile(packagePath, JSON.stringify(packageJson, null, 2));


### PR DESCRIPTION
When running `idyll create` if the user provides a post title like "My Great Post", this is used directly in the `package.json` `name` field, which causes errors when running `npm install`.

This PR makes it so that spaces are removed from the `name` field, so that these errors are avoided. 