### PR TITLE
bugfix for multiple scroller; fix conditional edge case

### DIFF
--- a/packages/idyll-components/src/conditional.js
+++ b/packages/idyll-components/src/conditional.js
@@ -5,7 +5,7 @@ class Conditional extends React.Component {
     const { idyll, hasError, updateProps, ...props } = this.props;
 
     if (!props.if) {
-      return null;
+      return <div style={{display: 'none'}}>{props.children}</div>;
     }
 
     return <div>{props.children}</div>;

--- a/packages/idyll-components/src/scroller.js
+++ b/packages/idyll-components/src/scroller.js
@@ -50,9 +50,9 @@ class Scroller extends React.Component {
     // setup the instance, pass callback functions
     scroller
       .setup({
-        step: '.idyll-scroll-text .idyll-step', // required
+        step: `#idyll-scroll-${this.id} .idyll-step`, // required
         container: `#idyll-scroll-${this.id}`, // required (for sticky)
-        graphic: '.idyll-scroll-graphic' // required (for sticky)
+        graphic: `#idyll-scroll-${this.id} .idyll-scroll-graphic` // required (for sticky)
       })
       .onStepEnter(this.handleStepEnter.bind(this))
       // .onStepExit(handleStepExit)


### PR DESCRIPTION
This fixes a couple minor bugs with the component lib.

First, it fixes a bug where scrollers where not being properly scoped if there were multiple on a page (current behavior is that `currentStep` for all scrollers on the page would be updated in sync rather than individually. 

Second, it updates how conditionals handle their children when the condition is false. In the updated version children are still rendered, they are just placed inside a `div` with `display: none`; in the current version they aren't rendered at all, and this can cause some children to be improperly initialized in cases where the conditional is false on initial renders. 