### PR TITLE
Youtube component bugfixes

### DIFF
--- a/packages/idyll-components/src/youtube.js
+++ b/packages/idyll-components/src/youtube.js
@@ -2,6 +2,7 @@ import React from 'react';
 let YouTube;
 
 const YT_PLAYING = 1;
+const YT_PAUSED = 2;
 
 class YoutubeComponent extends React.Component {
 
@@ -32,6 +33,7 @@ class YoutubeComponent extends React.Component {
 
     return (
       <YouTube
+        key={this.props.id}
         videoId={this.props.id}
         opts={opts}
         onReady={this._onReady.bind(this)}
@@ -39,12 +41,24 @@ class YoutubeComponent extends React.Component {
     );
   }
 
-  componentDidUpdate(props, newState) {
-    if (this._player && props.play !== this.props.play) {
-      this.props.play ? this._player.playVideo() : this._player.pauseVideo();
-    }
-    if (this._player && props.audio !== this.props.audio) {
-      this.props.audio ? this._player.unMute() : this._player.mute();
+  componentDidUpdate(prevProps, prevState) {
+    if (this._player && this.props.id !== prevProps.id) {
+      // // The video has changed
+      // this.props.audio ? this._player.unMute() : this._player.mute();
+      // if (this.props.play) {
+      //   console.log('playing video')
+      //   setTimeout(() => {
+      //     this._player.playVideo();
+      //   }, 1000)
+      // }
+    } else {
+      // Modify options to the same video
+      if (this._player && this.props.play !== prevProps.play) {
+        this.props.play ? this._player.playVideo() : this._player.pauseVideo();
+      }
+      if (this._player && this.props.audio !== prevProps.audio) {
+        this.props.audio ? this._player.unMute() : this._player.mute();
+      }
     }
   }
 
@@ -54,9 +68,9 @@ class YoutubeComponent extends React.Component {
       this._player.mute();
     }
     this._player.addEventListener('onStateChange', (event) => {
-      if (event.data === YT_PLAYING) {
+      if (event.data === YT_PLAYING && !this.props.play) {
         this.props.updateProps({ play: true })
-      } else {
+      } else if (event.data === YT_PAUSED && this.props.play) {
         this.props.updateProps({ play: false })
       }
     })

--- a/packages/idyll-docs/gallery/contents.js
+++ b/packages/idyll-docs/gallery/contents.js
@@ -4,6 +4,13 @@ const exampleGroups = [
     title: 'Explorable Explanations',
     examples: [
       {
+        label: "Beat Basics",
+        subtitle: "Explore 3/4 and 6/8 time using John Varney's rhythm wheel.",
+        href: 'https://megan-vo.github.io/basic-beats/',
+        image: 'beat-basics.png',
+        sourceUrl: "https://github.com/megan-vo/basic-beats"
+      },
+      {
         label: "How does the eye work?",
         href: 'https://idyll.pub/post/the-eye-5b169094cce3bece5d95e964/',
         image: 'the-eye.png'

--- a/packages/idyll-docs/pages/docs/syntax.js
+++ b/packages/idyll-docs/pages/docs/syntax.js
@@ -139,7 +139,7 @@ Use backticks to pass an evaluated expression:
 
 Note that because Idyll is reactive, if a variable changes, any expressions that reference that
 variable will immediately be recomputed. See this utilized to create reactive vega-lite specifications:
-https://idyll-lang.github.io/examples/csv/.
+https://idyll-lang.org/examples/csv/.
 
 If the property expects a function,
 the expression will automatically be


### PR DESCRIPTION
The current version of the YouTube component has bugs where the Idyll variable values would get out of sync with the Youtube player state and things this would lead to generally weird behavior when switching the video id. 

See the working updates here: https://idyll.pub/post/idyll-youtube-test-1df35e702b04b399fb49870c/