### PR TITLE
Give `displayType` key to some components

### DIFF
--- a/packages/idyll-components/src/action.js
+++ b/packages/idyll-components/src/action.js
@@ -13,6 +13,7 @@ class Action extends React.PureComponent {
 Action._idyll = {
   name: "Action",
   tagType: "open",
+  displayType: "inline",
   children: [
     "action text"
   ],

--- a/packages/idyll-components/src/display.js
+++ b/packages/idyll-components/src/display.js
@@ -35,6 +35,7 @@ class Display extends React.PureComponent {
 Display._idyll = {
   name: "Display",
   tagType: "closed",
+  displayType: "inline",
   props: [{
     name: "value",
     type: "number",

--- a/packages/idyll-components/src/dynamic.js
+++ b/packages/idyll-components/src/dynamic.js
@@ -45,6 +45,7 @@ Dynamic.defaultProps = {
 Dynamic._idyll = {
   name: "Dynamic",
   tagType: "closed",
+  displayType: "inline",
   props: [{
     name: "value",
     type: "number",

--- a/packages/idyll-components/src/link.js
+++ b/packages/idyll-components/src/link.js
@@ -21,6 +21,7 @@ class Link extends React.PureComponent {
 Link._idyll = {
   name: "Link",
   tagType: "closed",
+  displayType: "inline",
   props: [{
     name: "text",
     type: "string",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [*] The commit message follows our guidelines
- [*] Tests for the changes have been added (for bug fixes / features)
- [*] Docs have been added / updated (for bug fixes / features)


This PR gives the components `Action`, `Display`, `Dynamic`, and `Link` a 'displayType' key to their `_.idyll` metadata to signify that they are inline display elements.

What this does is that it'll help #410 be able to only give an overlay view for block components, and not inline components

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope
