### PR TITLE
Make -i input and -o output options relative to current working direc…

### DIFF
--- a/packages/idyll-cli/src/path-builder.js
+++ b/packages/idyll-cli/src/path-builder.js
@@ -9,39 +9,46 @@ const {
 
 const debug = require('debug')('idyll:cli')
 
-module.exports = function (opts) {
-  const basedir = opts.inputFile
-    ? isAbsolute(opts.inputFile)
-      ? dirname(opts.inputFile)
-      : dirname(join(process.cwd(), opts.inputFile))
+function getBaseDir(path) {
+  return path && isAbsolute(path)
+    ? dirname(path)
     : process.cwd();
+}
 
-  const getPath = (p) => {
-    if (!p) return undefined;
-    if (isAbsolute(p)) return p;
-    return join(basedir, p);
+function resolveWithBase(base) {
+  return (path) => {
+    if (!path || isAbsolute(path)) {
+      return path;
+    }
+    return join(base, path);
   }
+}
+
+module.exports = function (opts) {
+  const projectBaseDir = getBaseDir(opts.inputFile)
+  const resolveWithProjBase = resolveWithBase(projectBaseDir);
 
   const getComponentDirs = (paths) => {
-    if (paths instanceof Array) return paths.map(p => getPath(p));
-    return [getPath(paths)];
+    if (paths instanceof Array) return paths.map(p => resolveWithProjBase(p));
+    return [resolveWithProjBase(paths)];
   }
 
-  const OUTPUT_DIR = getPath(opts.output);
+  const resolveWithOutputBase = resolveWithBase(getBaseDir(opts.output));
+  const OUTPUT_DIR = resolveWithOutputBase(opts.output);
   const STATIC_OUTPUT_DIR = join(OUTPUT_DIR, 'static');
-  const TMP_DIR = getPath(opts.temp);
+  const TMP_DIR = resolveWithProjBase(opts.temp);
 
   return {
     APP_PATH: resolve(__dirname, '..'),
-    CSS_INPUT_FILE: getPath(opts.css),
-    DATA_DIR: getPath(opts.datasets),
-    STATIC_DIR: getPath(opts.static),
+    CSS_INPUT_FILE: resolveWithProjBase(opts.css),
+    DATA_DIR: resolveWithProjBase(opts.datasets),
+    STATIC_DIR: resolveWithProjBase(opts.static),
     COMPONENT_DIRS: getComponentDirs(opts.components),
     DEFAULT_COMPONENT_DIRS: getComponentDirs(opts.defaultComponents),
-    HTML_TEMPLATE_FILE: getPath(opts.template),
-    IDYLL_INPUT_FILE: getPath(opts.inputFile),
-    INPUT_DIR: basedir,
-    PACKAGE_FILE: getPath('package.json'),
+    HTML_TEMPLATE_FILE: resolveWithProjBase(opts.template),
+    IDYLL_INPUT_FILE: resolveWithProjBase(opts.inputFile),
+    INPUT_DIR: projectBaseDir,
+    PACKAGE_FILE: resolveWithProjBase('package.json'),
 
     OUTPUT_DIR,
     HTML_OUTPUT_FILE: join(OUTPUT_DIR, 'index.html'),

--- a/packages/idyll-cli/test/batteries-included/test.js
+++ b/packages/idyll-cli/test/batteries-included/test.js
@@ -48,6 +48,7 @@ let projectBuildResults;
 beforeAll(done => {
   idyll({
     inputFile: join(PROJECT_DIR, 'index.idl'),
+    output: PROJECT_BUILD_DIR,
     compiler: {
       spellcheck: false
     },

--- a/packages/idyll-cli/test/path-builder/test.js
+++ b/packages/idyll-cli/test/path-builder/test.js
@@ -1,0 +1,119 @@
+const {
+  dirname,
+  join,
+} = require('path');
+const pathBuilder = require('../../src/path-builder');
+
+function opts(inputPath, outputPath) {
+  const overrideOpts = {};
+  if (inputPath) {
+    overrideOpts['i'] = inputPath;
+    overrideOpts['inputFile'] = inputPath;
+  }
+  if (outputPath) {
+    overrideOpts['o'] = outputPath;
+    overrideOpts['output'] = outputPath;
+  }
+  return {
+    alias: {},
+    watch: true,
+    open: true,
+    datasets: 'data',
+    minify: false,
+    ssr: true,
+    components: [ 'components' ],
+    static: 'static',
+    defaultComponents: '',
+    layout: 'blog',
+    theme: 'github',
+    output: 'build',
+    outputCSS: 'idyll_styles.css',
+    outputJS: 'idyll_index.js',
+    port: 3000,
+    temp: '.idyll',
+    template: '',
+    transform: [],
+    compiler: {},
+    help: false,
+    h: false,
+    version: false,
+    m: [ 'components' ],
+    css: 'styles.css',
+    c: 'styles.css',
+    d: 'data',
+    'input-file': 'index.idyll',
+    i: 'index.idyll',
+    inputFile: 'index.idyll',
+    l: 'blog',
+    o: 'build',
+    googleFonts: [],
+    g: [],
+    e: 'github',
+    ...overrideOpts,
+  }
+}
+
+describe('path builder with input and output args', () => {
+  it('should use absolute -i (input path) args directly', () => {
+    const inputPath = join('/', 'absolute', 'nested', 'index.idyll');
+    const pathOpts = opts(inputPath)
+    const paths = pathBuilder(pathOpts);
+    const expectedInputPath = inputPath;
+    const expectedOutputDir = join(process.cwd(), 'build');
+    expect(paths.IDYLL_INPUT_FILE).toBe(expectedInputPath);
+    expect(paths.OUTPUT_DIR).toBe(expectedOutputDir);
+  });
+
+  it('should use absolute -o (output path) arg directly', () => {
+    const outputDir = join('/', 'nested', 'build');
+    const pathOpts = opts(null, outputDir)
+    const paths = pathBuilder(pathOpts);
+    const expectedInputPath = join(process.cwd(), pathOpts.inputFile);
+    const expectedOutputDir = outputDir;
+    expect(paths.IDYLL_INPUT_FILE).toBe(expectedInputPath);
+    expect(paths.OUTPUT_DIR).toBe(expectedOutputDir);
+  });
+
+  it('should use absolute -i and -o (input and output path) args directly', () => {
+    const inputPath = join('/', 'absolute', 'nested', 'index.idyll');
+    const outputDir = join('/', 'outputs', 'nested', 'build');
+    const pathOpts = opts(inputPath, outputDir)
+    const paths = pathBuilder(pathOpts);
+    const expectedInputPath = inputPath;
+    const expectedOutputDir = outputDir;
+    expect(paths.IDYLL_INPUT_FILE).toBe(expectedInputPath);
+    expect(paths.OUTPUT_DIR).toBe(expectedOutputDir);
+  });
+
+  it('should resolve relative -i (input path) arg', () => {
+    const inputPath = join('nested', 'index.idyll');
+    const pathOpts = opts(inputPath)
+    const paths = pathBuilder(pathOpts);
+    const expectedInputPath = join(process.cwd(), inputPath);
+    const expectedOutputDir = join(process.cwd(), 'build');
+    expect(paths.IDYLL_INPUT_FILE).toBe(expectedInputPath);
+    expect(paths.OUTPUT_DIR).toBe(expectedOutputDir);
+  });
+
+  it('should resolve relative -o (output path) arg', () => {
+    const outputPath = join('nested', 'v1', 'build');
+    const pathOpts = opts(null, outputPath)
+    const paths = pathBuilder(pathOpts);
+    const expectedInputPath = join(process.cwd(), pathOpts.inputFile);
+    const expectedOutputDir = join(process.cwd(), outputPath);
+    expect(paths.IDYLL_INPUT_FILE).toBe(expectedInputPath);
+    expect(paths.OUTPUT_DIR).toBe(expectedOutputDir);
+  });
+
+  it('should resolve relative -i and -o (input and output path) args', () => {
+    const inputPath = join('nested', 'index.idyll');
+    const outputPath = join('build');
+    const pathOpts = opts(inputPath, outputPath)
+    const paths = pathBuilder(pathOpts);
+    const expectedInputPath = join(process.cwd(), inputPath);
+    const expectedOutputDir = join(process.cwd(), outputPath);
+    expect(paths.IDYLL_INPUT_FILE).toBe(expectedInputPath);
+    expect(paths.OUTPUT_DIR).toBe(expectedOutputDir);
+  });
+
+});


### PR DESCRIPTION
Make -i input and -o output options relative to current working directory

If -i or -o option is not an absolute path, resolve full path using cwd

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix. 

* **What is the current behavior?** (You can also link to an open issue here)
Fixes #417 

* **What is the new behavior (if this is a feature change)?**
If -i and -o options are not absolute paths, they are resolved using current working directory from which idyll cmd was run.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
This could be a breaking change for users that have some type of automated workflow that depended on the old behavior. Probably unlikely. 