### PR TITLE
add missing units to styles

### DIFF
--- a/packages/idyll-layouts/src/blog/styles.js
+++ b/packages/idyll-layouts/src/blog/styles.js
@@ -14,7 +14,7 @@ body {
 }
 
 .idyll-text-container {
-  max-width: 600;
+  max-width: 600px;
   margin-top: 0;
   margin-right: 0;
   margin-bottom: 0;


### PR DESCRIPTION
Small bugfix to address an issue introduced when converting text-container styles over to CSS.