### PR TITLE
fix some issues around context initialization

### DIFF
--- a/packages/idyll-cli/src/pipeline/parse.js
+++ b/packages/idyll-cli/src/pipeline/parse.js
@@ -153,11 +153,14 @@ exports.getHTML = (paths, ast, _components, datasets, template, opts) => {
   const React = require('react');
   const IdyllDocument = require('idyll-document').default;
   const meta = parseMeta(ast);
+  const context = require(opts.context ? opts.context : __dirname + '/../client/context');
+
   meta.idyllContent = ReactDOMServer.renderToString(
     React.createElement(IdyllDocument, {
       ast: ast,
       components,
       datasets,
+      context,
       theme: opts.theme,
       layout: opts.layout,
       authorView: opts.authorView


### PR DESCRIPTION
This updates the context initialization logic in the runtime so that custom contexts are injected properly before variable initializations. This makes it possible for users to initialize vars according to custom functions, and closes #326.