### PR TITLE
give command line flags priority over options in package.json

### DIFF
--- a/packages/idyll-cli/bin/cmds/build.js
+++ b/packages/idyll-cli/bin/cmds/build.js
@@ -14,9 +14,6 @@ exports.builder = (yargs) => {
     .example('$0 build -i index.idyll', 'Turn a .idl file or project into output');
 }
 
-
-
-
 exports.handler = (argv) => {
   // API checks the inverse
   argv.minify = !argv['no-minify'];
@@ -25,23 +22,44 @@ exports.handler = (argv) => {
   // delete stuff we don't need
   delete argv._;
   delete argv['$0'];
-  delete argv.n;
   delete argv.noMinify;
   delete argv['no-minify'];
-  delete argv.k;
-  delete argv.r;
   delete argv.noSsr;
   delete argv['no-ssr'];
+
+  ['a', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'l', 'm', 'n', 'o', 'q', 'r', 's', 't'].forEach(key => {
+    delete argv[key]
+  });
 
   // delete undefined keys so Object.assign won't use them
   Object.keys(argv).forEach((key) => {
     if (argv[key] === undefined) delete argv[key];
   })
 
-  const paths = pathBuilder(argv);
+  const defaults = {
+    'components': ['components'],
+    'static': 'static',
+    'css': 'styles.css',
+    'datasets': 'data',
+    'inputFile': 'index.idyll',
+    'layout': 'blog',
+    'output': 'build',
+    'transform': [],
+    'googleFonts': [],
+    'outputJS': 'idyll_index.js',
+    'outputCSS': 'idyll_styles.css'
+  }
+
+  const paths = pathBuilder(Object.assign({}, defaults, argv));
   const inputPackage = fs.existsSync(paths.PACKAGE_FILE) ? require(paths.PACKAGE_FILE) : {};
 
-  argv = Object.assign({}, argv, inputPackage.idyll);
+  argv = Object.assign({}, inputPackage.idyll, argv);
+
+  Object.keys(defaults).forEach(key => {
+    if (argv[key] === undefined) {
+      argv[key] = defaults[key];
+    }
+  })
 
   debug('Building with CLI arguments:', argv);
   console.log(`\n${chalk.green('Building Idyll project with output directory:')} ${chalk.hex('#6122fb')(argv['output'])}\n`);
@@ -73,42 +91,30 @@ function buildOptions (yargs) {
       f: 'favicon'
     })
     .describe('components', 'Directory where components are located')
-    .default('components', 'components')
     .array('components')
     .describe('static', 'Directory where static assets are located')
-    .default('static', 'static')
     .describe('css', 'Custom CSS file to include in output')
-    .default('css', 'styles.css')
     .describe('datasets', 'Directory where data files are located')
-    .default('datasets', 'data')
     .describe('default-components', 'Directory where default set of components are located')
     .array('default-components')
     .describe('input-file', 'File containing Idyll source')
-    .default('input-file', 'index.idyll')
     .describe('input-string', 'Idyll source as a string')
     .describe('layout', 'Name of (or path to) the layout to use')
-    .default('layout', 'blog')
     .boolean('no-minify')
     .describe('no-minify', 'Skip JS minification')
     .describe('output', 'Directory where built files should be written')
-    .default('output', 'build')
     .boolean('no-ssr')
     .describe('no-ssr', 'Do not pre-render HTML as part of the build')
     .describe('template', 'Path to HTML template')
     .array('transform')
     .describe('transform', 'Custom browserify transforms to apply.')
-    .default('transform', [])
     .array('googleFonts')
     .describe('googleFonts', 'List of google fonts to include.')
-    .default('googleFonts', [])
     .describe('favicon', 'A .ico file to use as article favicon. This should be in the static folder, e.g. "static/favicon.ico"')
     .describe('theme', 'Name of (or path to) the theme to use')
-    .default('theme', 'github')
     .describe('alias', 'A list of component aliases')
     .describe('outputCSS', 'Name of CSS file to generate')
-    .default('outputCSS', 'idyll_styles.css')
     .describe('outputJS', 'Name of JS file to generate')
-    .default('outputJS', 'idyll_index.js')
     .alias('h', 'help')
 }
 


### PR DESCRIPTION
Fixes #426 

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This fixes a bug where options set via the command line were being overridden by options set in package.json. This change gives priorities to those options set specifically via command line flag.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
