### PR TITLE
Derived variable references

### DIFF
--- a/packages/idyll-docs/contents.js
+++ b/packages/idyll-docs/contents.js
@@ -2,28 +2,34 @@ const Contents = [
   {
     title: 'Overview',
     pages: [
-      {title: 'Introduction', route: '/docs' },
-      {title: 'Getting started', route: '/docs/getting-started' },
-      {title: 'Markup Syntax', route: '/docs/syntax' },
-      {title: 'Build Options', route: '/docs/configuration-and-styles' },
-      {title: 'Advanced Configuration', route: '/docs/advanced-configuration' }
-    ],
+      { title: 'Introduction', route: '/docs' },
+      { title: 'Getting started', route: '/docs/getting-started' },
+      { title: 'Markup syntax', route: '/docs/syntax' },
+      { title: 'Options and styles', route: '/docs/configuration-and-styles' },
+      { title: 'Advanced configuration', route: '/docs/advanced-configuration' }
+    ]
   },
   {
     title: 'Interactivity',
     pages: [
-      {title: 'Built-in components', route: '/docs/components' },
-      {title: 'Using components from npm', route: '/docs/components/npm' },
-      {title: 'Make your own component', route: '/docs/components/custom' },
-      {title: 'Scrolling and Refs', route: '/docs/components/scrolling-and-refs' }
-    ],
+      { title: 'Built-in components', route: '/docs/components' },
+      { title: 'Using components from npm', route: '/docs/components/npm' },
+      { title: 'Make your own component', route: '/docs/components/custom' },
+      {
+        title: 'Scrolling and Refs',
+        route: '/docs/components/scrolling-and-refs'
+      }
+    ]
   },
   {
     title: 'Publishing',
     pages: [
-      { title: 'Deploying to the web', route: '/docs/publishing/deploying-to-the-web' },
+      {
+        title: 'Deploying to the web',
+        route: '/docs/publishing/deploying-to-the-web'
+      },
       { title: 'Embedding Idyll', route: '/docs/publishing/embedding' }
-    ],
+    ]
   },
   {
     title: 'Useful Links',
@@ -32,10 +38,10 @@ const Contents = [
       { title: 'Chat', route: 'https://gitter.im/idyll-lang/Lobby' },
       { title: 'Twitter', route: 'https://twitter.com/idyll_lang' },
       { title: 'Support Us', route: 'https://opencollective.com/idyll' }
-    ],
-  },
-]
+    ]
+  }
+];
 
 module.exports = {
   Contents
-}
+};

--- a/packages/idyll-document/src/runtime.js
+++ b/packages/idyll-document/src/runtime.js
@@ -6,7 +6,7 @@ import ReactJsonSchema from './utils/schema2element';
 import entries from 'object.entries';
 import values from 'object.values';
 import { generatePlaceholder } from './components/placeholder';
-import AuthorTool from './components/author-tool'
+import AuthorTool from './components/author-tool';
 
 import * as layouts from 'idyll-layouts';
 import * as themes from 'idyll-themes';
@@ -33,13 +33,13 @@ const refCache = {};
 const evalContext = {};
 let scrollContainer;
 
-const getLayout = (layout) => {
+const getLayout = layout => {
   return layouts[layout.trim()] || {};
-}
+};
 
-const getTheme = (theme) => {
+const getTheme = theme => {
   return themes[theme.trim()] || {};
-}
+};
 
 const getRefs = () => {
   const refs = {};
@@ -49,7 +49,14 @@ const getRefs = () => {
 
   scrollWatchers.forEach(watcher => {
     // left and right props assume no horizontal scrolling
-    const { watchItem, callbacks, container, recalculateLocation, offsets, ...watcherProps } = watcher;
+    const {
+      watchItem,
+      callbacks,
+      container,
+      recalculateLocation,
+      offsets,
+      ...watcherProps
+    } = watcher;
     refs[watchItem.dataset.ref] = {
       ...watcherProps,
       domNode: watchItem
@@ -116,7 +123,12 @@ const createWrapper = ({ theme, layout, authorView }) => {
       });
       // re-run this component's expressions using the latest doc state
       Object.keys(__expr__).forEach(key => {
-        nextState[key] = evalExpression(newState, __expr__[key], key, evalContext);
+        nextState[key] = evalExpression(
+          newState,
+          __expr__[key],
+          key,
+          evalContext
+        );
       });
       // trigger a re-render of this component
       // and more importantly, its wrapped component
@@ -128,13 +140,12 @@ const createWrapper = ({ theme, layout, authorView }) => {
 
       if (this.usesRefs) {
         const nextState = { refs: newState.refs };
-        entries(__expr__)
-          .forEach(([key, val]) => {
-            if (!key.includes('refs.')) {
-              return;
-            }
-            nextState[key] = evalExpression(newState, val, key, evalContext);
-          });
+        entries(__expr__).forEach(([key, val]) => {
+          if (!key.includes('refs.')) {
+            return;
+          }
+          nextState[key] = evalExpression(newState, val, key, evalContext);
+        });
 
         // trigger a render with latest state
         this.setState(nextState);
@@ -159,7 +170,10 @@ const createWrapper = ({ theme, layout, authorView }) => {
       }
 
       const state = filterIdyllProps(this.state, this.props.isHTMLNode);
-      const { children, ...passThruProps } = filterIdyllProps(this.props, this.props.isHTMLNode);
+      const { children, ...passThruProps } = filterIdyllProps(
+        this.props,
+        this.props.isHTMLNode
+      );
       let childComponent = null;
       let uniqueKey = `${this.key}-help`;
       const returnComponent = React.Children.map(children, (c, i) => {
@@ -172,13 +186,16 @@ const createWrapper = ({ theme, layout, authorView }) => {
             authorView: authorView
           },
           ...state,
-          ...passThruProps,
-        })
+          ...passThruProps
+        });
       });
       const metaData = childComponent.type._idyll;
       if (authorView && metaData && metaData.props) {
         // ensure inline elements do not have this overlay
-        if (metaData.displayType === undefined || metaData.displayType !== "inline") {
+        if (
+          metaData.displayType === undefined ||
+          metaData.displayType !== 'inline'
+        ) {
           return (
             <AuthorTool
               component={returnComponent}
@@ -190,12 +207,12 @@ const createWrapper = ({ theme, layout, authorView }) => {
       }
       return returnComponent;
     }
-  }
+  };
 };
 
 const getDerivedValues = dVars => {
   const o = {};
-  Object.keys(dVars).forEach(key => o[key] = dVars[key].value);
+  Object.keys(dVars).forEach(key => (o[key] = dVars[key].value));
   return o;
 };
 
@@ -208,70 +225,70 @@ class IdyllRuntime extends React.PureComponent {
 
     const ast = filterASTForDocument(props.ast);
 
-    const {
-      vars,
-      derived,
-      data,
-      elements,
-    } = splitAST(ast);
-    const Wrapper = createWrapper({ theme: props.theme, layout: props.layout, authorView: props.authorView });
+    const { vars, derived, data, elements } = splitAST(ast);
+    const Wrapper = createWrapper({
+      theme: props.theme,
+      layout: props.layout,
+      authorView: props.authorView
+    });
 
     let hasInitialized = false;
     let initialContext = {};
     // Initialize a custom context
     if (typeof props.context === 'function') {
       props.context({
-        update: (newState) => {
+        update: newState => {
           if (!hasInitialized) {
             initialContext = Object.assign(initialContext, newState);
           } else {
-            this.updateState(newState)
+            this.updateState(newState);
           }
         },
         data: () => {
-          return this.state
+          return this.state;
         },
-        onInitialize: (cb) => {
+        onInitialize: cb => {
           this._onInitializeState = cb;
         },
-        onUpdate: (cb) => {
+        onUpdate: cb => {
           this._onUpdateState = cb;
         }
       });
     }
 
+    const initialState = Object.assign(
+      {},
+      {
+        ...getVars(vars, initialContext),
+        ...getData(data, props.datasets)
+      },
+      initialContext,
+      props.initialState ? props.initialState : {}
+    );
+    const derivedVars = (this.derivedVars = getVars(derived, initialState));
 
-    const initialState = Object.assign({}, {
-      ...getVars(vars, initialContext),
-      ...getData(data, props.datasets),
-    }, initialContext, props.initialState ? props.initialState : {});
-    const derivedVars = this.derivedVars = getVars(derived, initialState);
-
-    let state = this.state = {
+    let state = (this.state = {
       ...initialState,
-      ...getDerivedValues(derivedVars),
-    };
+      ...getDerivedValues(derivedVars)
+    });
 
-    this.updateState = (newState) => {
+    this.updateState = newState => {
       // merge new doc state with old
       const newMergedState = { ...this.state, ...newState };
       // update derived values
       const newDerivedValues = getDerivedValues(
-        getVars(derived, newMergedState),
+        getVars(derived, newMergedState)
       );
       const nextState = { ...newMergedState, ...newDerivedValues };
 
       const changedMap = {};
-      const changedKeys = Object.keys(state).reduce(
-        (acc, k) => {
-          if (state[k] !== nextState[k]) {
-            acc.push(k);
-            changedMap[k] = nextState[k] || state[k];
-          }
-          return acc;
-        },
-        []
-      )
+      const changedKeys = Object.keys(state).reduce((acc, k) => {
+        if (state[k] !== nextState[k]) {
+          acc.push(k);
+          changedMap[k] = nextState[k] || state[k];
+        }
+        return acc;
+      }, []);
 
       // Update doc state reference.
       // We re-use the same object here so that
@@ -280,7 +297,9 @@ class IdyllRuntime extends React.PureComponent {
       // pass the new doc state to all listeners aka component wrappers
       updatePropsCallbacks.forEach(f => f(state, changedKeys));
 
-      changedKeys.length && this._onUpdateState && this._onUpdateState(changedMap);
+      changedKeys.length &&
+        this._onUpdateState &&
+        this._onUpdateState(changedMap);
     };
 
     evalContext.update = this.updateState;
@@ -297,15 +316,21 @@ class IdyllRuntime extends React.PureComponent {
     // Components that the Document needs to function properly
     const internalComponents = {
       Wrapper
-    }
+    };
 
-    Object.keys(internalComponents).forEach((key) => {
+    Object.keys(internalComponents).forEach(key => {
       if (props.components[key]) {
-        console.warn(`Warning! You are including a component named ${key}, but this is a reserved Idyll component. Please rename your component.`);
+        console.warn(
+          `Warning! You are including a component named ${key}, but this is a reserved Idyll component. Please rename your component.`
+        );
       }
-    })
+    });
 
-    const components = Object.assign(fallbackComponents, props.components, internalComponents);
+    const components = Object.assign(
+      fallbackComponents,
+      props.components,
+      internalComponents
+    );
 
     const rjs = new ReactJsonSchema(components);
     const schema = translate(ast);
@@ -314,78 +339,73 @@ class IdyllRuntime extends React.PureComponent {
 
     let refCounter = 0;
 
-    const transformedSchema = mapTree(
-      schema,
-      node => {
-        if (typeof node === 'string') return node;
+    const transformedSchema = mapTree(schema, node => {
+      if (typeof node === 'string') return node;
 
-        // transform refs from strings to functions and store them
-        if (node.ref || node.hasHook) {
-          node.refName = node.ref || node.component + (refCounter++).toString();
-          node.ref = el => {
-            if (!el) return;
-            const domNode = ReactDOM.findDOMNode(el);
-            domNode.dataset.ref = node.refName;
-            scrollOffsets[node.refName] = node.scrollOffset || 0;
-            refCache[node.refName] = {
-              props: node,
-              domNode: domNode
-            };
+      // transform refs from strings to functions and store them
+      if (node.ref || node.hasHook) {
+        node.refName = node.ref || node.component + (refCounter++).toString();
+        node.ref = el => {
+          if (!el) return;
+          const domNode = ReactDOM.findDOMNode(el);
+          domNode.dataset.ref = node.refName;
+          scrollOffsets[node.refName] = node.scrollOffset || 0;
+          refCache[node.refName] = {
+            props: node,
+            domNode: domNode
           };
-        }
-
-        if (!wrapTargets.includes(node)) return node;
-
-        const {
-          component,
-          children,
-          key,
-          __vars__ = {},
-          __expr__ = {},
-          ...props // actual component props
-        } = node;
-
-        // assign the initial values for tracked vars and expressions
-        Object.keys(props).forEach(k => {
-          if (__vars__[k]) {
-            node[k] = state[__vars__[k]];
-          }
-          if (__expr__[k] && !__expr__[k].includes('refs.')) {
-            if (hooks.indexOf(k) > -1) {
-              return;
-            }
-            node[k] = evalExpression(state, __expr__[k], k, evalContext);
-          }
-        });
-
-        const resolvedComponent = rjs.resolveComponent(node);
-        const isHTMLNode = typeof resolvedComponent === 'string';
-
-        return {
-          component: Wrapper,
-          __vars__,
-          __expr__,
-          isHTMLNode: isHTMLNode,
-          hasHook: node.hasHook,
-          refName: node.refName,
-          updateProps: (newProps) => {
-            // init new doc state object
-            const newState = {};
-            // iterate over passed in updates
-            Object.keys(newProps).forEach(k => {
-              // if a tracked var was updated get its new value
-              if (__vars__[k]) {
-                newState[__vars__[k]] = newProps[k];
-              }
-            });
-            this.updateState(newState);
-          },
-          children: [
-            filterIdyllProps(node, isHTMLNode)
-          ],
         };
       }
-    );
+
+      if (!wrapTargets.includes(node)) return node;
+
+      const {
+        component,
+        children,
+        key,
+        __vars__ = {},
+        __expr__ = {},
+        ...props // actual component props
+      } = node;
+
+      // assign the initial values for tracked vars and expressions
+      Object.keys(props).forEach(k => {
+        if (__vars__[k]) {
+          node[k] = state[__vars__[k]];
+        }
+        if (__expr__[k] && !__expr__[k].includes('refs.')) {
+          if (hooks.indexOf(k) > -1) {
+            return;
+          }
+          node[k] = evalExpression(state, __expr__[k], k, evalContext);
+        }
+      });
+
+      const resolvedComponent = rjs.resolveComponent(node);
+      const isHTMLNode = typeof resolvedComponent === 'string';
+
+      return {
+        component: Wrapper,
+        __vars__,
+        __expr__,
+        isHTMLNode: isHTMLNode,
+        hasHook: node.hasHook,
+        refName: node.refName,
+        updateProps: newProps => {
+          // init new doc state object
+          const newState = {};
+          // iterate over passed in updates
+          Object.keys(newProps).forEach(k => {
+            // if a tracked var was updated get its new value
+            if (__vars__[k]) {
+              newState[__vars__[k]] = newProps[k];
+            }
+          });
+          this.updateState(newState);
+        },
+        children: [filterIdyllProps(node, isHTMLNode)]
+      };
+    });
 
     this.kids = rjs.parseSchema(transformedSchema);
   }
@@ -400,33 +420,40 @@ class IdyllRuntime extends React.PureComponent {
 
     let scroller = scrollparent(el);
     let scrollContainer;
-    if (scroller === document.documentElement || scroller === document.body || scroller === window) {
+    if (
+      scroller === document.documentElement ||
+      scroller === document.body ||
+      scroller === window
+    ) {
       scroller = window;
       scrollContainer = scrollMonitor;
     } else {
       scrollContainer = scrollMonitor.createContainer(scroller);
     }
-    Object.keys(refCache).forEach((key) => {
+    Object.keys(refCache).forEach(key => {
       const { props, domNode } = refCache[key];
       const watcher = scrollContainer.create(domNode, scrollOffsets[key]);
-      hooks.forEach((hook) => {
+      hooks.forEach(hook => {
         if (props[hook]) {
           watcher[scrollMonitorEvents[hook]](() => {
             evalExpression(this.state, props[hook], hook, evalContext)();
           });
         }
-      })
+      });
       scrollWatchers.push(watcher);
     });
     scroller.addEventListener('scroll', this.scrollListener);
   }
 
   updateDerivedVars(newState) {
+    const context = {};
     Object.keys(this.derivedVars).forEach(dv => {
       this.derivedVars[dv].value = this.derivedVars[dv].update(
         newState,
         this.state,
+        context
       );
+      context[dv] = this.derivedVars[dv].value;
     });
   }
 
@@ -448,7 +475,7 @@ class IdyllRuntime extends React.PureComponent {
       <div className="idyll-root" ref={this.initScrollListener}>
         {this.kids}
       </div>
-    )
+    );
   }
 }
 

--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -102,9 +102,9 @@ export const getVars = (arr, context = {}, evalContext) => {
               Object.assign({}, context, formatAccumulatedValues(acc)),
               expr
             ),
-            update: (newState, oldState) => {
+            update: (newState, oldState, context = {}) => {
               return evalExpression(
-                Object.assign({}, oldState, newState),
+                Object.assign({}, oldState, newState, context),
                 expr
               );
             }

--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -16,51 +16,56 @@ export const buildExpression = (acc, expr, key, context, isEventHandler) => {
             return true;
           }
         })
-        ${falafel(isEventHandler ? expr : `var __idyllReturnValue = ${expr || 'undefined'}`, (node) => {
-          switch(node.type) {
-            case 'Identifier':
-              if (Object.keys(acc).indexOf(node.name) > -1) {
-                node.update('__idyllStateProxy.' + node.source());
-              }
-              break;
+        ${falafel(
+          isEventHandler
+            ? expr
+            : `var __idyllReturnValue = ${expr || 'undefined'}`,
+          node => {
+            switch (node.type) {
+              case 'Identifier':
+                if (Object.keys(acc).indexOf(node.name) > -1) {
+                  node.update('__idyllStateProxy.' + node.source());
+                }
+                break;
+            }
           }
-        })};
+        )};
         ${isEventHandler ? '' : 'return __idyllReturnValue;'}
     })(this)
   `;
-}
-
+};
 
 export const evalExpression = (acc, expr, key, context) => {
-  const isEventHandler = (key && (key.match(/^on[A-Z].*/) || key.match(/^handle[A-Z].*/)));
+  const isEventHandler =
+    key && (key.match(/^on[A-Z].*/) || key.match(/^handle[A-Z].*/));
   let e = buildExpression(acc, expr, key, context, isEventHandler);
 
   if (isEventHandler) {
-    return (function() {
+    return function() {
       eval(e);
-    }).bind(Object.assign({}, acc, context || {}));
+    }.bind(Object.assign({}, acc, context || {}));
   }
 
   try {
-    return (function(evalString){
+    return function(evalString) {
       try {
         return eval('(' + evalString + ')');
-      } catch(err) {}
-    }).call(Object.assign({}, acc, context || {}), e);
+      } catch (err) {}
+    }.call(Object.assign({}, acc, context || {}), e);
   } catch (err) {}
-}
+};
 
 export const getVars = (arr, context = {}, evalContext) => {
   const pluck = (acc, val) => {
-    const [ variableType, attrs = [], ] = val;
+    const [variableType, attrs = []] = val;
 
     const [nameArr, valueArr] = attrs;
     if (!nameArr || !valueArr) return acc;
 
-    const [, [, nameValue]] = nameArr
+    const [, [, nameValue]] = nameArr;
     const [, [valueType, valueValue]] = valueArr;
 
-    switch(valueType) {
+    switch (valueType) {
       case 'value':
         acc[nameValue] = valueValue;
         break;
@@ -74,25 +79,28 @@ export const getVars = (arr, context = {}, evalContext) => {
       case 'expression':
         const expr = valueValue;
         if (variableType === 'var') {
-          acc[nameValue] = evalExpression(context, expr);
+          acc[nameValue] = evalExpression(
+            Object.assign({}, context, acc),
+            expr
+          );
         } else {
           acc[nameValue] = {
-            value: evalExpression(context, expr),
+            value: evalExpression(Object.assign({}, context, acc), expr),
             update: (newState, oldState) => {
-              return evalExpression(Object.assign({}, oldState, newState), expr)
+              return evalExpression(
+                Object.assign({}, oldState, newState),
+                expr
+              );
             }
-          }
+          };
         }
     }
 
     return acc;
-  }
+  };
 
-  return arr.reduce(
-    pluck,
-    {}
-  )
-}
+  return arr.reduce(pluck, {});
+};
 
 export const filterIdyllProps = (props, filterInjected) => {
   const {
@@ -108,41 +116,38 @@ export const filterIdyllProps = (props, filterInjected) => {
     ...rest
   } = props;
   if (filterInjected) {
-    const { idyll, hasError, updateProps, ...ret} = rest;
+    const { idyll, hasError, updateProps, ...ret } = rest;
     return ret;
   }
   return rest;
-}
+};
 
 export const getData = (arr, datasets = {}) => {
   const pluck = (acc, val) => {
-    const [ , attrs, ] = val
-    const [nameArr, ] = attrs;
+    const [, attrs] = val;
+    const [nameArr] = attrs;
 
-    const [, [, nameValue]] = nameArr
+    const [, [, nameValue]] = nameArr;
 
     acc[nameValue] = datasets[nameValue];
 
     return acc;
-  }
+  };
 
-  return arr.reduce(
-    pluck,
-    {}
-  )
-}
+  return arr.reduce(pluck, {});
+};
 
-export const splitAST = (ast) => {
+export const splitAST = ast => {
   const state = {
     vars: [],
     derived: [],
     data: [],
-    elements: [],
-  }
+    elements: []
+  };
 
-  const handleNode = (storeElements) => {
-    return (node) => {
-      const [ name, props, children ] = node;
+  const handleNode = storeElements => {
+    return node => {
+      const [name, props, children] = node;
       if (name === 'var') {
         state.vars.push(node);
       } else if (state[name]) {
@@ -154,12 +159,12 @@ export const splitAST = (ast) => {
         return;
       }
       children.forEach(handleNode(false));
-    }
-  }
+    };
+  };
 
   ast.forEach(handleNode(true));
   return state;
-}
+};
 
 export const hooks = [
   'onEnterView',
@@ -169,53 +174,50 @@ export const hooks = [
 ];
 
 export const scrollMonitorEvents = {
-  'onEnterView': 'enterViewport',
-  'onEnterViewFully': 'fullyEnterViewport',
-  'onExitView': 'partiallyExitViewport',
-  'onExitViewFully': 'exitViewport'
-}
+  onEnterView: 'enterViewport',
+  onEnterViewFully: 'fullyEnterViewport',
+  onExitView: 'partiallyExitViewport',
+  onExitViewFully: 'exitViewport'
+};
 
-export const translate = (arr) => {
-  const attrConvert = (list) => {
-    return list.reduce(
-      (acc, [name, [type, val]]) => {
-        if (type === 'variable') {
-          acc.__vars__ = acc.__vars__ || {};
-          acc.__vars__[name] = val;
-        }
-        // each node keeps a list of props that are expressions
-        if (type === 'expression') {
-          acc.__expr__ = acc.__expr__ || {};
-          acc.__expr__[name] = val;
-        }
-        // flag nodes that define a hook function
-        if (hooks.includes(name)) {
-          acc.hasHook = true;
-        };
+export const translate = arr => {
+  const attrConvert = list => {
+    return list.reduce((acc, [name, [type, val]]) => {
+      if (type === 'variable') {
+        acc.__vars__ = acc.__vars__ || {};
+        acc.__vars__[name] = val;
+      }
+      // each node keeps a list of props that are expressions
+      if (type === 'expression') {
+        acc.__expr__ = acc.__expr__ || {};
+        acc.__expr__[name] = val;
+      }
+      // flag nodes that define a hook function
+      if (hooks.includes(name)) {
+        acc.hasHook = true;
+      }
 
-        acc[name] = val;
-        return acc;
-      },
-      {}
-    )
-  }
+      acc[name] = val;
+      return acc;
+    }, {});
+  };
 
-  const tNode = (node) => {
+  const tNode = node => {
     if (typeof node === 'string') return node;
 
     if (node.length === 3) {
-      const [ name, attrs, children ] = node;
+      const [name, attrs, children] = node;
 
       return {
         component: name,
         ...attrConvert(attrs),
-        children: children.map(tNode),
-      }
+        children: children.map(tNode)
+      };
     }
-  }
+  };
 
-  return splitAST(arr).elements.map(tNode)
-}
+  return splitAST(arr).elements.map(tNode);
+};
 
 export const mapTree = (tree, mapFn, filterFn = () => true) => {
   const walkFn = (acc, node) => {
@@ -233,14 +235,11 @@ export const mapTree = (tree, mapFn, filterFn = () => true) => {
     return acc;
   };
 
-  return tree.reduce(
-    walkFn,
-    []
-  );
+  return tree.reduce(walkFn, []);
 };
 
-export const filterASTForDocument = (ast) => {
-  return mapTree(ast, n => n, ([name]) => name !== 'meta')
+export const filterASTForDocument = ast => {
+  return mapTree(ast, n => n, ([name]) => name !== 'meta');
 };
 
 export const findWrapTargets = (schema, state) => {
@@ -250,7 +249,7 @@ export const findWrapTargets = (schema, state) => {
   // always return node so we can walk the whole tree
   // but collect and ultimately return just the nodes
   // we are interested in wrapping
-  mapTree(schema, (node) => {
+  mapTree(schema, node => {
     if (typeof node === 'string') return node;
 
     if (node.hasHook) {
@@ -282,7 +281,7 @@ export const findWrapTargets = (schema, state) => {
     });
 
     return node;
-  })
+  });
 
   return targets;
-}
+};

--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -56,6 +56,19 @@ export const evalExpression = (acc, expr, key, context) => {
 };
 
 export const getVars = (arr, context = {}, evalContext) => {
+  const formatAccumulatedValues = acc => {
+    const ret = {};
+    Object.keys(acc).forEach(key => {
+      const accVal = acc[key];
+      if (accVal.update && accVal.value) {
+        ret[key] = accVal.value;
+      } else {
+        ret[key] = accVal;
+      }
+    });
+    return ret;
+  };
+
   const pluck = (acc, val) => {
     const [variableType, attrs = []] = val;
 
@@ -80,12 +93,15 @@ export const getVars = (arr, context = {}, evalContext) => {
         const expr = valueValue;
         if (variableType === 'var') {
           acc[nameValue] = evalExpression(
-            Object.assign({}, context, acc),
+            Object.assign({}, context, formatAccumulatedValues(acc)),
             expr
           );
         } else {
           acc[nameValue] = {
-            value: evalExpression(Object.assign({}, context, acc), expr),
+            value: evalExpression(
+              Object.assign({}, context, formatAccumulatedValues(acc)),
+              expr
+            ),
             update: (newState, oldState) => {
               return evalExpression(
                 Object.assign({}, oldState, newState),

--- a/packages/idyll-document/test/__snapshots__/schema2element.js.snap
+++ b/packages/idyll-document/test/__snapshots__/schema2element.js.snap
@@ -191,6 +191,15 @@ ShallowWrapper {
         <Display
             __expr__={
                 Object {
+                    "value": "xCubed",
+                  }
+            }
+            id="derivedVarDisplay2"
+            value="xCubed"
+        />
+        <Display
+            __expr__={
+                Object {
                     "value": "\\"string\\"",
                   }
             }
@@ -250,6 +259,15 @@ ShallowWrapper {
             }
             id="bareDerivedDisplay"
             value="xSquared"
+        />
+        <Display
+            __vars__={
+                Object {
+                    "value": "xCubed",
+                  }
+            }
+            id="bareDerivedDisplay2"
+            value="xCubed"
         />
         <Display
             __expr__={
@@ -567,6 +585,15 @@ ShallowWrapper {
           <Display
                     __expr__={
                               Object {
+                                        "value": "xCubed",
+                                      }
+                    }
+                    id="derivedVarDisplay2"
+                    value="xCubed"
+          />
+          <Display
+                    __expr__={
+                              Object {
                                         "value": "\\"string\\"",
                                       }
                     }
@@ -626,6 +653,15 @@ ShallowWrapper {
                     }
                     id="bareDerivedDisplay"
                     value="xSquared"
+          />
+          <Display
+                    __vars__={
+                              Object {
+                                        "value": "xCubed",
+                                      }
+                    }
+                    id="bareDerivedDisplay2"
+                    value="xCubed"
           />
           <Display
                     __expr__={
@@ -938,6 +974,15 @@ ShallowWrapper {
             <Display
               __expr__={
                             Object {
+                                          "value": "xCubed",
+                                        }
+              }
+              id="derivedVarDisplay2"
+              value="xCubed"
+/>,
+            <Display
+              __expr__={
+                            Object {
                                           "value": "\\"string\\"",
                                         }
               }
@@ -997,6 +1042,15 @@ ShallowWrapper {
               }
               id="bareDerivedDisplay"
               value="xSquared"
+/>,
+            <Display
+              __vars__={
+                            Object {
+                                          "value": "xCubed",
+                                        }
+              }
+              id="bareDerivedDisplay2"
+              value="xCubed"
 />,
             <Display
               __expr__={
@@ -1798,6 +1852,22 @@ or be used to parameterize components. Derived variables can be used to create v
             "nodeType": "class",
             "props": Object {
               "__expr__": Object {
+                "value": "xCubed",
+              },
+              "children": undefined,
+              "id": "derivedVarDisplay2",
+              "value": "xCubed",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": "21",
+            "nodeType": "class",
+            "props": Object {
+              "__expr__": Object {
                 "value": "\\"string\\"",
               },
               "children": undefined,
@@ -1810,7 +1880,7 @@ or be used to parameterize components. Derived variables can be used to create v
           },
           Object {
             "instance": null,
-            "key": "21",
+            "key": "22",
             "nodeType": "class",
             "props": Object {
               "__expr__": Object {
@@ -1826,7 +1896,7 @@ or be used to parameterize components. Derived variables can be used to create v
           },
           Object {
             "instance": null,
-            "key": "22",
+            "key": "23",
             "nodeType": "class",
             "props": Object {
               "__expr__": Object {
@@ -1842,7 +1912,7 @@ or be used to parameterize components. Derived variables can be used to create v
           },
           Object {
             "instance": null,
-            "key": "23",
+            "key": "24",
             "nodeType": "class",
             "props": Object {
               "__expr__": Object {
@@ -1858,7 +1928,7 @@ or be used to parameterize components. Derived variables can be used to create v
           },
           Object {
             "instance": null,
-            "key": "24",
+            "key": "25",
             "nodeType": "class",
             "props": Object {
               "__vars__": Object {
@@ -1874,7 +1944,7 @@ or be used to parameterize components. Derived variables can be used to create v
           },
           Object {
             "instance": null,
-            "key": "25",
+            "key": "26",
             "nodeType": "class",
             "props": Object {
               "__vars__": Object {
@@ -1890,7 +1960,7 @@ or be used to parameterize components. Derived variables can be used to create v
           },
           Object {
             "instance": null,
-            "key": "26",
+            "key": "27",
             "nodeType": "class",
             "props": Object {
               "__vars__": Object {
@@ -1906,7 +1976,23 @@ or be used to parameterize components. Derived variables can be used to create v
           },
           Object {
             "instance": null,
-            "key": "27",
+            "key": "28",
+            "nodeType": "class",
+            "props": Object {
+              "__vars__": Object {
+                "value": "xCubed",
+              },
+              "children": undefined,
+              "id": "bareDerivedDisplay2",
+              "value": "xCubed",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": "29",
             "nodeType": "class",
             "props": Object {
               "__expr__": Object {
@@ -1922,7 +2008,7 @@ or be used to parameterize components. Derived variables can be used to create v
           },
           Object {
             "instance": null,
-            "key": "28",
+            "key": "30",
             "nodeType": "class",
             "props": Object {
               "__vars__": Object {
@@ -1938,7 +2024,7 @@ or be used to parameterize components. Derived variables can be used to create v
           },
           Object {
             "instance": null,
-            "key": "29",
+            "key": "31",
             "nodeType": "class",
             "props": Object {
               "__expr__": Object {
@@ -1954,7 +2040,7 @@ or be used to parameterize components. Derived variables can be used to create v
           },
           Object {
             "instance": null,
-            "key": "30",
+            "key": "32",
             "nodeType": "class",
             "props": Object {
               "__vars__": Object {
@@ -1970,7 +2056,7 @@ or be used to parameterize components. Derived variables can be used to create v
           },
           Object {
             "instance": null,
-            "key": "31",
+            "key": "33",
             "nodeType": "host",
             "props": Object {
               "children": undefined,
@@ -1981,7 +2067,7 @@ or be used to parameterize components. Derived variables can be used to create v
           },
           Object {
             "instance": null,
-            "key": "32",
+            "key": "34",
             "nodeType": "host",
             "props": Object {
               "children": Array [
@@ -1996,7 +2082,7 @@ or be used to parameterize components. Derived variables can be used to create v
           },
           Object {
             "instance": null,
-            "key": "33",
+            "key": "35",
             "nodeType": "class",
             "props": Object {
               "__expr__": Object {
@@ -2020,7 +2106,7 @@ or be used to parameterize components. Derived variables can be used to create v
           },
           Object {
             "instance": null,
-            "key": "34",
+            "key": "36",
             "nodeType": "class",
             "props": Object {
               "__expr__": Object {
@@ -2041,7 +2127,7 @@ or be used to parameterize components. Derived variables can be used to create v
           },
           Object {
             "instance": null,
-            "key": "35",
+            "key": "37",
             "nodeType": "host",
             "props": Object {
               "children": Array [
@@ -2083,7 +2169,7 @@ Late Var Range:",
           },
           Object {
             "instance": null,
-            "key": "36",
+            "key": "38",
             "nodeType": "class",
             "props": Object {
               "__vars__": Object {
@@ -2101,7 +2187,7 @@ Late Var Range:",
           },
           Object {
             "instance": null,
-            "key": "37",
+            "key": "39",
             "nodeType": "host",
             "props": Object {
               "children": Array [
@@ -2360,6 +2446,15 @@ Late Var Range:",
             <Display
                         __expr__={
                                     Object {
+                                                "value": "xCubed",
+                                              }
+                        }
+                        id="derivedVarDisplay2"
+                        value="xCubed"
+            />
+            <Display
+                        __expr__={
+                                    Object {
                                                 "value": "\\"string\\"",
                                               }
                         }
@@ -2419,6 +2514,15 @@ Late Var Range:",
                         }
                         id="bareDerivedDisplay"
                         value="xSquared"
+            />
+            <Display
+                        __vars__={
+                                    Object {
+                                                "value": "xCubed",
+                                              }
+                        }
+                        id="bareDerivedDisplay2"
+                        value="xCubed"
             />
             <Display
                         __expr__={
@@ -2731,6 +2835,15 @@ Late Var Range:",
               <Display
                 __expr__={
                                 Object {
+                                                "value": "xCubed",
+                                              }
+                }
+                id="derivedVarDisplay2"
+                value="xCubed"
+/>,
+              <Display
+                __expr__={
+                                Object {
                                                 "value": "\\"string\\"",
                                               }
                 }
@@ -2790,6 +2903,15 @@ Late Var Range:",
                 }
                 id="bareDerivedDisplay"
                 value="xSquared"
+/>,
+              <Display
+                __vars__={
+                                Object {
+                                                "value": "xCubed",
+                                              }
+                }
+                id="bareDerivedDisplay2"
+                value="xCubed"
 />,
               <Display
                 __expr__={
@@ -3591,6 +3713,22 @@ or be used to parameterize components. Derived variables can be used to create v
               "nodeType": "class",
               "props": Object {
                 "__expr__": Object {
+                  "value": "xCubed",
+                },
+                "children": undefined,
+                "id": "derivedVarDisplay2",
+                "value": "xCubed",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": "21",
+              "nodeType": "class",
+              "props": Object {
+                "__expr__": Object {
                   "value": "\\"string\\"",
                 },
                 "children": undefined,
@@ -3603,7 +3741,7 @@ or be used to parameterize components. Derived variables can be used to create v
             },
             Object {
               "instance": null,
-              "key": "21",
+              "key": "22",
               "nodeType": "class",
               "props": Object {
                 "__expr__": Object {
@@ -3619,7 +3757,7 @@ or be used to parameterize components. Derived variables can be used to create v
             },
             Object {
               "instance": null,
-              "key": "22",
+              "key": "23",
               "nodeType": "class",
               "props": Object {
                 "__expr__": Object {
@@ -3635,7 +3773,7 @@ or be used to parameterize components. Derived variables can be used to create v
             },
             Object {
               "instance": null,
-              "key": "23",
+              "key": "24",
               "nodeType": "class",
               "props": Object {
                 "__expr__": Object {
@@ -3651,7 +3789,7 @@ or be used to parameterize components. Derived variables can be used to create v
             },
             Object {
               "instance": null,
-              "key": "24",
+              "key": "25",
               "nodeType": "class",
               "props": Object {
                 "__vars__": Object {
@@ -3667,7 +3805,7 @@ or be used to parameterize components. Derived variables can be used to create v
             },
             Object {
               "instance": null,
-              "key": "25",
+              "key": "26",
               "nodeType": "class",
               "props": Object {
                 "__vars__": Object {
@@ -3683,7 +3821,7 @@ or be used to parameterize components. Derived variables can be used to create v
             },
             Object {
               "instance": null,
-              "key": "26",
+              "key": "27",
               "nodeType": "class",
               "props": Object {
                 "__vars__": Object {
@@ -3699,7 +3837,23 @@ or be used to parameterize components. Derived variables can be used to create v
             },
             Object {
               "instance": null,
-              "key": "27",
+              "key": "28",
+              "nodeType": "class",
+              "props": Object {
+                "__vars__": Object {
+                  "value": "xCubed",
+                },
+                "children": undefined,
+                "id": "bareDerivedDisplay2",
+                "value": "xCubed",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": "29",
               "nodeType": "class",
               "props": Object {
                 "__expr__": Object {
@@ -3715,7 +3869,7 @@ or be used to parameterize components. Derived variables can be used to create v
             },
             Object {
               "instance": null,
-              "key": "28",
+              "key": "30",
               "nodeType": "class",
               "props": Object {
                 "__vars__": Object {
@@ -3731,7 +3885,7 @@ or be used to parameterize components. Derived variables can be used to create v
             },
             Object {
               "instance": null,
-              "key": "29",
+              "key": "31",
               "nodeType": "class",
               "props": Object {
                 "__expr__": Object {
@@ -3747,7 +3901,7 @@ or be used to parameterize components. Derived variables can be used to create v
             },
             Object {
               "instance": null,
-              "key": "30",
+              "key": "32",
               "nodeType": "class",
               "props": Object {
                 "__vars__": Object {
@@ -3763,7 +3917,7 @@ or be used to parameterize components. Derived variables can be used to create v
             },
             Object {
               "instance": null,
-              "key": "31",
+              "key": "33",
               "nodeType": "host",
               "props": Object {
                 "children": undefined,
@@ -3774,7 +3928,7 @@ or be used to parameterize components. Derived variables can be used to create v
             },
             Object {
               "instance": null,
-              "key": "32",
+              "key": "34",
               "nodeType": "host",
               "props": Object {
                 "children": Array [
@@ -3789,7 +3943,7 @@ or be used to parameterize components. Derived variables can be used to create v
             },
             Object {
               "instance": null,
-              "key": "33",
+              "key": "35",
               "nodeType": "class",
               "props": Object {
                 "__expr__": Object {
@@ -3813,7 +3967,7 @@ or be used to parameterize components. Derived variables can be used to create v
             },
             Object {
               "instance": null,
-              "key": "34",
+              "key": "36",
               "nodeType": "class",
               "props": Object {
                 "__expr__": Object {
@@ -3834,7 +3988,7 @@ or be used to parameterize components. Derived variables can be used to create v
             },
             Object {
               "instance": null,
-              "key": "35",
+              "key": "37",
               "nodeType": "host",
               "props": Object {
                 "children": Array [
@@ -3876,7 +4030,7 @@ Late Var Range:",
             },
             Object {
               "instance": null,
-              "key": "36",
+              "key": "38",
               "nodeType": "class",
               "props": Object {
                 "__vars__": Object {
@@ -3894,7 +4048,7 @@ Late Var Range:",
             },
             Object {
               "instance": null,
-              "key": "37",
+              "key": "39",
               "nodeType": "host",
               "props": Object {
                 "children": Array [

--- a/packages/idyll-document/test/component.js
+++ b/packages/idyll-document/test/component.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import { join } from 'path';
 import React from 'react';
 import { mount, shallow } from 'enzyme';
-import compile from 'idyll-compiler'
+import compile from 'idyll-compiler';
 import * as components from 'idyll-components';
 
 import IdyllDocument from '../src/';
@@ -23,7 +23,7 @@ describe('IdyllDocument', () => {
   });
 
   it('wraps the right components', () => {
-    expect(astDoc.find('Wrapper').length).toBe(23);
+    expect(astDoc.find('Wrapper').length).toBe(25);
   });
 
   it('wraps both of the charts', () => {
@@ -32,33 +32,33 @@ describe('IdyllDocument', () => {
 });
 
 describe('Source to Doc', () => {
-  it('can create a header', (done) => {
-    compile('# A header')
-      .then((ast) => {
-        const doc = mount(<IdyllDocument ast={ast} components={components} />);
-        expect(doc).toBeDefined();
-        expect(doc.find('h1').length).toBe(1);
-        done();
-      });
-  })
+  it('can create a header', done => {
+    compile('# A header').then(ast => {
+      const doc = mount(<IdyllDocument ast={ast} components={components} />);
+      expect(doc).toBeDefined();
+      expect(doc.find('h1').length).toBe(1);
+      done();
+    });
+  });
 
-  it('can create an SVG', (done) => {
-    compile('[SVG /]')
-      .then((ast) => {
-        const doc = mount(<IdyllDocument ast={ast} components={components} />);
-        expect(doc).toBeDefined();
-        done();
-      });
-  })
+  it('can create an SVG', done => {
+    compile('[SVG /]').then(ast => {
+      const doc = mount(<IdyllDocument ast={ast} components={components} />);
+      expect(doc).toBeDefined();
+      done();
+    });
+  });
 
-  it('works with markup instead of an AST', (done) => {
-    const doc = mount(<IdyllDocument markup={'# A header'} components={components} />);
+  it('works with markup instead of an AST', done => {
+    const doc = mount(
+      <IdyllDocument markup={'# A header'} components={components} />
+    );
 
     setTimeout(() => {
       doc.update();
       expect(doc).toBeDefined();
       expect(doc.find('h1').length).toBe(1);
       done();
-    }, 100)
-  })
-})
+    }, 100);
+  });
+});

--- a/packages/idyll-document/test/fixtures/ast.json
+++ b/packages/idyll-document/test/fixtures/ast.json
@@ -1,189 +1,64 @@
 [
+  ["var", [["name", ["value", "x"]], ["value", ["value", 2]]], []],
   [
     "var",
     [
-      [
-        "name",
-        [
-          "value",
-          "x"
-        ]
-      ],
-      [
-        "value",
-        [
-          "value",
-          2
-        ]
-      ]
+      ["name", ["value", "objectVar"]],
+      ["value", ["expression", " { an: \"object\" } "]]
     ],
     []
   ],
   [
     "var",
     [
-      [
-        "name",
-        [
-          "value",
-          "objectVar"
-        ]
-      ],
-      [
-        "value",
-        [
-          "expression",
-          " { an: \"object\" } "
-        ]
-      ]
+      ["name", ["value", "arrayVar"]],
+      ["value", ["expression", " [ \"array\" ] "]]
     ],
     []
   ],
-  [
-    "var",
-    [
-      [
-        "name",
-        [
-          "value",
-          "arrayVar"
-        ]
-      ],
-      [
-        "value",
-        [
-          "expression",
-          " [ \"array\" ] "
-        ]
-      ]
-    ],
-    []
-  ],
-  [
-    "var",
-    [
-      [
-        "name",
-        [
-          "value",
-          "frequency"
-        ]
-      ],
-      [
-        "value",
-        [
-          "value",
-          1
-        ]
-      ]
-    ],
-    []
-  ],
-  [
-    "var",
-    [
-      [
-        "name",
-        [
-          "value",
-          "lateVar"
-        ]
-      ],
-      [
-        "value",
-        [
-          "value",
-          50
-        ]
-      ]
-    ],
-    []
-  ],
+  ["var", [["name", ["value", "frequency"]], ["value", ["value", 1]]], []],
+  ["var", [["name", ["value", "lateVar"]], ["value", ["value", 50]]], []],
   [
     "data",
-    [
-      [
-        "name",
-        [
-          "value",
-          "myData"
-        ]
-      ],
-      [
-        "source",
-        [
-          "value",
-          "myData.csv"
-        ]
-      ]
-    ],
+    [["name", ["value", "myData"]], ["source", ["value", "myData.csv"]]],
     []
   ],
   [
     "derived",
-    [
-      [
-        "name",
-        [
-          "value",
-          "xSquared"
-        ]
-      ],
-      [
-        "value",
-        [
-          "expression",
-          "x * x"
-        ]
-      ]
-    ],
+    [["name", ["value", "xSquared"]], ["value", ["expression", "x * x "]]],
+    []
+  ],
+  [
+    "derived",
+    [["name", ["value", "xCubed"]], ["value", ["expression", "x * xSquared "]]],
     []
   ],
   [
     "TextContainer",
     [],
     [
-      [
-        "h1",
-        [],
-        [
-          "Welcome to Idyll"
-        ]
-      ],
+      ["h1", [], ["Welcome to Idyll"]],
       [
         "h3",
         [],
-        [
-          "Idyll is a language for creating interactive documents on the web."
-        ]
+        ["Idyll is a language for creating interactive documents on the web."]
       ],
       [
         "p",
         [],
         [
           "This document is being rendered from ",
-          [
-            "strong",
-            [],
-            [
-              "Idyll markup"
-            ]
-          ],
+          ["strong", [], ["Idyll markup"]],
           ". If you’ve used ",
           [
             "a",
             [
               [
                 "href",
-                [
-                  "value",
-                  "https://daringfireball.net/projects/markdown/"
-                ]
+                ["value", "https://daringfireball.net/projects/markdown/"]
               ]
             ],
-            [
-              "markdown"
-            ]
+            ["markdown"]
           ],
           ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update."
         ]
@@ -193,65 +68,23 @@
         [],
         [
           "To make things a little more interesting you can add JavaScript components to your text.\nFor example, a ",
-          [
-            "code",
-            [],
-            [
-              "[Chart /]"
-            ]
-          ],
+          ["code", [], ["[Chart /]"]],
           " component can be used to render a simple visualization:"
         ]
       ],
-      [
-        "Chart",
-        [
-          [
-            "type",
-            [
-              "value",
-              "scatter"
-            ]
-          ]
-        ],
-        []
-      ],
+      ["Chart", [["type", ["value", "scatter"]]], []],
       [
         "p",
         [],
         [
           "Try changing the chart’s type from ",
-          [
-            "code",
-            [],
-            [
-              "scatter"
-            ]
-          ],
+          ["code", [], ["scatter"]],
           " to ",
-          [
-            "code",
-            [],
-            [
-              "line"
-            ]
-          ],
+          ["code", [], ["line"]],
           ", ",
-          [
-            "code",
-            [],
-            [
-              "area"
-            ]
-          ],
+          ["code", [], ["area"]],
           ", or ",
-          [
-            "code",
-            [],
-            [
-              "pie"
-            ]
-          ],
+          ["code", [], ["pie"]],
           "."
         ]
       ],
@@ -260,13 +93,7 @@
         [],
         [
           "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (",
-          [
-            "code",
-            [],
-            [
-              "`2 * Math.PI`"
-            ]
-          ],
+          ["code", [], ["`2 * Math.PI`"]],
           ")."
         ]
       ],
@@ -280,39 +107,23 @@
             [
               [
                 "href",
-                [
-                  "value",
-                  "https://idyll-lang.github.io/components-built-in"
-                ]
+                ["value", "https://idyll-lang.github.io/components-built-in"]
               ]
             ],
-            [
-              "Idyll’s documentation"
-            ]
+            ["Idyll’s documentation"]
           ],
           " for a full list — Additional components can be installed via ",
-          [
-            "code",
-            [],
-            [
-              "npm"
-            ]
-          ],
+          ["code", [], ["npm"]],
           " (any React component should work), and if you are comfortable with JavaScript you can write ",
           [
             "a",
             [
               [
                 "href",
-                [
-                  "value",
-                  "https://idyll-lang.github.io/components-custom"
-                ]
+                ["value", "https://idyll-lang.github.io/components-custom"]
               ]
             ],
-            [
-              "custom components"
-            ]
+            ["custom components"]
           ],
           " as well."
         ]
@@ -327,84 +138,34 @@
       [
         "p",
         [],
-        [
-          "Instantiating a variable is similar to instantiating a component:"
-        ]
+        ["Instantiating a variable is similar to instantiating a component:"]
       ],
-      [
-        "code",
-        [],
-        [
-          "[var name:\"x\" value:1 /]"
-        ]
-      ],
+      ["code", [], ["[var name:\"x\" value:1 /]"]],
       [
         "p",
         [],
         [
           "Once you’ve created a variable, it can be displayed inline with text\n(x = ",
-          [
-            "Display",
-            [
-              [
-                "var",
-                [
-                  "variable",
-                  "x"
-                ]
-              ]
-            ],
-            []
-          ],
+          ["Display", [["var", ["variable", "x"]]], []],
           "),\nor be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:"
         ]
       ],
-      [
-        "code",
-        [],
-        [
-          "[derived name:\"xSquared\" value:`x * x` /]"
-        ]
-      ],
+      ["code", [], ["[derived name:\"xSquared\" value:`x * x` /]"]],
       [
         "p",
         [],
         [
           "Here I bind the value of ",
-          [
-            "code",
-            [],
-            [
-              "x"
-            ]
-          ],
+          ["code", [], ["x"]],
           " to a range slider. Move the slider and watch the variables update."
         ]
       ],
       [
         "Range",
         [
-          [
-            "value",
-            [
-              "variable",
-              "x"
-            ]
-          ],
-          [
-            "min",
-            [
-              "value",
-              0
-            ]
-          ],
-          [
-            "max",
-            [
-              "value",
-              100
-            ]
-          ]
+          ["value", ["variable", "x"]],
+          ["min", ["value", 0]],
+          ["max", ["value", 100]]
         ],
         []
       ],
@@ -412,328 +173,133 @@
         "p",
         [],
         [
-          [
-            "equation",
-            [],
-            [
-              "x"
-            ]
-          ],
+          ["equation", [], ["x"]],
           ":\n ",
-          [
-            "Display",
-            [
-              [
-                "var",
-                [
-                  "expression",
-                  "x"
-                ]
-              ]
-            ],
-            []
-          ]
+          ["Display", [["var", ["expression", "x"]]], []]
         ]
       ],
       [
         "p",
         [],
         [
-          [
-            "equation",
-            [],
-            [
-              "x^2"
-            ]
-          ],
+          ["equation", [], ["x^2"]],
           ":",
-          [
-            "Display",
-            [
-              [
-                "var",
-                [
-                  "expression",
-                  "xSquared"
-                ]
-              ]
-            ],
-            []
-          ]
+          ["Display", [["var", ["expression", "xSquared"]]], []]
         ]
       ],
+      ["p", [], ["Test expression, displays:"]],
       [
-        "p",
-        [],
-        [
-          "Test expression, displays:"
-        ]
+        "Display",
+        [["id", ["value", "varDisplay"]], ["value", ["expression", "x"]]],
+        []
       ],
       [
         "Display",
         [
-          [
-            "id",
-            [
-              "value",
-              "varDisplay"
-            ]
-          ],
-          [
-            "value",
-            [
-              "expression",
-              "x"
-            ]
-          ]
+          ["id", ["value", "derivedVarDisplay"]],
+          ["value", ["expression", "xSquared"]]
         ],
         []
       ],
       [
         "Display",
         [
-          [
-            "id",
-            [
-              "value",
-              "derivedVarDisplay"
-            ]
-          ],
-          [
-            "value",
-            [
-              "expression",
-              "xSquared"
-            ]
-          ]
+          ["id", ["value", "derivedVarDisplay2"]],
+          ["value", ["expression", "xCubed"]]
         ],
         []
       ],
       [
         "Display",
         [
-          [
-            "id",
-            [
-              "value",
-              "strDisplay"
-            ]
-          ],
-          [
-            "value",
-            [
-              "expression",
-              "\"string\""
-            ]
-          ]
+          ["id", ["value", "strDisplay"]],
+          ["value", ["expression", "\"string\""]]
         ],
         []
       ],
       [
         "Display",
         [
-          [
-            "id",
-            [
-              "value",
-              "staticObjectDisplay"
-            ]
-          ],
-          [
-            "value",
-            [
-              "expression",
-              "{ static: \"object\" }"
-            ]
-          ]
+          ["id", ["value", "staticObjectDisplay"]],
+          ["value", ["expression", "{ static: \"object\" }"]]
         ],
         []
       ],
       [
         "Display",
         [
-          [
-            "id",
-            [
-              "value",
-              "dynamicObjectDisplay"
-            ]
-          ],
-          [
-            "value",
-            [
-              "expression",
-              "{ dynamic: x }"
-            ]
-          ]
+          ["id", ["value", "dynamicObjectDisplay"]],
+          ["value", ["expression", "{ dynamic: x }"]]
+        ],
+        []
+      ],
+      [
+        "Display",
+        [["id", ["value", "dataDisplay"]], ["value", ["expression", "myData"]]],
+        []
+      ],
+      [
+        "Display",
+        [
+          ["id", ["value", "bareDataDisplay"]],
+          ["value", ["variable", "myData"]]
+        ],
+        []
+      ],
+      [
+        "Display",
+        [["id", ["value", "bareVarDisplay"]], ["value", ["variable", "x"]]],
+        []
+      ],
+      [
+        "Display",
+        [
+          ["id", ["value", "bareDerivedDisplay"]],
+          ["value", ["variable", "xSquared"]]
         ],
         []
       ],
       [
         "Display",
         [
-          [
-            "id",
-            [
-              "value",
-              "dataDisplay"
-            ]
-          ],
-          [
-            "value",
-            [
-              "expression",
-              "myData"
-            ]
-          ]
+          ["id", ["value", "bareDerivedDisplay2"]],
+          ["value", ["variable", "xCubed"]]
         ],
         []
       ],
       [
         "Display",
         [
-          [
-            "id",
-            [
-              "value",
-              "bareDataDisplay"
-            ]
-          ],
-          [
-            "value",
-            [
-              "variable",
-              "myData"
-            ]
-          ]
+          ["id", ["value", "objectVarDisplay"]],
+          ["value", ["expression", " objectVar "]]
         ],
         []
       ],
       [
         "Display",
         [
-          [
-            "id",
-            [
-              "value",
-              "bareVarDisplay"
-            ]
-          ],
-          [
-            "value",
-            [
-              "variable",
-              "x"
-            ]
-          ]
+          ["id", ["value", "bareObjectVarDisplay"]],
+          ["value", ["variable", "objectVar"]]
         ],
         []
       ],
       [
         "Display",
         [
-          [
-            "id",
-            [
-              "value",
-              "bareDerivedDisplay"
-            ]
-          ],
-          [
-            "value",
-            [
-              "variable",
-              "xSquared"
-            ]
-          ]
+          ["id", ["value", "arrayVarDisplay"]],
+          ["value", ["expression", " arrayVar "]]
         ],
         []
       ],
       [
         "Display",
         [
-          [
-            "id",
-            [
-              "value",
-              "objectVarDisplay"
-            ]
-          ],
-          [
-            "value",
-            [
-              "expression",
-              " objectVar "
-            ]
-          ]
+          ["id", ["value", "bareArrayVarDisplay"]],
+          ["value", ["variable", "arrayVar"]]
         ],
         []
       ],
-      [
-        "Display",
-        [
-          [
-            "id",
-            [
-              "value",
-              "bareObjectVarDisplay"
-            ]
-          ],
-          [
-            "value",
-            [
-              "variable",
-              "objectVar"
-            ]
-          ]
-        ],
-        []
-      ],
-      [
-        "Display",
-        [
-          [
-            "id",
-            [
-              "value",
-              "arrayVarDisplay"
-            ]
-          ],
-          [
-            "value",
-            [
-              "expression",
-              " arrayVar "
-            ]
-          ]
-        ],
-        []
-      ],
-      [
-        "Display",
-        [
-          [
-            "id",
-            [
-              "value",
-              "bareArrayVarDisplay"
-            ]
-          ],
-          [
-            "value",
-            [
-              "variable",
-              "arrayVar"
-            ]
-          ]
-        ],
-        []
-      ],
-      [
-        "br",
-        [],
-        []
-      ],
+      ["br", [], []],
       [
         "p",
         [],
@@ -744,61 +310,19 @@
       [
         "Chart",
         [
-          [
-            "equation",
-            [
-              "expression",
-              "(t) => Math.sin(t * frequency)"
-            ]
-          ],
-          [
-            "domain",
-            [
-              "expression",
-              "[0, 2 * Math.PI]"
-            ]
-          ],
-          [
-            "samplePoints",
-            [
-              "value",
-              1000
-            ]
-          ]
+          ["equation", ["expression", "(t) => Math.sin(t * frequency)"]],
+          ["domain", ["expression", "[0, 2 * Math.PI]"]],
+          ["samplePoints", ["value", 1000]]
         ],
         []
       ],
       [
         "Range",
         [
-          [
-            "value",
-            [
-              "variable",
-              "frequency"
-            ]
-          ],
-          [
-            "min",
-            [
-              "value",
-              0.5
-            ]
-          ],
-          [
-            "max",
-            [
-              "expression",
-              "2 * Math.PI"
-            ]
-          ],
-          [
-            "step",
-            [
-              "value",
-              0.0001
-            ]
-          ]
+          ["value", ["variable", "frequency"]],
+          ["min", ["value", 0.5]],
+          ["max", ["expression", "2 * Math.PI"]],
+          ["step", ["value", 0.0001]]
         ],
         []
       ],
@@ -809,20 +333,8 @@
           [
             "Display",
             [
-              [
-                "id",
-                [
-                  "value",
-                  "lateVarDisplay"
-                ]
-              ],
-              [
-                "value",
-                [
-                  "variable",
-                  "lateVar"
-                ]
-              ]
+              ["id", ["value", "lateVarDisplay"]],
+              ["value", ["variable", "lateVar"]]
             ],
             []
           ],
@@ -832,27 +344,9 @@
       [
         "Range",
         [
-          [
-            "value",
-            [
-              "variable",
-              "lateVar"
-            ]
-          ],
-          [
-            "min",
-            [
-              "value",
-              2
-            ]
-          ],
-          [
-            "max",
-            [
-              "value",
-              100
-            ]
-          ]
+          ["value", ["variable", "lateVar"]],
+          ["min", ["value", 2]],
+          ["max", ["value", 100]]
         ],
         []
       ],
@@ -863,34 +357,14 @@
           "Read more about Idyll at ",
           [
             "a",
-            [
-              [
-                "href",
-                [
-                  "value",
-                  "https://idyll-lang.github.io/"
-                ]
-              ]
-            ],
-            [
-              "https://idyll-lang.github.io/"
-            ]
+            [["href", ["value", "https://idyll-lang.github.io/"]]],
+            ["https://idyll-lang.github.io/"]
           ],
           ", and come say “Hi!” in our ",
           [
             "a",
-            [
-              [
-                "href",
-                [
-                  "value",
-                  "https://gitter.im/idyll-lang/Lobby"
-                ]
-              ]
-            ],
-            [
-              "chatroom on gitter"
-            ]
+            [["href", ["value", "https://gitter.im/idyll-lang/Lobby"]]],
+            ["chatroom on gitter"]
           ],
           "."
         ]

--- a/packages/idyll-document/test/fixtures/schema.json
+++ b/packages/idyll-document/test/fixtures/schema.json
@@ -4,9 +4,7 @@
     "children": [
       {
         "component": "h1",
-        "children": [
-          "Welcome to Idyll"
-        ]
+        "children": ["Welcome to Idyll"]
       },
       {
         "component": "h3",
@@ -20,17 +18,13 @@
           "This document is being rendered from ",
           {
             "component": "strong",
-            "children": [
-              "Idyll markup"
-            ]
+            "children": ["Idyll markup"]
           },
           ". If you’ve used ",
           {
             "component": "a",
             "href": "https://daringfireball.net/projects/markdown/",
-            "children": [
-              "markdown"
-            ]
+            "children": ["markdown"]
           },
           ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update."
         ]
@@ -41,9 +35,7 @@
           "To make things a little more interesting you can add JavaScript components to your text.\nFor example, a ",
           {
             "component": "code",
-            "children": [
-              "[Chart /]"
-            ]
+            "children": ["[Chart /]"]
           },
           " component can be used to render a simple visualization:"
         ]
@@ -59,30 +51,22 @@
           "Try changing the chart’s type from ",
           {
             "component": "code",
-            "children": [
-              "scatter"
-            ]
+            "children": ["scatter"]
           },
           " to ",
           {
             "component": "code",
-            "children": [
-              "line"
-            ]
+            "children": ["line"]
           },
           ", ",
           {
             "component": "code",
-            "children": [
-              "area"
-            ]
+            "children": ["area"]
           },
           ", or ",
           {
             "component": "code",
-            "children": [
-              "pie"
-            ]
+            "children": ["pie"]
           },
           "."
         ]
@@ -93,9 +77,7 @@
           "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (",
           {
             "component": "code",
-            "children": [
-              "`2 * Math.PI`"
-            ]
+            "children": ["`2 * Math.PI`"]
           },
           ")."
         ]
@@ -107,24 +89,18 @@
           {
             "component": "a",
             "href": "https://idyll-lang.github.io/components-built-in",
-            "children": [
-              "Idyll’s documentation"
-            ]
+            "children": ["Idyll’s documentation"]
           },
           " for a full list — Additional components can be installed via ",
           {
             "component": "code",
-            "children": [
-              "npm"
-            ]
+            "children": ["npm"]
           },
           " (any React component should work), and if you are comfortable with JavaScript you can write ",
           {
             "component": "a",
             "href": "https://idyll-lang.github.io/components-custom",
-            "children": [
-              "custom components"
-            ]
+            "children": ["custom components"]
           },
           " as well."
         ]
@@ -143,9 +119,7 @@
       },
       {
         "component": "code",
-        "children": [
-          "[var name:\"x\" value:1 /]"
-        ]
+        "children": ["[var name:\"x\" value:1 /]"]
       },
       {
         "component": "p",
@@ -164,9 +138,7 @@
       },
       {
         "component": "code",
-        "children": [
-          "[derived name:\"xSquared\" value:`x * x` /]"
-        ]
+        "children": ["[derived name:\"xSquared\" value:`x * x` /]"]
       },
       {
         "component": "p",
@@ -174,9 +146,7 @@
           "Here I bind the value of ",
           {
             "component": "code",
-            "children": [
-              "x"
-            ]
+            "children": ["x"]
           },
           " to a range slider. Move the slider and watch the variables update."
         ]
@@ -196,9 +166,7 @@
         "children": [
           {
             "component": "equation",
-            "children": [
-              "x"
-            ]
+            "children": ["x"]
           },
           ":\n ",
           {
@@ -216,9 +184,7 @@
         "children": [
           {
             "component": "equation",
-            "children": [
-              "x^2"
-            ]
+            "children": ["x^2"]
           },
           ":",
           {
@@ -233,9 +199,7 @@
       },
       {
         "component": "p",
-        "children": [
-          "Test expression, displays:"
-        ]
+        "children": ["Test expression, displays:"]
       },
       {
         "component": "Display",
@@ -253,6 +217,15 @@
           "value": "xSquared"
         },
         "value": "xSquared",
+        "children": []
+      },
+      {
+        "component": "Display",
+        "id": "derivedVarDisplay2",
+        "__expr__": {
+          "value": "xCubed"
+        },
+        "value": "xCubed",
         "children": []
       },
       {
@@ -316,6 +289,15 @@
           "value": "xSquared"
         },
         "value": "xSquared",
+        "children": []
+      },
+      {
+        "component": "Display",
+        "id": "bareDerivedDisplay2",
+        "__vars__": {
+          "value": "xCubed"
+        },
+        "value": "xCubed",
         "children": []
       },
       {
@@ -421,17 +403,13 @@
           {
             "component": "a",
             "href": "https://idyll-lang.github.io/",
-            "children": [
-              "https://idyll-lang.github.io/"
-            ]
+            "children": ["https://idyll-lang.github.io/"]
           },
           ", and come say “Hi!” in our ",
           {
             "component": "a",
             "href": "https://gitter.im/idyll-lang/Lobby",
-            "children": [
-              "chatroom on gitter"
-            ]
+            "children": ["chatroom on gitter"]
           },
           "."
         ]

--- a/packages/idyll-document/test/fixtures/src.idl
+++ b/packages/idyll-document/test/fixtures/src.idl
@@ -31,7 +31,8 @@ Once you've created a variable, it can be displayed inline with text
 (x = [Display var:x /]),
 or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:
 
-[derived name:"xSquared" value:`x * x` /]
+[derived name:"xSquared" value:`x * x ` /]
+[derived name:"xCubed" value:`x * xSquared ` /]
 
 ``[derived name:"xSquared" value:`x * x` /]``
 
@@ -52,6 +53,7 @@ Test expression, displays:
 
 [Display id:"varDisplay" value:`x` /]
 [Display id:"derivedVarDisplay" value:`xSquared` /]
+[Display id:"derivedVarDisplay2" value:`xCubed` /]
 [Display id:"strDisplay" value:`"string"` /]
 [Display id:"staticObjectDisplay" value:`{ static: "object" }` /]
 [Display id:"dynamicObjectDisplay" value:`{ dynamic: x }` /]
@@ -60,6 +62,7 @@ Test expression, displays:
 [Display id:"bareDataDisplay" value:myData /]
 [Display id:"bareVarDisplay" value:x /]
 [Display id:"bareDerivedDisplay" value:xSquared /]
+[Display id:"bareDerivedDisplay2" value:xCubed /]
 
 [var name:"objectVar" value:` { an: "object" } `  /]
 [var name:"arrayVar" value:` [ "array" ] `  /]

--- a/packages/idyll-document/test/vars.js
+++ b/packages/idyll-document/test/vars.js
@@ -10,22 +10,28 @@ let component, idyllContext;
 const FAKE_DATA = 'FAKE DATA';
 
 beforeAll(() => {
-  component = mount(<IdyllDocument ast={ast} components={components} datasets={{myData: FAKE_DATA}} context={(ctx) => {
-    idyllContext = ctx;
-  }} />);
-})
+  component = mount(
+    <IdyllDocument
+      ast={ast}
+      components={components}
+      datasets={{ myData: FAKE_DATA }}
+      context={ctx => {
+        idyllContext = ctx;
+      }}
+    />
+  );
+});
 
 describe('Component state initialization', () => {
-
-
   it('creates the expected state', () => {
     expect(idyllContext.data()).toEqual({
       x: 2,
       frequency: 1,
       xSquared: 4,
+      xCubed: 8,
       myData: FAKE_DATA,
-      objectVar: {an: "object"},
-      arrayVar: [ "array" ],
+      objectVar: { an: 'object' },
+      arrayVar: ['array'],
       lateVar: 50
     });
   });
@@ -44,151 +50,241 @@ describe('Component state initialization', () => {
   // });
 
   it('renders expressions correctly before updates', () => {
-    const displayComponents = component.findWhere((n) => {return n.type() === components.Display;});
+    const displayComponents = component.findWhere(n => {
+      return n.type() === components.Display;
+    });
     expect(displayComponents.length).toBeGreaterThan(0);
 
-    const checks = [{
-      id: 'varDisplay',
-      html: '<span>2.00</span>'
-    }, {
-      id: 'derivedVarDisplay',
-      html: '<span>4.00</span>'
-    }, {
-      id: 'strDisplay',
-      html: '<span>string</span>'
-    }, {
-      id: 'staticObjectDisplay',
-      html: `<span>${JSON.stringify({static: 'object'})}</span>`
-    }, {
-      id: 'dynamicObjectDisplay',
-      html: `<span>${JSON.stringify({dynamic: 2.0})}</span>`
-    }, {
-      id: 'dataDisplay',
-      html: `<span>${FAKE_DATA}</span>`
-    }, {
-      id: 'bareDataDisplay',
-      html: `<span>${FAKE_DATA}</span>`
-    }, {
-      id: 'bareVarDisplay',
-      html: '<span>2.00</span>'
-    }, {
-      id: 'bareDerivedDisplay',
-      html: '<span>4.00</span>'
-    }, {
-      id: 'objectVarDisplay',
-      html: `<span>${JSON.stringify({an: "object"})}</span>`
-    }, {
-      id: 'bareObjectVarDisplay',
-      html: `<span>${JSON.stringify({an: "object"})}</span>`
-    }, {
-      id: 'arrayVarDisplay',
-      html: `<span>${JSON.stringify([ "array" ])}</span>`
-    }, {
-      id: 'bareArrayVarDisplay',
-      html: `<span>${JSON.stringify([ "array" ])}</span>`
-    }];
+    const checks = [
+      {
+        id: 'varDisplay',
+        html: '<span>2.00</span>'
+      },
+      {
+        id: 'derivedVarDisplay',
+        html: '<span>4.00</span>'
+      },
+      {
+        id: 'derivedVarDisplay2',
+        html: '<span>8.00</span>'
+      },
+      {
+        id: 'strDisplay',
+        html: '<span>string</span>'
+      },
+      {
+        id: 'staticObjectDisplay',
+        html: `<span>${JSON.stringify({ static: 'object' })}</span>`
+      },
+      {
+        id: 'dynamicObjectDisplay',
+        html: `<span>${JSON.stringify({ dynamic: 2.0 })}</span>`
+      },
+      {
+        id: 'dataDisplay',
+        html: `<span>${FAKE_DATA}</span>`
+      },
+      {
+        id: 'bareDataDisplay',
+        html: `<span>${FAKE_DATA}</span>`
+      },
+      {
+        id: 'bareVarDisplay',
+        html: '<span>2.00</span>'
+      },
+      {
+        id: 'bareDerivedDisplay',
+        html: '<span>4.00</span>'
+      },
+      {
+        id: 'bareDerivedDisplay2',
+        html: '<span>8.00</span>'
+      },
+      {
+        id: 'objectVarDisplay',
+        html: `<span>${JSON.stringify({ an: 'object' })}</span>`
+      },
+      {
+        id: 'bareObjectVarDisplay',
+        html: `<span>${JSON.stringify({ an: 'object' })}</span>`
+      },
+      {
+        id: 'arrayVarDisplay',
+        html: `<span>${JSON.stringify(['array'])}</span>`
+      },
+      {
+        id: 'bareArrayVarDisplay',
+        html: `<span>${JSON.stringify(['array'])}</span>`
+      }
+    ];
 
-    checks.forEach((check) => {
+    checks.forEach(check => {
       const display = displayComponents.find(`#${check.id}`);
       expect(display.length).toBe(1);
       expect(display.html()).toBe(check.html);
     });
   });
 
-
   it('handles custom initial state', () => {
-    component = mount(<IdyllDocument ast={ast} initialState={{ x: 4 }} components={components} datasets={{myData: FAKE_DATA}} context={(ctx) => idyllContext = ctx} />);
+    component = mount(
+      <IdyllDocument
+        ast={ast}
+        initialState={{ x: 4 }}
+        components={components}
+        datasets={{ myData: FAKE_DATA }}
+        context={ctx => (idyllContext = ctx)}
+      />
+    );
 
     expect(idyllContext.data()).toEqual({
       x: 4,
       frequency: 1,
       xSquared: 16,
+      xCubed: 64,
       myData: FAKE_DATA,
-      objectVar: {an: "object"},
-      arrayVar: [ "array" ],
+      objectVar: { an: 'object' },
+      arrayVar: ['array'],
       lateVar: 50
     });
-  })
+  });
 
   it('can update the vars and derived vars', () => {
-    const rangeComponents = component.findWhere((n) => {return n.type() === components.Range;});
+    const rangeComponents = component.findWhere(n => {
+      return n.type() === components.Range;
+    });
     expect(rangeComponents.length).toBeGreaterThan(1);
 
     const updateProps = rangeComponents.first().prop('updateProps');
     expect(updateProps).toEqual(expect.any(Function));
 
-    idyllContext.onUpdate((newState) => {
+    idyllContext.onUpdate(newState => {
       expect(newState).toEqual({
         x: 8,
-        xSquared: 64
-      })
-    })
+        xSquared: 64,
+        xCubed: 512
+      });
+    });
 
     updateProps({ value: 8 });
     expect(idyllContext.data()).toEqual({
       x: 8,
       frequency: 1,
       xSquared: 64,
+      xCubed: 512,
       myData: FAKE_DATA,
-      objectVar: {an: "object"},
-      arrayVar: [ "array" ],
+      objectVar: { an: 'object' },
+      arrayVar: ['array'],
+      lateVar: 50
+    });
+  });
+
+  it('allows derived vars to reference other derived vars', () => {
+    const rangeComponents = component.findWhere(n => {
+      return n.type() === components.Range;
+    });
+    expect(rangeComponents.length).toBeGreaterThan(1);
+
+    const updateProps = rangeComponents.first().prop('updateProps');
+    expect(updateProps).toEqual(expect.any(Function));
+
+    idyllContext.onUpdate(newState => {
+      expect(newState).toEqual({
+        x: 8,
+        xSquared: 64,
+        xCubed: 512
+      });
+    });
+
+    updateProps({ value: 8 });
+    expect(idyllContext.data()).toEqual({
+      x: 8,
+      frequency: 1,
+      xSquared: 64,
+      xCubed: 512,
+      myData: FAKE_DATA,
+      objectVar: { an: 'object' },
+      arrayVar: ['array'],
       lateVar: 50
     });
   });
 
   it('renders expressions correctly after updates', () => {
-    const displayComponents = component.findWhere((n) => {return n.type() === components.Display;});
+    const displayComponents = component.findWhere(n => {
+      return n.type() === components.Display;
+    });
     expect(displayComponents.length).toBeGreaterThan(0);
 
-    const checks = [{
-      id: 'varDisplay',
-      html: '<span>8.00</span>'
-    }, {
-      id: 'derivedVarDisplay',
-      html: '<span>64.00</span>'
-    }, {
-      id: 'strDisplay',
-      html: '<span>string</span>'
-    }, {
-      id: 'staticObjectDisplay',
-      html: `<span>${JSON.stringify({static: 'object'})}</span>`
-    }, {
-      id: 'dynamicObjectDisplay',
-      html: `<span>${JSON.stringify({dynamic: 8.0})}</span>`
-    }, {
-      id: 'dataDisplay',
-      html: `<span>${FAKE_DATA}</span>`
-    }, {
-      id: 'bareDataDisplay',
-      html: `<span>${FAKE_DATA}</span>`
-    }, {
-      id: 'bareDerivedDisplay',
-      html: '<span>64.00</span>'
-    }, {
-      id: 'bareVarDisplay',
-      html: '<span>8.00</span>'
-    }, {
-      id: 'objectVarDisplay',
-      html: `<span>${JSON.stringify({an: "object"})}</span>`
-    }, {
-      id: 'bareObjectVarDisplay',
-      html: `<span>${JSON.stringify({an: "object"})}</span>`
-    }, {
-      id: 'arrayVarDisplay',
-      html: `<span>${JSON.stringify([ "array" ])}</span>`
-    }, {
-      id: 'bareArrayVarDisplay',
-      html: `<span>${JSON.stringify([ "array" ])}</span>`
-    }, {
-      id: 'lateVarDisplay',
-      html: `<span>50.00</span>`
-    }];
+    const checks = [
+      {
+        id: 'varDisplay',
+        html: '<span>8.00</span>'
+      },
+      {
+        id: 'derivedVarDisplay',
+        html: '<span>64.00</span>'
+      },
+      {
+        id: 'derivedVarDisplay2',
+        html: '<span>512.00</span>'
+      },
+      {
+        id: 'strDisplay',
+        html: '<span>string</span>'
+      },
+      {
+        id: 'staticObjectDisplay',
+        html: `<span>${JSON.stringify({ static: 'object' })}</span>`
+      },
+      {
+        id: 'dynamicObjectDisplay',
+        html: `<span>${JSON.stringify({ dynamic: 8.0 })}</span>`
+      },
+      {
+        id: 'dataDisplay',
+        html: `<span>${FAKE_DATA}</span>`
+      },
+      {
+        id: 'bareDataDisplay',
+        html: `<span>${FAKE_DATA}</span>`
+      },
+      {
+        id: 'bareDerivedDisplay',
+        html: '<span>64.00</span>'
+      },
+      {
+        id: 'bareDerivedDisplay2',
+        html: '<span>512.00</span>'
+      },
+      {
+        id: 'bareVarDisplay',
+        html: '<span>8.00</span>'
+      },
+      {
+        id: 'objectVarDisplay',
+        html: `<span>${JSON.stringify({ an: 'object' })}</span>`
+      },
+      {
+        id: 'bareObjectVarDisplay',
+        html: `<span>${JSON.stringify({ an: 'object' })}</span>`
+      },
+      {
+        id: 'arrayVarDisplay',
+        html: `<span>${JSON.stringify(['array'])}</span>`
+      },
+      {
+        id: 'bareArrayVarDisplay',
+        html: `<span>${JSON.stringify(['array'])}</span>`
+      },
+      {
+        id: 'lateVarDisplay',
+        html: `<span>50.00</span>`
+      }
+    ];
 
-    checks.forEach((check) => {
+    checks.forEach(check => {
       const display = displayComponents.find(`#${check.id}`);
       expect(display.length).toBe(1);
       expect(display.html()).toBe(check.html);
     });
   });
-
 });


### PR DESCRIPTION
This allows derived variables to reference other derived vars in their value functions. A small example:

```
[var name:"x" value:2/]

[derived name:"xSquared" value:`x * x ` /]
[derived name:"xCubed" value:`x * xSquared ` /]
```

This fixed #438. ~~I still need to update the tests.~~

/cc @rafaveguim 