### PR TITLE
Documentation: custom components should inherit from React.PureComponent

### DIFF
--- a/packages/idyll-docs/pages/docs/components/custom.js
+++ b/packages/idyll-docs/pages/docs/components/custom.js
@@ -21,7 +21,7 @@ export default ({ url }) => (
         {`// custom.js
 const React = require('react');
 
-class Custom extends React.Component {
+class Custom extends React.PureComponent {
   render() {
     const { idyll, hasError, updateProps, ...props } = this.props;
 
@@ -40,6 +40,10 @@ module.exports = Custom;`}
       following code:</p>
 
       <pre><code>{`[Custom /]`}</code></pre>
+  
+      <p>Notice that the custom component inherits from <code>React.PureComponent</code> 
+      rather than <code>React.Component</code> so that rendering is updated only when 
+      properties or state change. This speeds up compilation in watch mode.</p>
 
       <h2>Updating the Document</h2>
 
@@ -56,7 +60,7 @@ module.exports = Custom;`}
 
       <Highlight className='javascript'>
         {`const React = require('react');
-class Incrementer extends React.Component {
+class Incrementer extends React.PureComponent {
 
   increment() {
     this.props.updateProps({


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Docs update.

* **What is the current behavior?** (You can also link to an open issue here)

The documentation should state that [custom components](https://idyll-lang.org/docs/components/custom) should inherit from `React.PureComponent` instead of `React.Component` so that rendering is updated only on properties or state changes. This speeds up compilation in watch mode.

See #440.

* **What is the new behavior (if this is a feature change)?**

/

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:
