### PR TITLE
Add an onMount trigger to the context api

### DIFF
--- a/packages/idyll-document/src/runtime.js
+++ b/packages/idyll-document/src/runtime.js
@@ -250,6 +250,9 @@ class IdyllRuntime extends React.PureComponent {
         onInitialize: cb => {
           this._onInitializeState = cb;
         },
+        onMount: cb => {
+          this._onMount = cb;
+        },
         onUpdate: cb => {
           this._onUpdateState = cb;
         }
@@ -468,6 +471,7 @@ class IdyllRuntime extends React.PureComponent {
   componentDidMount() {
     const refs = getRefs();
     updateRefsCallbacks.forEach(f => f({ ...this.state, refs }));
+    this._onMount && this._onMount();
   }
 
   render() {


### PR DESCRIPTION
This updates the context API with a new `onMount` callback.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
New Feature

* **What is the new behavior (if this is a feature change)?**
It exposes a new function `onMount` to the context API that plugins and users can access to trigger events when the application has mounted in a browser.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
