### PR TITLE
use standard HTML SVG tag if a src isn't provided

### DIFF
--- a/packages/idyll-components/src/svg.js
+++ b/packages/idyll-components/src/svg.js
@@ -3,25 +3,28 @@ import InlineSVG from 'react-inlinesvg';
 
 class SVG extends React.PureComponent {
   render() {
-    return (
-      <InlineSVG {...this.props} />
-    );
+    if (!this.props.src) {
+      return <svg {...this.props} />;
+    }
+    return <InlineSVG {...this.props} />;
   }
 }
 
 SVG.defaultProps = {
   src: ''
-}
+};
 
 SVG._idyll = {
-  name: "SVG",
-  tagType: "closed",
-  props: [{
-    name: "src",
-    type: "string",
-    example: '"https://upload.wikimedia.org/wikipedia/commons/f/fd/Ghostscript_Tiger.svg"'
-  }]
-}
+  name: 'SVG',
+  tagType: 'closed',
+  props: [
+    {
+      name: 'src',
+      type: 'string',
+      example:
+        '"https://upload.wikimedia.org/wikipedia/commons/f/fd/Ghostscript_Tiger.svg"'
+    }
+  ]
+};
 
 export default SVG;
-


### PR DESCRIPTION
This enables the use of the standard SVG tag in idyll markup, rather than forcing people to include SVGs as a separate file.

This is not a breaking change as behavior remains unchanged for use of `[SVG /]` tags where an SVG `src` is provided.