### PR TITLE
remove SVG warnings

### DIFF
--- a/packages/idyll-components/src/svg.js
+++ b/packages/idyll-components/src/svg.js
@@ -3,10 +3,11 @@ import InlineSVG from 'react-inlinesvg';
 
 class SVG extends React.PureComponent {
   render() {
+    const { hasError, updateProps, idyll, ...props } = this.props;
     if (!this.props.src) {
-      return <svg {...this.props} />;
+      return <svg {...props} />;
     }
-    return <InlineSVG {...this.props} />;
+    return <InlineSVG {...props} />;
   }
 }
 


### PR DESCRIPTION
Small fix to remove SVG warnings when using it as an HTML tag.