### PR TITLE
Fix issues for nested updates

### DIFF
--- a/packages/idyll-document/package.json
+++ b/packages/idyll-document/package.json
@@ -31,6 +31,7 @@
     "change-case": "^3.0.1",
     "cross-env": "^5.2.0",
     "falafel": "^2.1.0",
+    "fast-deep-equal": "^2.0.1",
     "html-tags": "^2.0.0",
     "idyll-compiler": "^3.3.1",
     "idyll-layouts": "^2.6.1",

--- a/packages/idyll-document/src/runtime.js
+++ b/packages/idyll-document/src/runtime.js
@@ -7,6 +7,7 @@ import entries from 'object.entries';
 import values from 'object.values';
 import { generatePlaceholder } from './components/placeholder';
 import AuthorTool from './components/author-tool';
+import equal from 'fast-deep-equal';
 
 import * as layouts from 'idyll-layouts';
 import * as themes from 'idyll-themes';
@@ -286,7 +287,7 @@ class IdyllRuntime extends React.PureComponent {
 
       const changedMap = {};
       const changedKeys = Object.keys(state).reduce((acc, k) => {
-        if (state[k] !== nextState[k]) {
+        if (!equal(state[k], nextState[k])) {
           acc.push(k);
           changedMap[k] = nextState[k] || state[k];
         }

--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -3,34 +3,72 @@ const entries = require('object.entries');
 const falafel = require('falafel');
 
 export const buildExpression = (acc, expr, key, context, isEventHandler) => {
+  let identifiers = [];
+  const modifiedExpression = falafel(
+    isEventHandler ? expr : `var __idyllReturnValue = ${expr || 'undefined'}`,
+    node => {
+      switch (node.type) {
+        case 'Identifier':
+          if (Object.keys(acc).indexOf(node.name) > -1) {
+            identifiers.push(node.name);
+            node.update('__idyllStateProxy.' + node.source());
+          }
+          break;
+      }
+    }
+  );
+
+  if (!isEventHandler) {
+    return `
+    ((context) => {
+      var __idyllStateProxy = new Proxy({}, {
+        get: (_, prop) => {
+          return context[prop];
+        },
+        set: (_, prop, value) => {
+          var newState = {};
+          newState[prop] = value;
+          context.update(newState);
+          return true;
+        }
+      });
+      ${modifiedExpression};
+      return __idyllReturnValue;
+    })(this)`;
+  }
+
   return `
     ((context) => {
-        var __idyllStateProxy = new Proxy({}, {
-          get: (_, prop) => {
-            return context[prop];
+        var __idyllExpressionExecuted = false;
+        var __idyllStateProxy = new Proxy({
+          ${identifiers
+            .map(key => {
+              return `${key}: __idyllCopy(context['${key}'])`;
+            })
+            .join(', ')}
+        }, {
+          get: (target, prop) => {
+            return target[prop];
           },
-          set: (_, prop, value) => {
-            var newState = {};
-            newState[prop] = value;
-            context.update(newState);
+          set: (target, prop, value) => {
+            if (__idyllExpressionExecuted) {
+              var newState = {};
+              newState[prop] = value;
+              context.update(newState);
+            }
+            target[prop] = value;
             return true;
           }
-        })
-        ${falafel(
-          isEventHandler
-            ? expr
-            : `var __idyllReturnValue = ${expr || 'undefined'}`,
-          node => {
-            switch (node.type) {
-              case 'Identifier':
-                if (Object.keys(acc).indexOf(node.name) > -1) {
-                  node.update('__idyllStateProxy.' + node.source());
-                }
-                break;
-            }
-          }
-        )};
-        ${isEventHandler ? '' : 'return __idyllReturnValue;'}
+        });
+        ${modifiedExpression};
+        context.update({
+          ${identifiers
+            .map(key => {
+              return `${key}: __idyllStateProxy['${key}']`;
+            })
+            .join(', ')}
+        });
+        __idyllExpressionExecuted = true;
     })(this)
   `;
 };
@@ -43,14 +81,30 @@ export const evalExpression = (acc, expr, key, context) => {
   if (isEventHandler) {
     return function() {
       eval(e);
-    }.bind(Object.assign({}, acc, context || {}));
+    }.bind(
+      Object.assign({}, acc, context || {}, {
+        __idyllCopy: function copy(o) {
+          if (typeof o !== 'object') return o;
+          var output, v, key;
+          output = Array.isArray(o) ? [] : {};
+          for (key in o) {
+            v = o[key];
+            output[key] = typeof v === 'object' ? copy(v) : v;
+          }
+          return output;
+        }
+      })
+    );
   }
 
   try {
     return function(evalString) {
       try {
         return eval('(' + evalString + ')');
-      } catch (err) {}
+      } catch (err) {
+        console.warn('Error occurred in Idyll expression');
+        console.error(err);
+      }
     }.call(Object.assign({}, acc, context || {}), e);
   } catch (err) {}
 };

--- a/packages/idyll-document/test/eval.js
+++ b/packages/idyll-document/test/eval.js
@@ -1,22 +1,21 @@
-
 import { buildExpression, evalExpression } from '../src/utils';
 
 const context = {
   setState: () => {
     console.log('setting state');
   }
-}
+};
 
-const whitespace = (str) => {
-  return str.trim().replace(/[\s\n\t]+/g, ' ')
-}
+const whitespace = str => {
+  return str.trim().replace(/[\s\n\t]+/g, ' ');
+};
 
 describe('Detect global variables', () => {
-
   it('Handles a basic variable', () => {
     const expression = buildExpression({ x: 10 }, `x`, 'key', context, false);
 
-    expect(whitespace(expression)).toBe(whitespace(`
+    expect(whitespace(expression)).toBe(
+      whitespace(`
       ((context) => {
         var __idyllStateProxy = new Proxy({}, {
           get: (_, prop) => {
@@ -28,17 +27,19 @@ describe('Detect global variables', () => {
             context.update(newState);
             return true;
           }
-        })
+        });
         var __idyllReturnValue = __idyllStateProxy.x;
         return __idyllReturnValue;
       })(this)
-    `));
-  })
+    `)
+    );
+  });
 
   it('Handles an empty string', () => {
     const expression = buildExpression({ x: 10 }, '', 'key', context, false);
 
-    expect(whitespace(expression)).toBe(whitespace(`
+    expect(whitespace(expression)).toBe(
+      whitespace(`
       ((context) => {
         var __idyllStateProxy = new Proxy({}, {
           get: (_, prop) => {
@@ -50,58 +51,96 @@ describe('Detect global variables', () => {
             context.update(newState);
             return true;
           }
-        })
+        });
         var __idyllReturnValue = undefined;
         return __idyllReturnValue;
       })(this)
-    `));
-  })
+    `)
+    );
+  });
 
   it('Evals a basic variable', () => {
     const output = evalExpression({ x: 10 }, `x`, 'key', context);
     expect(output).toBe(10);
-  })
+  });
 
   it('Handles an assignment to a variable ', () => {
-    const expression = buildExpression({ x: 10 }, `x = 20`, 'key', context, true);
+    const expression = buildExpression(
+      { x: 10 },
+      `x = 20`,
+      'key',
+      context,
+      true
+    );
 
-    expect(whitespace(expression)).toBe(whitespace(`
+    expect(whitespace(expression)).toBe(
+      whitespace(`
       ((context) => {
-        var __idyllStateProxy = new Proxy({}, {
-          get: (_, prop) => {
-            return context[prop];
+        var __idyllExpressionExecuted = false;
+        var __idyllStateProxy = new Proxy({
+          x: __idyllCopy(context['x'])
+        }, {
+          get: (target, prop) => {
+            return target[prop];
           },
-          set: (_, prop, value) => {
-            var newState = {};
-            newState[prop] = value;
-            context.update(newState);
+          set: (target, prop, value) => {
+            if (__idyllExpressionExecuted) {
+              var newState = {};
+              newState[prop] = value;
+              context.update(newState);
+            }
+            target[prop] = value;
             return true;
           }
-        })
+        });
         __idyllStateProxy.x = 20;
+        context.update({
+          x: __idyllStateProxy['x']
+        });
+        __idyllExpressionExecuted = true;
       })(this)
-    `));
-  })
+    `)
+    );
+  });
 
   it('Handles incrementers', () => {
-    const expression = buildExpression({ x: 10, y: 20 }, `x++; ++y`, 'key', context, true);
+    const expression = buildExpression(
+      { x: 10, y: 20 },
+      `x++; ++y`,
+      'key',
+      context,
+      true
+    );
 
-    expect(whitespace(expression)).toBe(whitespace(`
+    expect(whitespace(expression)).toBe(
+      whitespace(`
       ((context) => {
-        var __idyllStateProxy = new Proxy({}, {
-          get: (_, prop) => {
-            return context[prop];
+        var __idyllExpressionExecuted = false;
+        var __idyllStateProxy = new Proxy({
+          x: __idyllCopy(context['x']),
+          y: __idyllCopy(context['y'])
+        }, {
+          get: (target, prop) => {
+            return target[prop];
           },
-          set: (_, prop, value) => {
-            var newState = {};
-            newState[prop] = value;
-            context.update(newState);
+          set: (target, prop, value) => {
+            if (__idyllExpressionExecuted) {
+              var newState = {};
+              newState[prop] = value;
+              context.update(newState);
+            }
+            target[prop] = value;
             return true;
           }
-        })
+        });
         __idyllStateProxy.x++; ++__idyllStateProxy.y;
+        context.update({
+          x: __idyllStateProxy['x'],
+          y: __idyllStateProxy['y']
+        });
+        __idyllExpressionExecuted = true;
       })(this)
-    `));
-  })
-
+    `)
+    );
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3520,6 +3520,11 @@ fast-deep-equal@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
 
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"


### PR DESCRIPTION
This fixes issues where assignments to nested properties of objects or array indices weren't properly triggering re-renders on the page. This update fixes this so that the page properly updates when any values change, even deeply nested ones.