### PR TITLE
Add proper dev mode that watches for changes and rebuilds to all relevant packages.

### DIFF
--- a/packages/idyll-ast/package.json
+++ b/packages/idyll-ast/package.json
@@ -9,6 +9,7 @@
     "build:cjs": "cross-env BABEL_ENV=cjs babel src -d dist/cjs",
     "build:es": "cross-env BABEL_ENV=es babel src -d dist/es",
     "build": "npm run build:es && npm run build:cjs",
+    "dev": "concurrently \"yarn run build:es --watch\" \"yarn run build:cjs --watch\"",
     "test": "mocha",
     "prepublish": "npm run build",
     "prepublishOnly": "npm run build"
@@ -30,6 +31,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.6.0",
+    "concurrently": "^4.1.0",
     "cross-env": "^5.0.5",
     "expect.js": "^0.3.1",
     "mocha": "^3.2.0",

--- a/packages/idyll-compiler/package.json
+++ b/packages/idyll-compiler/package.json
@@ -10,7 +10,7 @@
     "build:es": "cross-env BABEL_ENV=es babel src -d dist/es",
     "compile": "nearleyc src/grammar.ne -o src/grammar.js",
     "build": "npm run compile && npm run build:es && npm run build:cjs",
-    "dev": "yarn run build:es --watch",
+    "dev": "concurrently \"yarn run build:es --watch\" \"yarn run build:cjs --watch\"",
     "test": "npm run compile && mocha",
     "prepublish": "npm run build",
     "prepublishOnly": "npm run build"
@@ -32,6 +32,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.6.0",
+    "concurrently": "^4.1.0",
     "cross-env": "^5.0.5",
     "expect.js": "^0.3.1",
     "mocha": "^3.2.0",

--- a/packages/idyll-components/package.json
+++ b/packages/idyll-components/package.json
@@ -9,7 +9,7 @@
     "build:cjs": "cross-env BABEL_ENV=cjs babel src -d dist/cjs",
     "build:es": "cross-env BABEL_ENV=es babel src -d dist/es",
     "build": "npm run build:cjs && npm run build:es",
-    "dev": "yarn run build:es --watch",
+    "dev": "concurrently \"yarn run build:es --watch\" \"yarn run build:cjs --watch\"",
     "prepublishOnly": "npm run build",
     "test": "jest"
   },

--- a/packages/idyll-components/package.json
+++ b/packages/idyll-components/package.json
@@ -63,6 +63,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.24.1",
+    "concurrently": "^4.1.0",
     "cross-env": "^5.0.5",
     "enzyme": "^3.0.0",
     "enzyme-adapter-react-16": "^1.0.0",

--- a/packages/idyll-layouts/package.json
+++ b/packages/idyll-layouts/package.json
@@ -9,7 +9,7 @@
     "build:cjs": "cross-env BABEL_ENV=cjs babel src -d dist/cjs",
     "build:es": "cross-env BABEL_ENV=es babel src -d dist/es",
     "build": "npm run build:cjs && npm run build:es",
-    "dev": "yarn run build:es --watch",
+    "dev": "concurrently \"yarn run build:es --watch\" \"yarn run build:cjs --watch\"",
     "prepublishOnly": "npm run build",
     "test": "jest"
   },
@@ -38,6 +38,7 @@
     "babel-cli": "6.26.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.0",
+    "concurrently": "^4.1.0",
     "cross-env": "^5.0.5",
     "jest": "^20.0.4",
     "rimraf": "^2.6.2"

--- a/packages/idyll-themes/package.json
+++ b/packages/idyll-themes/package.json
@@ -9,7 +9,7 @@
     "build:cjs": "cross-env BABEL_ENV=cjs babel src -d dist/cjs",
     "build:es": "cross-env BABEL_ENV=es babel src -d dist/es",
     "build": "npm run build:cjs && npm run build:es",
-    "dev": "yarn run build:es --watch",
+    "dev": "concurrently \"yarn run build:es --watch\" \"yarn run build:cjs --watch\"",
     "prepublishOnly": "npm run build",
     "test": "jest"
   },
@@ -38,6 +38,7 @@
     "babel-cli": "6.26.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.0",
+    "concurrently": "^4.1.0",
     "cross-env": "^5.0.5",
     "jest": "^20.0.4",
     "rimraf": "^2.6.2"


### PR DESCRIPTION
This PR updates the `dev` script in all of the relevant packages so that it works as expected: if you run `yarn run dev` in a package, any changes made to files in that package will be picked up and the files will automatically be compiled to both `cjs` and `es`. 

Needs to wait for #459 to land before merge as I started some of the changes while implementing that PR. 

/cc @manjhawar96 