### PR TITLE
fix bug in expression regarding refs and prop access

### DIFF
--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -12,7 +12,9 @@ export const buildExpression = (acc, expr, isEventHandler) => {
       node => {
         switch (node.type) {
           case 'Identifier':
-            if (Object.keys(acc).indexOf(node.name) > -1) {
+            const isPropertyAccess =
+              node.parent.source().indexOf(`.${node.name}`) > -1;
+            if (!isPropertyAccess && Object.keys(acc).indexOf(node.name) > -1) {
               identifiers.push(node.name);
               node.update('__idyllStateProxy.' + node.source());
             }
@@ -85,7 +87,6 @@ export const evalExpression = (acc, expr, key, context) => {
   const isEventHandler =
     key && (key.match(/^on[A-Z].*/) || key.match(/^handle[A-Z].*/));
   let e = buildExpression(acc, expr, isEventHandler);
-
   if (isEventHandler) {
     return function() {
       eval(e);


### PR DESCRIPTION
This fixes a bug when accessing properties in idyll expressions. They could incorrectly be replaced with a reference to the idyll proxy, which should only happen on top level variables.