### PR TITLE
update wrap targets to recalculate their props when they get rendered…

### DIFF
--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -206,6 +206,7 @@ export const filterIdyllProps = (props, filterInjected) => {
     __vars__,
     __expr__,
     hasHook,
+    initialState,
     isHTMLNode,
     refName,
     onEnterViewFully,


### PR DESCRIPTION
Fixes a bug where component state would get out of sync if they weren't displayed on the page in initial render. This would likely only come up if you were doing custom manipulation of some components children. 

This makes it so that components always update their state when they are initially rendered to the page.