### PR TITLE
Provide AST node reference to wrapper & authorview components

### DIFF
--- a/packages/idyll-document/src/runtime.js
+++ b/packages/idyll-document/src/runtime.js
@@ -213,6 +213,7 @@ const createWrapper = ({ theme, layout, authorView, userViewComponent }) => {
           const ViewComponent = userViewComponent || AuthorTool;
           return (
             <ViewComponent
+              idyllASTNode={this.props.idyllASTNode}
               component={returnComponent}
               authorComponent={childComponent}
               uniqueKey={uniqueKey}
@@ -380,10 +381,15 @@ class IdyllRuntime extends React.PureComponent {
         };
       }
       //Inspect for isHTMLNode  props and to check for dynamic components.
-      if (!wrapTargets.includes(node)) return node;
+      if (!wrapTargets.includes(node)) {
+        // Don't include the AST node reference on unwrapped components
+        const { idyllASTNode, ...rest } = node;
+        return rest;
+      }
       const {
         component,
         children,
+        idyllASTNode,
         key,
         __vars__ = {},
         __expr__ = {},
@@ -414,6 +420,7 @@ class IdyllRuntime extends React.PureComponent {
         component: Wrapper,
         __vars__,
         __expr__,
+        idyllASTNode,
         isHTMLNode: isHTMLNode,
         hasHook: node.hasHook,
         refName: node.refName,

--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -211,6 +211,7 @@ export const filterIdyllProps = (props, filterInjected) => {
   const {
     __vars__,
     __expr__,
+    idyllASTNode,
     hasHook,
     initialState,
     isHTMLNode,
@@ -290,8 +291,10 @@ export const scrollMonitorEvents = {
 };
 
 export const translate = ast => {
-  const attrConvert = props => {
-    let reducedProps = {};
+  const attrConvert = (props, node) => {
+    let reducedProps = {
+      idyllASTNode: node
+    };
     for (let propName in props) {
       const name = propName;
       const type = props[propName].type;
@@ -329,7 +332,7 @@ export const translate = ast => {
     const children = getChildren(node);
     return {
       component: name,
-      ...attrConvert(attrs),
+      ...attrConvert(attrs, node),
       children: children.map(tNode)
     };
   };

--- a/packages/idyll-document/test/__snapshots__/schema2element.js.snap
+++ b/packages/idyll-document/test/__snapshots__/schema2element.js.snap
@@ -4,30 +4,1132 @@ exports[`ReactJsonSchema can parse a schema 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <div>
-    <TextContainer>
-        <h1>
+    <TextContainer
+        idyllASTNode={
+            Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 12,
+                        "type": "textnode",
+                        "value": "Welcome to Idyll",
+                      },
+                    ],
+                    "id": 11,
+                    "name": "h1",
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 14,
+                        "type": "textnode",
+                        "value": "Idyll is a language for creating interactive documents on the web.",
+                      },
+                    ],
+                    "id": 13,
+                    "name": "h3",
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 16,
+                        "type": "textnode",
+                        "value": "This document is being rendered from ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 18,
+                            "type": "textnode",
+                            "value": "Idyll markup",
+                          },
+                        ],
+                        "id": 17,
+                        "name": "strong",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 19,
+                        "type": "textnode",
+                        "value": ". If you’ve used ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 21,
+                            "type": "textnode",
+                            "value": "markdown",
+                          },
+                        ],
+                        "id": 20,
+                        "name": "a",
+                        "properties": Object {
+                          "href": Object {
+                            "type": "value",
+                            "value": "https://daringfireball.net/projects/markdown/",
+                          },
+                        },
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 22,
+                        "type": "textnode",
+                        "value": ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.",
+                      },
+                    ],
+                    "id": 15,
+                    "name": "p",
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 24,
+                        "type": "textnode",
+                        "value": "To make things a little more interesting you can add JavaScript components to your text.
+            For example, a ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 26,
+                            "type": "textnode",
+                            "value": "[Chart /]",
+                          },
+                        ],
+                        "id": 25,
+                        "name": "code",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 27,
+                        "type": "textnode",
+                        "value": " component can be used to render a simple visualization:",
+                      },
+                    ],
+                    "id": 23,
+                    "name": "p",
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 28,
+                    "name": "Chart",
+                    "properties": Object {
+                      "type": Object {
+                        "type": "value",
+                        "value": "scatter",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 30,
+                        "type": "textnode",
+                        "value": "Try changing the chart’s type from ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 32,
+                            "type": "textnode",
+                            "value": "scatter",
+                          },
+                        ],
+                        "id": 31,
+                        "name": "code",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 33,
+                        "type": "textnode",
+                        "value": " to ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 35,
+                            "type": "textnode",
+                            "value": "line",
+                          },
+                        ],
+                        "id": 34,
+                        "name": "code",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 36,
+                        "type": "textnode",
+                        "value": ", ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 38,
+                            "type": "textnode",
+                            "value": "area",
+                          },
+                        ],
+                        "id": 37,
+                        "name": "code",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 39,
+                        "type": "textnode",
+                        "value": ", or ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 41,
+                            "type": "textnode",
+                            "value": "pie",
+                          },
+                        ],
+                        "id": 40,
+                        "name": "code",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 42,
+                        "type": "textnode",
+                        "value": ".",
+                      },
+                    ],
+                    "id": 29,
+                    "name": "p",
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 44,
+                        "type": "textnode",
+                        "value": "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 46,
+                            "type": "textnode",
+                            "value": "\`2 * Math.PI\`",
+                          },
+                        ],
+                        "id": 45,
+                        "name": "code",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 47,
+                        "type": "textnode",
+                        "value": ").",
+                      },
+                    ],
+                    "id": 43,
+                    "name": "p",
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 49,
+                        "type": "textnode",
+                        "value": "There are a number of components available — see ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 51,
+                            "type": "textnode",
+                            "value": "Idyll’s documentation",
+                          },
+                        ],
+                        "id": 50,
+                        "name": "a",
+                        "properties": Object {
+                          "href": Object {
+                            "type": "value",
+                            "value": "https://idyll-lang.github.io/components-built-in",
+                          },
+                        },
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 52,
+                        "type": "textnode",
+                        "value": " for a full list — Additional components can be installed via ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 54,
+                            "type": "textnode",
+                            "value": "npm",
+                          },
+                        ],
+                        "id": 53,
+                        "name": "code",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 55,
+                        "type": "textnode",
+                        "value": " (any React component should work), and if you are comfortable with JavaScript you can write ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 57,
+                            "type": "textnode",
+                            "value": "custom components",
+                          },
+                        ],
+                        "id": 56,
+                        "name": "a",
+                        "properties": Object {
+                          "href": Object {
+                            "type": "value",
+                            "value": "https://idyll-lang.github.io/components-custom",
+                          },
+                        },
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 58,
+                        "type": "textnode",
+                        "value": " as well.",
+                      },
+                    ],
+                    "id": 48,
+                    "name": "p",
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 60,
+                        "type": "textnode",
+                        "value": "Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.",
+                      },
+                    ],
+                    "id": 59,
+                    "name": "p",
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 62,
+                        "type": "textnode",
+                        "value": "Instantiating a variable is similar to instantiating a component:",
+                      },
+                    ],
+                    "id": 61,
+                    "name": "p",
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 64,
+                        "type": "textnode",
+                        "value": "[var name:\\"x\\" value:1 /]",
+                      },
+                    ],
+                    "id": 63,
+                    "name": "code",
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 66,
+                        "type": "textnode",
+                        "value": "Once you’ve created a variable, it can be displayed inline with text
+            (x = ",
+                      },
+                      Object {
+                        "children": Array [],
+                        "id": 67,
+                        "name": "Display",
+                        "properties": Object {
+                          "var": Object {
+                            "type": "variable",
+                            "value": "x",
+                          },
+                        },
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 68,
+                        "type": "textnode",
+                        "value": "),
+            or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:",
+                      },
+                    ],
+                    "id": 65,
+                    "name": "p",
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 70,
+                        "type": "textnode",
+                        "value": "[derived name:\\"xSquared\\" value:\`x * x\` /]",
+                      },
+                    ],
+                    "id": 69,
+                    "name": "code",
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 72,
+                        "type": "textnode",
+                        "value": "Here I bind the value of ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 74,
+                            "type": "textnode",
+                            "value": "x",
+                          },
+                        ],
+                        "id": 73,
+                        "name": "code",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 75,
+                        "type": "textnode",
+                        "value": " to a range slider. Move the slider and watch the variables update.",
+                      },
+                    ],
+                    "id": 71,
+                    "name": "p",
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 76,
+                    "name": "Range",
+                    "properties": Object {
+                      "max": Object {
+                        "type": "value",
+                        "value": 100,
+                      },
+                      "min": Object {
+                        "type": "value",
+                        "value": 0,
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "x",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 79,
+                            "type": "textnode",
+                            "value": "x",
+                          },
+                        ],
+                        "id": 78,
+                        "name": "equation",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 80,
+                        "type": "textnode",
+                        "value": ":
+             ",
+                      },
+                      Object {
+                        "children": Array [],
+                        "id": 81,
+                        "name": "Display",
+                        "properties": Object {
+                          "var": Object {
+                            "type": "expression",
+                            "value": "x",
+                          },
+                        },
+                        "type": "component",
+                      },
+                    ],
+                    "id": 77,
+                    "name": "p",
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 84,
+                            "type": "textnode",
+                            "value": "x^2",
+                          },
+                        ],
+                        "id": 83,
+                        "name": "equation",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 85,
+                        "type": "textnode",
+                        "value": ":",
+                      },
+                      Object {
+                        "children": Array [],
+                        "id": 86,
+                        "name": "Display",
+                        "properties": Object {
+                          "var": Object {
+                            "type": "expression",
+                            "value": "xSquared",
+                          },
+                        },
+                        "type": "component",
+                      },
+                    ],
+                    "id": 82,
+                    "name": "p",
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 88,
+                        "type": "textnode",
+                        "value": "Test expression, displays:",
+                      },
+                    ],
+                    "id": 87,
+                    "name": "p",
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 89,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "varDisplay",
+                      },
+                      "value": Object {
+                        "type": "expression",
+                        "value": "x",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 90,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "derivedVarDisplay",
+                      },
+                      "value": Object {
+                        "type": "expression",
+                        "value": "xSquared",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 91,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "derivedVarDisplay2",
+                      },
+                      "value": Object {
+                        "type": "expression",
+                        "value": "xCubed",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 92,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "strDisplay",
+                      },
+                      "value": Object {
+                        "type": "expression",
+                        "value": "\\"string\\"",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 93,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "staticObjectDisplay",
+                      },
+                      "value": Object {
+                        "type": "expression",
+                        "value": "{ static: \\"object\\" }",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 94,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "dynamicObjectDisplay",
+                      },
+                      "value": Object {
+                        "type": "expression",
+                        "value": "{ dynamic: x }",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 95,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "dataDisplay",
+                      },
+                      "value": Object {
+                        "type": "expression",
+                        "value": "myData",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 96,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "bareDataDisplay",
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "myData",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 97,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "bareVarDisplay",
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "x",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 98,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "bareDerivedDisplay",
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "xSquared",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 99,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "bareDerivedDisplay2",
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "xCubed",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 100,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "objectVarDisplay",
+                      },
+                      "value": Object {
+                        "type": "expression",
+                        "value": " objectVar ",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 101,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "bareObjectVarDisplay",
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "objectVar",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 102,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "arrayVarDisplay",
+                      },
+                      "value": Object {
+                        "type": "expression",
+                        "value": " arrayVar ",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 103,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "bareArrayVarDisplay",
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "arrayVar",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 104,
+                    "name": "br",
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 106,
+                        "type": "textnode",
+                        "value": "Here is an example of how you could use a variable to control the frequency of a sine wave:",
+                      },
+                    ],
+                    "id": 105,
+                    "name": "p",
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 107,
+                    "name": "Chart",
+                    "properties": Object {
+                      "domain": Object {
+                        "type": "expression",
+                        "value": "[0, 2 * Math.PI]",
+                      },
+                      "equation": Object {
+                        "type": "expression",
+                        "value": "(t) => Math.sin(t * frequency)",
+                      },
+                      "samplePoints": Object {
+                        "type": "value",
+                        "value": 1000,
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 108,
+                    "name": "Range",
+                    "properties": Object {
+                      "max": Object {
+                        "type": "expression",
+                        "value": "2 * Math.PI",
+                      },
+                      "min": Object {
+                        "type": "value",
+                        "value": 0.5,
+                      },
+                      "step": Object {
+                        "type": "value",
+                        "value": 0.0001,
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "frequency",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "children": Array [],
+                        "id": 110,
+                        "name": "Display",
+                        "properties": Object {
+                          "id": Object {
+                            "type": "value",
+                            "value": "lateVarDisplay",
+                          },
+                          "value": Object {
+                            "type": "variable",
+                            "value": "lateVar",
+                          },
+                        },
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 111,
+                        "type": "textnode",
+                        "value": "
+            Late Var Range:",
+                      },
+                    ],
+                    "id": 109,
+                    "name": "p",
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 112,
+                    "name": "Range",
+                    "properties": Object {
+                      "max": Object {
+                        "type": "value",
+                        "value": 100,
+                      },
+                      "min": Object {
+                        "type": "value",
+                        "value": 2,
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "lateVar",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 114,
+                        "type": "textnode",
+                        "value": "Read more about Idyll at ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 116,
+                            "type": "textnode",
+                            "value": "https://idyll-lang.github.io/",
+                          },
+                        ],
+                        "id": 115,
+                        "name": "a",
+                        "properties": Object {
+                          "href": Object {
+                            "type": "value",
+                            "value": "https://idyll-lang.github.io/",
+                          },
+                        },
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 117,
+                        "type": "textnode",
+                        "value": ", and come say “Hi!” in our ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 119,
+                            "type": "textnode",
+                            "value": "chatroom on gitter",
+                          },
+                        ],
+                        "id": 118,
+                        "name": "a",
+                        "properties": Object {
+                          "href": Object {
+                            "type": "value",
+                            "value": "https://gitter.im/idyll-lang/Lobby",
+                          },
+                        },
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 120,
+                        "type": "textnode",
+                        "value": ".",
+                      },
+                    ],
+                    "id": 113,
+                    "name": "p",
+                    "type": "component",
+                  },
+                ],
+                "id": 10,
+                "name": "TextContainer",
+                "type": "component",
+              }
+        }
+    >
+        <h1
+            idyllASTNode={
+                Object {
+                    "children": Array [
+                      Object {
+                        "id": 12,
+                        "type": "textnode",
+                        "value": "Welcome to Idyll",
+                      },
+                    ],
+                    "id": 11,
+                    "name": "h1",
+                    "type": "component",
+                  }
+            }
+        >
             Welcome to Idyll
         </h1>
-        <h3>
+        <h3
+            idyllASTNode={
+                Object {
+                    "children": Array [
+                      Object {
+                        "id": 14,
+                        "type": "textnode",
+                        "value": "Idyll is a language for creating interactive documents on the web.",
+                      },
+                    ],
+                    "id": 13,
+                    "name": "h3",
+                    "type": "component",
+                  }
+            }
+        >
             Idyll is a language for creating interactive documents on the web.
         </h3>
-        <p>
+        <p
+            idyllASTNode={
+                Object {
+                    "children": Array [
+                      Object {
+                        "id": 16,
+                        "type": "textnode",
+                        "value": "This document is being rendered from ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 18,
+                            "type": "textnode",
+                            "value": "Idyll markup",
+                          },
+                        ],
+                        "id": 17,
+                        "name": "strong",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 19,
+                        "type": "textnode",
+                        "value": ". If you’ve used ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 21,
+                            "type": "textnode",
+                            "value": "markdown",
+                          },
+                        ],
+                        "id": 20,
+                        "name": "a",
+                        "properties": Object {
+                          "href": Object {
+                            "type": "value",
+                            "value": "https://daringfireball.net/projects/markdown/",
+                          },
+                        },
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 22,
+                        "type": "textnode",
+                        "value": ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.",
+                      },
+                    ],
+                    "id": 15,
+                    "name": "p",
+                    "type": "component",
+                  }
+            }
+        >
             This document is being rendered from 
-            <strong>
+            <strong
+                idyllASTNode={
+                    Object {
+                        "children": Array [
+                          Object {
+                            "id": 18,
+                            "type": "textnode",
+                            "value": "Idyll markup",
+                          },
+                        ],
+                        "id": 17,
+                        "name": "strong",
+                        "type": "component",
+                      }
+                }
+            >
                 Idyll markup
             </strong>
             . If you’ve used 
             <a
                 href="https://daringfireball.net/projects/markdown/"
+                idyllASTNode={
+                    Object {
+                        "children": Array [
+                          Object {
+                            "id": 21,
+                            "type": "textnode",
+                            "value": "markdown",
+                          },
+                        ],
+                        "id": 20,
+                        "name": "a",
+                        "properties": Object {
+                          "href": Object {
+                            "type": "value",
+                            "value": "https://daringfireball.net/projects/markdown/",
+                          },
+                        },
+                        "type": "component",
+                      }
+                }
             >
                 markdown
             </a>
             , Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.
         </p>
-        <p>
+        <p
+            idyllASTNode={
+                Object {
+                    "children": Array [
+                      Object {
+                        "id": 24,
+                        "type": "textnode",
+                        "value": "To make things a little more interesting you can add JavaScript components to your text.
+                For example, a ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 26,
+                            "type": "textnode",
+                            "value": "[Chart /]",
+                          },
+                        ],
+                        "id": 25,
+                        "name": "code",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 27,
+                        "type": "textnode",
+                        "value": " component can be used to render a simple visualization:",
+                      },
+                    ],
+                    "id": 23,
+                    "name": "p",
+                    "type": "component",
+                  }
+            }
+        >
             To make things a little more interesting you can add JavaScript components to your text.
             For example, a 
-            <code>
+            <code
+                idyllASTNode={
+                    Object {
+                        "children": Array [
+                          Object {
+                            "id": 26,
+                            "type": "textnode",
+                            "value": "[Chart /]",
+                          },
+                        ],
+                        "id": 25,
+                        "name": "code",
+                        "type": "component",
+                      }
+                }
+            >
                 [Chart /]
             </code>
              component can be used to render a simple visualization:
@@ -40,6 +1142,20 @@ ShallowWrapper {
                   ]
             }
             domainPadding={0}
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 28,
+                    "name": "Chart",
+                    "properties": Object {
+                      "type": Object {
+                        "type": "value",
+                        "value": "scatter",
+                      },
+                    },
+                    "type": "component",
+                  }
+            }
             range={
                 Array [
                     -1,
@@ -49,61 +1165,463 @@ ShallowWrapper {
             samplePoints={100}
             type="scatter"
         />
-        <p>
+        <p
+            idyllASTNode={
+                Object {
+                    "children": Array [
+                      Object {
+                        "id": 30,
+                        "type": "textnode",
+                        "value": "Try changing the chart’s type from ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 32,
+                            "type": "textnode",
+                            "value": "scatter",
+                          },
+                        ],
+                        "id": 31,
+                        "name": "code",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 33,
+                        "type": "textnode",
+                        "value": " to ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 35,
+                            "type": "textnode",
+                            "value": "line",
+                          },
+                        ],
+                        "id": 34,
+                        "name": "code",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 36,
+                        "type": "textnode",
+                        "value": ", ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 38,
+                            "type": "textnode",
+                            "value": "area",
+                          },
+                        ],
+                        "id": 37,
+                        "name": "code",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 39,
+                        "type": "textnode",
+                        "value": ", or ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 41,
+                            "type": "textnode",
+                            "value": "pie",
+                          },
+                        ],
+                        "id": 40,
+                        "name": "code",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 42,
+                        "type": "textnode",
+                        "value": ".",
+                      },
+                    ],
+                    "id": 29,
+                    "name": "p",
+                    "type": "component",
+                  }
+            }
+        >
             Try changing the chart’s type from 
-            <code>
+            <code
+                idyllASTNode={
+                    Object {
+                        "children": Array [
+                          Object {
+                            "id": 32,
+                            "type": "textnode",
+                            "value": "scatter",
+                          },
+                        ],
+                        "id": 31,
+                        "name": "code",
+                        "type": "component",
+                      }
+                }
+            >
                 scatter
             </code>
              to 
-            <code>
+            <code
+                idyllASTNode={
+                    Object {
+                        "children": Array [
+                          Object {
+                            "id": 35,
+                            "type": "textnode",
+                            "value": "line",
+                          },
+                        ],
+                        "id": 34,
+                        "name": "code",
+                        "type": "component",
+                      }
+                }
+            >
                 line
             </code>
             , 
-            <code>
+            <code
+                idyllASTNode={
+                    Object {
+                        "children": Array [
+                          Object {
+                            "id": 38,
+                            "type": "textnode",
+                            "value": "area",
+                          },
+                        ],
+                        "id": 37,
+                        "name": "code",
+                        "type": "component",
+                      }
+                }
+            >
                 area
             </code>
             , or 
-            <code>
+            <code
+                idyllASTNode={
+                    Object {
+                        "children": Array [
+                          Object {
+                            "id": 41,
+                            "type": "textnode",
+                            "value": "pie",
+                          },
+                        ],
+                        "id": 40,
+                        "name": "code",
+                        "type": "component",
+                      }
+                }
+            >
                 pie
             </code>
             .
         </p>
-        <p>
+        <p
+            idyllASTNode={
+                Object {
+                    "children": Array [
+                      Object {
+                        "id": 44,
+                        "type": "textnode",
+                        "value": "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 46,
+                            "type": "textnode",
+                            "value": "\`2 * Math.PI\`",
+                          },
+                        ],
+                        "id": 45,
+                        "name": "code",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 47,
+                        "type": "textnode",
+                        "value": ").",
+                      },
+                    ],
+                    "id": 43,
+                    "name": "p",
+                    "type": "component",
+                  }
+            }
+        >
             A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (
-            <code>
+            <code
+                idyllASTNode={
+                    Object {
+                        "children": Array [
+                          Object {
+                            "id": 46,
+                            "type": "textnode",
+                            "value": "\`2 * Math.PI\`",
+                          },
+                        ],
+                        "id": 45,
+                        "name": "code",
+                        "type": "component",
+                      }
+                }
+            >
                 \`2 * Math.PI\`
             </code>
             ).
         </p>
-        <p>
+        <p
+            idyllASTNode={
+                Object {
+                    "children": Array [
+                      Object {
+                        "id": 49,
+                        "type": "textnode",
+                        "value": "There are a number of components available — see ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 51,
+                            "type": "textnode",
+                            "value": "Idyll’s documentation",
+                          },
+                        ],
+                        "id": 50,
+                        "name": "a",
+                        "properties": Object {
+                          "href": Object {
+                            "type": "value",
+                            "value": "https://idyll-lang.github.io/components-built-in",
+                          },
+                        },
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 52,
+                        "type": "textnode",
+                        "value": " for a full list — Additional components can be installed via ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 54,
+                            "type": "textnode",
+                            "value": "npm",
+                          },
+                        ],
+                        "id": 53,
+                        "name": "code",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 55,
+                        "type": "textnode",
+                        "value": " (any React component should work), and if you are comfortable with JavaScript you can write ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 57,
+                            "type": "textnode",
+                            "value": "custom components",
+                          },
+                        ],
+                        "id": 56,
+                        "name": "a",
+                        "properties": Object {
+                          "href": Object {
+                            "type": "value",
+                            "value": "https://idyll-lang.github.io/components-custom",
+                          },
+                        },
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 58,
+                        "type": "textnode",
+                        "value": " as well.",
+                      },
+                    ],
+                    "id": 48,
+                    "name": "p",
+                    "type": "component",
+                  }
+            }
+        >
             There are a number of components available — see 
             <a
                 href="https://idyll-lang.github.io/components-built-in"
+                idyllASTNode={
+                    Object {
+                        "children": Array [
+                          Object {
+                            "id": 51,
+                            "type": "textnode",
+                            "value": "Idyll’s documentation",
+                          },
+                        ],
+                        "id": 50,
+                        "name": "a",
+                        "properties": Object {
+                          "href": Object {
+                            "type": "value",
+                            "value": "https://idyll-lang.github.io/components-built-in",
+                          },
+                        },
+                        "type": "component",
+                      }
+                }
             >
                 Idyll’s documentation
             </a>
              for a full list — Additional components can be installed via 
-            <code>
+            <code
+                idyllASTNode={
+                    Object {
+                        "children": Array [
+                          Object {
+                            "id": 54,
+                            "type": "textnode",
+                            "value": "npm",
+                          },
+                        ],
+                        "id": 53,
+                        "name": "code",
+                        "type": "component",
+                      }
+                }
+            >
                 npm
             </code>
              (any React component should work), and if you are comfortable with JavaScript you can write 
             <a
                 href="https://idyll-lang.github.io/components-custom"
+                idyllASTNode={
+                    Object {
+                        "children": Array [
+                          Object {
+                            "id": 57,
+                            "type": "textnode",
+                            "value": "custom components",
+                          },
+                        ],
+                        "id": 56,
+                        "name": "a",
+                        "properties": Object {
+                          "href": Object {
+                            "type": "value",
+                            "value": "https://idyll-lang.github.io/components-custom",
+                          },
+                        },
+                        "type": "component",
+                      }
+                }
             >
                 custom components
             </a>
              as well.
         </p>
-        <p>
+        <p
+            idyllASTNode={
+                Object {
+                    "children": Array [
+                      Object {
+                        "id": 60,
+                        "type": "textnode",
+                        "value": "Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.",
+                      },
+                    ],
+                    "id": 59,
+                    "name": "p",
+                    "type": "component",
+                  }
+            }
+        >
             Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.
         </p>
-        <p>
+        <p
+            idyllASTNode={
+                Object {
+                    "children": Array [
+                      Object {
+                        "id": 62,
+                        "type": "textnode",
+                        "value": "Instantiating a variable is similar to instantiating a component:",
+                      },
+                    ],
+                    "id": 61,
+                    "name": "p",
+                    "type": "component",
+                  }
+            }
+        >
             Instantiating a variable is similar to instantiating a component:
         </p>
-        <code>
+        <code
+            idyllASTNode={
+                Object {
+                    "children": Array [
+                      Object {
+                        "id": 64,
+                        "type": "textnode",
+                        "value": "[var name:\\"x\\" value:1 /]",
+                      },
+                    ],
+                    "id": 63,
+                    "name": "code",
+                    "type": "component",
+                  }
+            }
+        >
             [var name:"x" value:1 /]
         </code>
-        <p>
+        <p
+            idyllASTNode={
+                Object {
+                    "children": Array [
+                      Object {
+                        "id": 66,
+                        "type": "textnode",
+                        "value": "Once you’ve created a variable, it can be displayed inline with text
+                (x = ",
+                      },
+                      Object {
+                        "children": Array [],
+                        "id": 67,
+                        "name": "Display",
+                        "properties": Object {
+                          "var": Object {
+                            "type": "variable",
+                            "value": "x",
+                          },
+                        },
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 68,
+                        "type": "textnode",
+                        "value": "),
+                or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:",
+                      },
+                    ],
+                    "id": 65,
+                    "name": "p",
+                    "type": "component",
+                  }
+            }
+        >
             Once you’ve created a variable, it can be displayed inline with text
             (x = 
             <Display
@@ -112,17 +1630,93 @@ ShallowWrapper {
                         "var": "x",
                       }
                 }
+                idyllASTNode={
+                    Object {
+                        "children": Array [],
+                        "id": 67,
+                        "name": "Display",
+                        "properties": Object {
+                          "var": Object {
+                            "type": "variable",
+                            "value": "x",
+                          },
+                        },
+                        "type": "component",
+                      }
+                }
                 var="x"
             />
             ),
             or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:
         </p>
-        <code>
+        <code
+            idyllASTNode={
+                Object {
+                    "children": Array [
+                      Object {
+                        "id": 70,
+                        "type": "textnode",
+                        "value": "[derived name:\\"xSquared\\" value:\`x * x\` /]",
+                      },
+                    ],
+                    "id": 69,
+                    "name": "code",
+                    "type": "component",
+                  }
+            }
+        >
             [derived name:"xSquared" value:\`x * x\` /]
         </code>
-        <p>
+        <p
+            idyllASTNode={
+                Object {
+                    "children": Array [
+                      Object {
+                        "id": 72,
+                        "type": "textnode",
+                        "value": "Here I bind the value of ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 74,
+                            "type": "textnode",
+                            "value": "x",
+                          },
+                        ],
+                        "id": 73,
+                        "name": "code",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 75,
+                        "type": "textnode",
+                        "value": " to a range slider. Move the slider and watch the variables update.",
+                      },
+                    ],
+                    "id": 71,
+                    "name": "p",
+                    "type": "component",
+                  }
+            }
+        >
             Here I bind the value of 
-            <code>
+            <code
+                idyllASTNode={
+                    Object {
+                        "children": Array [
+                          Object {
+                            "id": 74,
+                            "type": "textnode",
+                            "value": "x",
+                          },
+                        ],
+                        "id": 73,
+                        "name": "code",
+                        "type": "component",
+                      }
+                }
+            >
                 x
             </code>
              to a range slider. Move the slider and watch the variables update.
@@ -133,13 +1727,90 @@ ShallowWrapper {
                     "value": "x",
                   }
             }
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 76,
+                    "name": "Range",
+                    "properties": Object {
+                      "max": Object {
+                        "type": "value",
+                        "value": 100,
+                      },
+                      "min": Object {
+                        "type": "value",
+                        "value": 0,
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "x",
+                      },
+                    },
+                    "type": "component",
+                  }
+            }
             max={100}
             min={0}
             step={1}
             value="x"
         />
-        <p>
-            <Equation>
+        <p
+            idyllASTNode={
+                Object {
+                    "children": Array [
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 79,
+                            "type": "textnode",
+                            "value": "x",
+                          },
+                        ],
+                        "id": 78,
+                        "name": "equation",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 80,
+                        "type": "textnode",
+                        "value": ":
+                 ",
+                      },
+                      Object {
+                        "children": Array [],
+                        "id": 81,
+                        "name": "Display",
+                        "properties": Object {
+                          "var": Object {
+                            "type": "expression",
+                            "value": "x",
+                          },
+                        },
+                        "type": "component",
+                      },
+                    ],
+                    "id": 77,
+                    "name": "p",
+                    "type": "component",
+                  }
+            }
+        >
+            <Equation
+                idyllASTNode={
+                    Object {
+                        "children": Array [
+                          Object {
+                            "id": 79,
+                            "type": "textnode",
+                            "value": "x",
+                          },
+                        ],
+                        "id": 78,
+                        "name": "equation",
+                        "type": "component",
+                      }
+                }
+            >
                 x
             </Equation>
             :
@@ -150,11 +1821,79 @@ ShallowWrapper {
                         "var": "x",
                       }
                 }
+                idyllASTNode={
+                    Object {
+                        "children": Array [],
+                        "id": 81,
+                        "name": "Display",
+                        "properties": Object {
+                          "var": Object {
+                            "type": "expression",
+                            "value": "x",
+                          },
+                        },
+                        "type": "component",
+                      }
+                }
                 var="x"
             />
         </p>
-        <p>
-            <Equation>
+        <p
+            idyllASTNode={
+                Object {
+                    "children": Array [
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 84,
+                            "type": "textnode",
+                            "value": "x^2",
+                          },
+                        ],
+                        "id": 83,
+                        "name": "equation",
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 85,
+                        "type": "textnode",
+                        "value": ":",
+                      },
+                      Object {
+                        "children": Array [],
+                        "id": 86,
+                        "name": "Display",
+                        "properties": Object {
+                          "var": Object {
+                            "type": "expression",
+                            "value": "xSquared",
+                          },
+                        },
+                        "type": "component",
+                      },
+                    ],
+                    "id": 82,
+                    "name": "p",
+                    "type": "component",
+                  }
+            }
+        >
+            <Equation
+                idyllASTNode={
+                    Object {
+                        "children": Array [
+                          Object {
+                            "id": 84,
+                            "type": "textnode",
+                            "value": "x^2",
+                          },
+                        ],
+                        "id": 83,
+                        "name": "equation",
+                        "type": "component",
+                      }
+                }
+            >
                 x^2
             </Equation>
             :
@@ -164,10 +1903,39 @@ ShallowWrapper {
                         "var": "xSquared",
                       }
                 }
+                idyllASTNode={
+                    Object {
+                        "children": Array [],
+                        "id": 86,
+                        "name": "Display",
+                        "properties": Object {
+                          "var": Object {
+                            "type": "expression",
+                            "value": "xSquared",
+                          },
+                        },
+                        "type": "component",
+                      }
+                }
                 var="xSquared"
             />
         </p>
-        <p>
+        <p
+            idyllASTNode={
+                Object {
+                    "children": Array [
+                      Object {
+                        "id": 88,
+                        "type": "textnode",
+                        "value": "Test expression, displays:",
+                      },
+                    ],
+                    "id": 87,
+                    "name": "p",
+                    "type": "component",
+                  }
+            }
+        >
             Test expression, displays:
         </p>
         <Display
@@ -177,6 +1945,24 @@ ShallowWrapper {
                   }
             }
             id="varDisplay"
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 89,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "varDisplay",
+                      },
+                      "value": Object {
+                        "type": "expression",
+                        "value": "x",
+                      },
+                    },
+                    "type": "component",
+                  }
+            }
             value="x"
         />
         <Display
@@ -186,6 +1972,24 @@ ShallowWrapper {
                   }
             }
             id="derivedVarDisplay"
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 90,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "derivedVarDisplay",
+                      },
+                      "value": Object {
+                        "type": "expression",
+                        "value": "xSquared",
+                      },
+                    },
+                    "type": "component",
+                  }
+            }
             value="xSquared"
         />
         <Display
@@ -195,6 +1999,24 @@ ShallowWrapper {
                   }
             }
             id="derivedVarDisplay2"
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 91,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "derivedVarDisplay2",
+                      },
+                      "value": Object {
+                        "type": "expression",
+                        "value": "xCubed",
+                      },
+                    },
+                    "type": "component",
+                  }
+            }
             value="xCubed"
         />
         <Display
@@ -204,6 +2026,24 @@ ShallowWrapper {
                   }
             }
             id="strDisplay"
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 92,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "strDisplay",
+                      },
+                      "value": Object {
+                        "type": "expression",
+                        "value": "\\"string\\"",
+                      },
+                    },
+                    "type": "component",
+                  }
+            }
             value="\\"string\\""
         />
         <Display
@@ -213,6 +2053,24 @@ ShallowWrapper {
                   }
             }
             id="staticObjectDisplay"
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 93,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "staticObjectDisplay",
+                      },
+                      "value": Object {
+                        "type": "expression",
+                        "value": "{ static: \\"object\\" }",
+                      },
+                    },
+                    "type": "component",
+                  }
+            }
             value="{ static: \\"object\\" }"
         />
         <Display
@@ -222,6 +2080,24 @@ ShallowWrapper {
                   }
             }
             id="dynamicObjectDisplay"
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 94,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "dynamicObjectDisplay",
+                      },
+                      "value": Object {
+                        "type": "expression",
+                        "value": "{ dynamic: x }",
+                      },
+                    },
+                    "type": "component",
+                  }
+            }
             value="{ dynamic: x }"
         />
         <Display
@@ -231,6 +2107,24 @@ ShallowWrapper {
                   }
             }
             id="dataDisplay"
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 95,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "dataDisplay",
+                      },
+                      "value": Object {
+                        "type": "expression",
+                        "value": "myData",
+                      },
+                    },
+                    "type": "component",
+                  }
+            }
             value="myData"
         />
         <Display
@@ -240,6 +2134,24 @@ ShallowWrapper {
                   }
             }
             id="bareDataDisplay"
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 96,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "bareDataDisplay",
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "myData",
+                      },
+                    },
+                    "type": "component",
+                  }
+            }
             value="myData"
         />
         <Display
@@ -249,6 +2161,24 @@ ShallowWrapper {
                   }
             }
             id="bareVarDisplay"
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 97,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "bareVarDisplay",
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "x",
+                      },
+                    },
+                    "type": "component",
+                  }
+            }
             value="x"
         />
         <Display
@@ -258,6 +2188,24 @@ ShallowWrapper {
                   }
             }
             id="bareDerivedDisplay"
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 98,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "bareDerivedDisplay",
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "xSquared",
+                      },
+                    },
+                    "type": "component",
+                  }
+            }
             value="xSquared"
         />
         <Display
@@ -267,6 +2215,24 @@ ShallowWrapper {
                   }
             }
             id="bareDerivedDisplay2"
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 99,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "bareDerivedDisplay2",
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "xCubed",
+                      },
+                    },
+                    "type": "component",
+                  }
+            }
             value="xCubed"
         />
         <Display
@@ -276,6 +2242,24 @@ ShallowWrapper {
                   }
             }
             id="objectVarDisplay"
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 100,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "objectVarDisplay",
+                      },
+                      "value": Object {
+                        "type": "expression",
+                        "value": " objectVar ",
+                      },
+                    },
+                    "type": "component",
+                  }
+            }
             value=" objectVar "
         />
         <Display
@@ -285,6 +2269,24 @@ ShallowWrapper {
                   }
             }
             id="bareObjectVarDisplay"
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 101,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "bareObjectVarDisplay",
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "objectVar",
+                      },
+                    },
+                    "type": "component",
+                  }
+            }
             value="objectVar"
         />
         <Display
@@ -294,6 +2296,24 @@ ShallowWrapper {
                   }
             }
             id="arrayVarDisplay"
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 102,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "arrayVarDisplay",
+                      },
+                      "value": Object {
+                        "type": "expression",
+                        "value": " arrayVar ",
+                      },
+                    },
+                    "type": "component",
+                  }
+            }
             value=" arrayVar "
         />
         <Display
@@ -303,10 +2323,52 @@ ShallowWrapper {
                   }
             }
             id="bareArrayVarDisplay"
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 103,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "bareArrayVarDisplay",
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "arrayVar",
+                      },
+                    },
+                    "type": "component",
+                  }
+            }
             value="arrayVar"
         />
-        <br />
-        <p>
+        <br
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 104,
+                    "name": "br",
+                    "type": "component",
+                  }
+            }
+        />
+        <p
+            idyllASTNode={
+                Object {
+                    "children": Array [
+                      Object {
+                        "id": 106,
+                        "type": "textnode",
+                        "value": "Here is an example of how you could use a variable to control the frequency of a sine wave:",
+                      },
+                    ],
+                    "id": 105,
+                    "name": "p",
+                    "type": "component",
+                  }
+            }
+        >
             Here is an example of how you could use a variable to control the frequency of a sine wave:
         </p>
         <Chart
@@ -319,6 +2381,28 @@ ShallowWrapper {
             domain="[0, 2 * Math.PI]"
             domainPadding={0}
             equation="(t) => Math.sin(t * frequency)"
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 107,
+                    "name": "Chart",
+                    "properties": Object {
+                      "domain": Object {
+                        "type": "expression",
+                        "value": "[0, 2 * Math.PI]",
+                      },
+                      "equation": Object {
+                        "type": "expression",
+                        "value": "(t) => Math.sin(t * frequency)",
+                      },
+                      "samplePoints": Object {
+                        "type": "value",
+                        "value": 1000,
+                      },
+                    },
+                    "type": "component",
+                  }
+            }
             range={
                 Array [
                     -1,
@@ -339,12 +2423,70 @@ ShallowWrapper {
                     "value": "frequency",
                   }
             }
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 108,
+                    "name": "Range",
+                    "properties": Object {
+                      "max": Object {
+                        "type": "expression",
+                        "value": "2 * Math.PI",
+                      },
+                      "min": Object {
+                        "type": "value",
+                        "value": 0.5,
+                      },
+                      "step": Object {
+                        "type": "value",
+                        "value": 0.0001,
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "frequency",
+                      },
+                    },
+                    "type": "component",
+                  }
+            }
             max="2 * Math.PI"
             min={0.5}
             step={0.0001}
             value="frequency"
         />
-        <p>
+        <p
+            idyllASTNode={
+                Object {
+                    "children": Array [
+                      Object {
+                        "children": Array [],
+                        "id": 110,
+                        "name": "Display",
+                        "properties": Object {
+                          "id": Object {
+                            "type": "value",
+                            "value": "lateVarDisplay",
+                          },
+                          "value": Object {
+                            "type": "variable",
+                            "value": "lateVar",
+                          },
+                        },
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 111,
+                        "type": "textnode",
+                        "value": "
+                Late Var Range:",
+                      },
+                    ],
+                    "id": 109,
+                    "name": "p",
+                    "type": "component",
+                  }
+            }
+        >
             <Display
                 __vars__={
                     Object {
@@ -352,6 +2494,24 @@ ShallowWrapper {
                       }
                 }
                 id="lateVarDisplay"
+                idyllASTNode={
+                    Object {
+                        "children": Array [],
+                        "id": 110,
+                        "name": "Display",
+                        "properties": Object {
+                          "id": Object {
+                            "type": "value",
+                            "value": "lateVarDisplay",
+                          },
+                          "value": Object {
+                            "type": "variable",
+                            "value": "lateVar",
+                          },
+                        },
+                        "type": "component",
+                      }
+                }
                 value="lateVar"
             />
             
@@ -363,21 +2523,144 @@ ShallowWrapper {
                     "value": "lateVar",
                   }
             }
+            idyllASTNode={
+                Object {
+                    "children": Array [],
+                    "id": 112,
+                    "name": "Range",
+                    "properties": Object {
+                      "max": Object {
+                        "type": "value",
+                        "value": 100,
+                      },
+                      "min": Object {
+                        "type": "value",
+                        "value": 2,
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "lateVar",
+                      },
+                    },
+                    "type": "component",
+                  }
+            }
             max={100}
             min={2}
             step={1}
             value="lateVar"
         />
-        <p>
+        <p
+            idyllASTNode={
+                Object {
+                    "children": Array [
+                      Object {
+                        "id": 114,
+                        "type": "textnode",
+                        "value": "Read more about Idyll at ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 116,
+                            "type": "textnode",
+                            "value": "https://idyll-lang.github.io/",
+                          },
+                        ],
+                        "id": 115,
+                        "name": "a",
+                        "properties": Object {
+                          "href": Object {
+                            "type": "value",
+                            "value": "https://idyll-lang.github.io/",
+                          },
+                        },
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 117,
+                        "type": "textnode",
+                        "value": ", and come say “Hi!” in our ",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "id": 119,
+                            "type": "textnode",
+                            "value": "chatroom on gitter",
+                          },
+                        ],
+                        "id": 118,
+                        "name": "a",
+                        "properties": Object {
+                          "href": Object {
+                            "type": "value",
+                            "value": "https://gitter.im/idyll-lang/Lobby",
+                          },
+                        },
+                        "type": "component",
+                      },
+                      Object {
+                        "id": 120,
+                        "type": "textnode",
+                        "value": ".",
+                      },
+                    ],
+                    "id": 113,
+                    "name": "p",
+                    "type": "component",
+                  }
+            }
+        >
             Read more about Idyll at 
             <a
                 href="https://idyll-lang.github.io/"
+                idyllASTNode={
+                    Object {
+                        "children": Array [
+                          Object {
+                            "id": 116,
+                            "type": "textnode",
+                            "value": "https://idyll-lang.github.io/",
+                          },
+                        ],
+                        "id": 115,
+                        "name": "a",
+                        "properties": Object {
+                          "href": Object {
+                            "type": "value",
+                            "value": "https://idyll-lang.github.io/",
+                          },
+                        },
+                        "type": "component",
+                      }
+                }
             >
                 https://idyll-lang.github.io/
             </a>
             , and come say “Hi!” in our 
             <a
                 href="https://gitter.im/idyll-lang/Lobby"
+                idyllASTNode={
+                    Object {
+                        "children": Array [
+                          Object {
+                            "id": 119,
+                            "type": "textnode",
+                            "value": "chatroom on gitter",
+                          },
+                        ],
+                        "id": 118,
+                        "name": "a",
+                        "properties": Object {
+                          "href": Object {
+                            "type": "value",
+                            "value": "https://gitter.im/idyll-lang/Lobby",
+                          },
+                        },
+                        "type": "component",
+                      }
+                }
             >
                 chatroom on gitter
             </a>
@@ -400,30 +2683,1132 @@ ShallowWrapper {
     "nodeType": "host",
     "props": Object {
       "children": Array [
-        <TextContainer>
-          <h1>
+        <TextContainer
+          idyllASTNode={
+                    Object {
+                              "children": Array [
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": 12,
+                                      "type": "textnode",
+                                      "value": "Welcome to Idyll",
+                                    },
+                                  ],
+                                  "id": 11,
+                                  "name": "h1",
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": 14,
+                                      "type": "textnode",
+                                      "value": "Idyll is a language for creating interactive documents on the web.",
+                                    },
+                                  ],
+                                  "id": 13,
+                                  "name": "h3",
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": 16,
+                                      "type": "textnode",
+                                      "value": "This document is being rendered from ",
+                                    },
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "id": 18,
+                                          "type": "textnode",
+                                          "value": "Idyll markup",
+                                        },
+                                      ],
+                                      "id": 17,
+                                      "name": "strong",
+                                      "type": "component",
+                                    },
+                                    Object {
+                                      "id": 19,
+                                      "type": "textnode",
+                                      "value": ". If you’ve used ",
+                                    },
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "id": 21,
+                                          "type": "textnode",
+                                          "value": "markdown",
+                                        },
+                                      ],
+                                      "id": 20,
+                                      "name": "a",
+                                      "properties": Object {
+                                        "href": Object {
+                                          "type": "value",
+                                          "value": "https://daringfireball.net/projects/markdown/",
+                                        },
+                                      },
+                                      "type": "component",
+                                    },
+                                    Object {
+                                      "id": 22,
+                                      "type": "textnode",
+                                      "value": ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.",
+                                    },
+                                  ],
+                                  "id": 15,
+                                  "name": "p",
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": 24,
+                                      "type": "textnode",
+                                      "value": "To make things a little more interesting you can add JavaScript components to your text.
+                    For example, a ",
+                                    },
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "id": 26,
+                                          "type": "textnode",
+                                          "value": "[Chart /]",
+                                        },
+                                      ],
+                                      "id": 25,
+                                      "name": "code",
+                                      "type": "component",
+                                    },
+                                    Object {
+                                      "id": 27,
+                                      "type": "textnode",
+                                      "value": " component can be used to render a simple visualization:",
+                                    },
+                                  ],
+                                  "id": 23,
+                                  "name": "p",
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 28,
+                                  "name": "Chart",
+                                  "properties": Object {
+                                    "type": Object {
+                                      "type": "value",
+                                      "value": "scatter",
+                                    },
+                                  },
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": 30,
+                                      "type": "textnode",
+                                      "value": "Try changing the chart’s type from ",
+                                    },
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "id": 32,
+                                          "type": "textnode",
+                                          "value": "scatter",
+                                        },
+                                      ],
+                                      "id": 31,
+                                      "name": "code",
+                                      "type": "component",
+                                    },
+                                    Object {
+                                      "id": 33,
+                                      "type": "textnode",
+                                      "value": " to ",
+                                    },
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "id": 35,
+                                          "type": "textnode",
+                                          "value": "line",
+                                        },
+                                      ],
+                                      "id": 34,
+                                      "name": "code",
+                                      "type": "component",
+                                    },
+                                    Object {
+                                      "id": 36,
+                                      "type": "textnode",
+                                      "value": ", ",
+                                    },
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "id": 38,
+                                          "type": "textnode",
+                                          "value": "area",
+                                        },
+                                      ],
+                                      "id": 37,
+                                      "name": "code",
+                                      "type": "component",
+                                    },
+                                    Object {
+                                      "id": 39,
+                                      "type": "textnode",
+                                      "value": ", or ",
+                                    },
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "id": 41,
+                                          "type": "textnode",
+                                          "value": "pie",
+                                        },
+                                      ],
+                                      "id": 40,
+                                      "name": "code",
+                                      "type": "component",
+                                    },
+                                    Object {
+                                      "id": 42,
+                                      "type": "textnode",
+                                      "value": ".",
+                                    },
+                                  ],
+                                  "id": 29,
+                                  "name": "p",
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": 44,
+                                      "type": "textnode",
+                                      "value": "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (",
+                                    },
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "id": 46,
+                                          "type": "textnode",
+                                          "value": "\`2 * Math.PI\`",
+                                        },
+                                      ],
+                                      "id": 45,
+                                      "name": "code",
+                                      "type": "component",
+                                    },
+                                    Object {
+                                      "id": 47,
+                                      "type": "textnode",
+                                      "value": ").",
+                                    },
+                                  ],
+                                  "id": 43,
+                                  "name": "p",
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": 49,
+                                      "type": "textnode",
+                                      "value": "There are a number of components available — see ",
+                                    },
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "id": 51,
+                                          "type": "textnode",
+                                          "value": "Idyll’s documentation",
+                                        },
+                                      ],
+                                      "id": 50,
+                                      "name": "a",
+                                      "properties": Object {
+                                        "href": Object {
+                                          "type": "value",
+                                          "value": "https://idyll-lang.github.io/components-built-in",
+                                        },
+                                      },
+                                      "type": "component",
+                                    },
+                                    Object {
+                                      "id": 52,
+                                      "type": "textnode",
+                                      "value": " for a full list — Additional components can be installed via ",
+                                    },
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "id": 54,
+                                          "type": "textnode",
+                                          "value": "npm",
+                                        },
+                                      ],
+                                      "id": 53,
+                                      "name": "code",
+                                      "type": "component",
+                                    },
+                                    Object {
+                                      "id": 55,
+                                      "type": "textnode",
+                                      "value": " (any React component should work), and if you are comfortable with JavaScript you can write ",
+                                    },
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "id": 57,
+                                          "type": "textnode",
+                                          "value": "custom components",
+                                        },
+                                      ],
+                                      "id": 56,
+                                      "name": "a",
+                                      "properties": Object {
+                                        "href": Object {
+                                          "type": "value",
+                                          "value": "https://idyll-lang.github.io/components-custom",
+                                        },
+                                      },
+                                      "type": "component",
+                                    },
+                                    Object {
+                                      "id": 58,
+                                      "type": "textnode",
+                                      "value": " as well.",
+                                    },
+                                  ],
+                                  "id": 48,
+                                  "name": "p",
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": 60,
+                                      "type": "textnode",
+                                      "value": "Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.",
+                                    },
+                                  ],
+                                  "id": 59,
+                                  "name": "p",
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": 62,
+                                      "type": "textnode",
+                                      "value": "Instantiating a variable is similar to instantiating a component:",
+                                    },
+                                  ],
+                                  "id": 61,
+                                  "name": "p",
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": 64,
+                                      "type": "textnode",
+                                      "value": "[var name:\\"x\\" value:1 /]",
+                                    },
+                                  ],
+                                  "id": 63,
+                                  "name": "code",
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": 66,
+                                      "type": "textnode",
+                                      "value": "Once you’ve created a variable, it can be displayed inline with text
+                    (x = ",
+                                    },
+                                    Object {
+                                      "children": Array [],
+                                      "id": 67,
+                                      "name": "Display",
+                                      "properties": Object {
+                                        "var": Object {
+                                          "type": "variable",
+                                          "value": "x",
+                                        },
+                                      },
+                                      "type": "component",
+                                    },
+                                    Object {
+                                      "id": 68,
+                                      "type": "textnode",
+                                      "value": "),
+                    or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:",
+                                    },
+                                  ],
+                                  "id": 65,
+                                  "name": "p",
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": 70,
+                                      "type": "textnode",
+                                      "value": "[derived name:\\"xSquared\\" value:\`x * x\` /]",
+                                    },
+                                  ],
+                                  "id": 69,
+                                  "name": "code",
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": 72,
+                                      "type": "textnode",
+                                      "value": "Here I bind the value of ",
+                                    },
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "id": 74,
+                                          "type": "textnode",
+                                          "value": "x",
+                                        },
+                                      ],
+                                      "id": 73,
+                                      "name": "code",
+                                      "type": "component",
+                                    },
+                                    Object {
+                                      "id": 75,
+                                      "type": "textnode",
+                                      "value": " to a range slider. Move the slider and watch the variables update.",
+                                    },
+                                  ],
+                                  "id": 71,
+                                  "name": "p",
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 76,
+                                  "name": "Range",
+                                  "properties": Object {
+                                    "max": Object {
+                                      "type": "value",
+                                      "value": 100,
+                                    },
+                                    "min": Object {
+                                      "type": "value",
+                                      "value": 0,
+                                    },
+                                    "value": Object {
+                                      "type": "variable",
+                                      "value": "x",
+                                    },
+                                  },
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "id": 79,
+                                          "type": "textnode",
+                                          "value": "x",
+                                        },
+                                      ],
+                                      "id": 78,
+                                      "name": "equation",
+                                      "type": "component",
+                                    },
+                                    Object {
+                                      "id": 80,
+                                      "type": "textnode",
+                                      "value": ":
+                     ",
+                                    },
+                                    Object {
+                                      "children": Array [],
+                                      "id": 81,
+                                      "name": "Display",
+                                      "properties": Object {
+                                        "var": Object {
+                                          "type": "expression",
+                                          "value": "x",
+                                        },
+                                      },
+                                      "type": "component",
+                                    },
+                                  ],
+                                  "id": 77,
+                                  "name": "p",
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "id": 84,
+                                          "type": "textnode",
+                                          "value": "x^2",
+                                        },
+                                      ],
+                                      "id": 83,
+                                      "name": "equation",
+                                      "type": "component",
+                                    },
+                                    Object {
+                                      "id": 85,
+                                      "type": "textnode",
+                                      "value": ":",
+                                    },
+                                    Object {
+                                      "children": Array [],
+                                      "id": 86,
+                                      "name": "Display",
+                                      "properties": Object {
+                                        "var": Object {
+                                          "type": "expression",
+                                          "value": "xSquared",
+                                        },
+                                      },
+                                      "type": "component",
+                                    },
+                                  ],
+                                  "id": 82,
+                                  "name": "p",
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": 88,
+                                      "type": "textnode",
+                                      "value": "Test expression, displays:",
+                                    },
+                                  ],
+                                  "id": 87,
+                                  "name": "p",
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 89,
+                                  "name": "Display",
+                                  "properties": Object {
+                                    "id": Object {
+                                      "type": "value",
+                                      "value": "varDisplay",
+                                    },
+                                    "value": Object {
+                                      "type": "expression",
+                                      "value": "x",
+                                    },
+                                  },
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 90,
+                                  "name": "Display",
+                                  "properties": Object {
+                                    "id": Object {
+                                      "type": "value",
+                                      "value": "derivedVarDisplay",
+                                    },
+                                    "value": Object {
+                                      "type": "expression",
+                                      "value": "xSquared",
+                                    },
+                                  },
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 91,
+                                  "name": "Display",
+                                  "properties": Object {
+                                    "id": Object {
+                                      "type": "value",
+                                      "value": "derivedVarDisplay2",
+                                    },
+                                    "value": Object {
+                                      "type": "expression",
+                                      "value": "xCubed",
+                                    },
+                                  },
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 92,
+                                  "name": "Display",
+                                  "properties": Object {
+                                    "id": Object {
+                                      "type": "value",
+                                      "value": "strDisplay",
+                                    },
+                                    "value": Object {
+                                      "type": "expression",
+                                      "value": "\\"string\\"",
+                                    },
+                                  },
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 93,
+                                  "name": "Display",
+                                  "properties": Object {
+                                    "id": Object {
+                                      "type": "value",
+                                      "value": "staticObjectDisplay",
+                                    },
+                                    "value": Object {
+                                      "type": "expression",
+                                      "value": "{ static: \\"object\\" }",
+                                    },
+                                  },
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 94,
+                                  "name": "Display",
+                                  "properties": Object {
+                                    "id": Object {
+                                      "type": "value",
+                                      "value": "dynamicObjectDisplay",
+                                    },
+                                    "value": Object {
+                                      "type": "expression",
+                                      "value": "{ dynamic: x }",
+                                    },
+                                  },
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 95,
+                                  "name": "Display",
+                                  "properties": Object {
+                                    "id": Object {
+                                      "type": "value",
+                                      "value": "dataDisplay",
+                                    },
+                                    "value": Object {
+                                      "type": "expression",
+                                      "value": "myData",
+                                    },
+                                  },
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 96,
+                                  "name": "Display",
+                                  "properties": Object {
+                                    "id": Object {
+                                      "type": "value",
+                                      "value": "bareDataDisplay",
+                                    },
+                                    "value": Object {
+                                      "type": "variable",
+                                      "value": "myData",
+                                    },
+                                  },
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 97,
+                                  "name": "Display",
+                                  "properties": Object {
+                                    "id": Object {
+                                      "type": "value",
+                                      "value": "bareVarDisplay",
+                                    },
+                                    "value": Object {
+                                      "type": "variable",
+                                      "value": "x",
+                                    },
+                                  },
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 98,
+                                  "name": "Display",
+                                  "properties": Object {
+                                    "id": Object {
+                                      "type": "value",
+                                      "value": "bareDerivedDisplay",
+                                    },
+                                    "value": Object {
+                                      "type": "variable",
+                                      "value": "xSquared",
+                                    },
+                                  },
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 99,
+                                  "name": "Display",
+                                  "properties": Object {
+                                    "id": Object {
+                                      "type": "value",
+                                      "value": "bareDerivedDisplay2",
+                                    },
+                                    "value": Object {
+                                      "type": "variable",
+                                      "value": "xCubed",
+                                    },
+                                  },
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 100,
+                                  "name": "Display",
+                                  "properties": Object {
+                                    "id": Object {
+                                      "type": "value",
+                                      "value": "objectVarDisplay",
+                                    },
+                                    "value": Object {
+                                      "type": "expression",
+                                      "value": " objectVar ",
+                                    },
+                                  },
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 101,
+                                  "name": "Display",
+                                  "properties": Object {
+                                    "id": Object {
+                                      "type": "value",
+                                      "value": "bareObjectVarDisplay",
+                                    },
+                                    "value": Object {
+                                      "type": "variable",
+                                      "value": "objectVar",
+                                    },
+                                  },
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 102,
+                                  "name": "Display",
+                                  "properties": Object {
+                                    "id": Object {
+                                      "type": "value",
+                                      "value": "arrayVarDisplay",
+                                    },
+                                    "value": Object {
+                                      "type": "expression",
+                                      "value": " arrayVar ",
+                                    },
+                                  },
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 103,
+                                  "name": "Display",
+                                  "properties": Object {
+                                    "id": Object {
+                                      "type": "value",
+                                      "value": "bareArrayVarDisplay",
+                                    },
+                                    "value": Object {
+                                      "type": "variable",
+                                      "value": "arrayVar",
+                                    },
+                                  },
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 104,
+                                  "name": "br",
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": 106,
+                                      "type": "textnode",
+                                      "value": "Here is an example of how you could use a variable to control the frequency of a sine wave:",
+                                    },
+                                  ],
+                                  "id": 105,
+                                  "name": "p",
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 107,
+                                  "name": "Chart",
+                                  "properties": Object {
+                                    "domain": Object {
+                                      "type": "expression",
+                                      "value": "[0, 2 * Math.PI]",
+                                    },
+                                    "equation": Object {
+                                      "type": "expression",
+                                      "value": "(t) => Math.sin(t * frequency)",
+                                    },
+                                    "samplePoints": Object {
+                                      "type": "value",
+                                      "value": 1000,
+                                    },
+                                  },
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 108,
+                                  "name": "Range",
+                                  "properties": Object {
+                                    "max": Object {
+                                      "type": "expression",
+                                      "value": "2 * Math.PI",
+                                    },
+                                    "min": Object {
+                                      "type": "value",
+                                      "value": 0.5,
+                                    },
+                                    "step": Object {
+                                      "type": "value",
+                                      "value": 0.0001,
+                                    },
+                                    "value": Object {
+                                      "type": "variable",
+                                      "value": "frequency",
+                                    },
+                                  },
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "children": Array [],
+                                      "id": 110,
+                                      "name": "Display",
+                                      "properties": Object {
+                                        "id": Object {
+                                          "type": "value",
+                                          "value": "lateVarDisplay",
+                                        },
+                                        "value": Object {
+                                          "type": "variable",
+                                          "value": "lateVar",
+                                        },
+                                      },
+                                      "type": "component",
+                                    },
+                                    Object {
+                                      "id": 111,
+                                      "type": "textnode",
+                                      "value": "
+                    Late Var Range:",
+                                    },
+                                  ],
+                                  "id": 109,
+                                  "name": "p",
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [],
+                                  "id": 112,
+                                  "name": "Range",
+                                  "properties": Object {
+                                    "max": Object {
+                                      "type": "value",
+                                      "value": 100,
+                                    },
+                                    "min": Object {
+                                      "type": "value",
+                                      "value": 2,
+                                    },
+                                    "value": Object {
+                                      "type": "variable",
+                                      "value": "lateVar",
+                                    },
+                                  },
+                                  "type": "component",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": 114,
+                                      "type": "textnode",
+                                      "value": "Read more about Idyll at ",
+                                    },
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "id": 116,
+                                          "type": "textnode",
+                                          "value": "https://idyll-lang.github.io/",
+                                        },
+                                      ],
+                                      "id": 115,
+                                      "name": "a",
+                                      "properties": Object {
+                                        "href": Object {
+                                          "type": "value",
+                                          "value": "https://idyll-lang.github.io/",
+                                        },
+                                      },
+                                      "type": "component",
+                                    },
+                                    Object {
+                                      "id": 117,
+                                      "type": "textnode",
+                                      "value": ", and come say “Hi!” in our ",
+                                    },
+                                    Object {
+                                      "children": Array [
+                                        Object {
+                                          "id": 119,
+                                          "type": "textnode",
+                                          "value": "chatroom on gitter",
+                                        },
+                                      ],
+                                      "id": 118,
+                                      "name": "a",
+                                      "properties": Object {
+                                        "href": Object {
+                                          "type": "value",
+                                          "value": "https://gitter.im/idyll-lang/Lobby",
+                                        },
+                                      },
+                                      "type": "component",
+                                    },
+                                    Object {
+                                      "id": 120,
+                                      "type": "textnode",
+                                      "value": ".",
+                                    },
+                                  ],
+                                  "id": 113,
+                                  "name": "p",
+                                  "type": "component",
+                                },
+                              ],
+                              "id": 10,
+                              "name": "TextContainer",
+                              "type": "component",
+                            }
+          }
+>
+          <h1
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 12,
+                                            "type": "textnode",
+                                            "value": "Welcome to Idyll",
+                                          },
+                                        ],
+                                        "id": 11,
+                                        "name": "h1",
+                                        "type": "component",
+                                      }
+                    }
+          >
                     Welcome to Idyll
           </h1>
-          <h3>
+          <h3
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 14,
+                                            "type": "textnode",
+                                            "value": "Idyll is a language for creating interactive documents on the web.",
+                                          },
+                                        ],
+                                        "id": 13,
+                                        "name": "h3",
+                                        "type": "component",
+                                      }
+                    }
+          >
                     Idyll is a language for creating interactive documents on the web.
           </h3>
-          <p>
+          <p
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 16,
+                                            "type": "textnode",
+                                            "value": "This document is being rendered from ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 18,
+                                                "type": "textnode",
+                                                "value": "Idyll markup",
+                                              },
+                                            ],
+                                            "id": 17,
+                                            "name": "strong",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 19,
+                                            "type": "textnode",
+                                            "value": ". If you’ve used ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 21,
+                                                "type": "textnode",
+                                                "value": "markdown",
+                                              },
+                                            ],
+                                            "id": 20,
+                                            "name": "a",
+                                            "properties": Object {
+                                              "href": Object {
+                                                "type": "value",
+                                                "value": "https://daringfireball.net/projects/markdown/",
+                                              },
+                                            },
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 22,
+                                            "type": "textnode",
+                                            "value": ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.",
+                                          },
+                                        ],
+                                        "id": 15,
+                                        "name": "p",
+                                        "type": "component",
+                                      }
+                    }
+          >
                     This document is being rendered from 
-                    <strong>
+                    <strong
+                              idyllASTNode={
+                                        Object {
+                                                  "children": Array [
+                                                    Object {
+                                                      "id": 18,
+                                                      "type": "textnode",
+                                                      "value": "Idyll markup",
+                                                    },
+                                                  ],
+                                                  "id": 17,
+                                                  "name": "strong",
+                                                  "type": "component",
+                                                }
+                              }
+                    >
                               Idyll markup
                     </strong>
                     . If you’ve used 
                     <a
                               href="https://daringfireball.net/projects/markdown/"
+                              idyllASTNode={
+                                        Object {
+                                                  "children": Array [
+                                                    Object {
+                                                      "id": 21,
+                                                      "type": "textnode",
+                                                      "value": "markdown",
+                                                    },
+                                                  ],
+                                                  "id": 20,
+                                                  "name": "a",
+                                                  "properties": Object {
+                                                    "href": Object {
+                                                      "type": "value",
+                                                      "value": "https://daringfireball.net/projects/markdown/",
+                                                    },
+                                                  },
+                                                  "type": "component",
+                                                }
+                              }
                     >
                               markdown
                     </a>
                     , Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.
           </p>
-          <p>
+          <p
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 24,
+                                            "type": "textnode",
+                                            "value": "To make things a little more interesting you can add JavaScript components to your text.
+                              For example, a ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 26,
+                                                "type": "textnode",
+                                                "value": "[Chart /]",
+                                              },
+                                            ],
+                                            "id": 25,
+                                            "name": "code",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 27,
+                                            "type": "textnode",
+                                            "value": " component can be used to render a simple visualization:",
+                                          },
+                                        ],
+                                        "id": 23,
+                                        "name": "p",
+                                        "type": "component",
+                                      }
+                    }
+          >
                     To make things a little more interesting you can add JavaScript components to your text.
                     For example, a 
-                    <code>
+                    <code
+                              idyllASTNode={
+                                        Object {
+                                                  "children": Array [
+                                                    Object {
+                                                      "id": 26,
+                                                      "type": "textnode",
+                                                      "value": "[Chart /]",
+                                                    },
+                                                  ],
+                                                  "id": 25,
+                                                  "name": "code",
+                                                  "type": "component",
+                                                }
+                              }
+                    >
                               [Chart /]
                     </code>
                      component can be used to render a simple visualization:
@@ -436,6 +3821,20 @@ ShallowWrapper {
                                       ]
                     }
                     domainPadding={0}
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 28,
+                                        "name": "Chart",
+                                        "properties": Object {
+                                          "type": Object {
+                                            "type": "value",
+                                            "value": "scatter",
+                                          },
+                                        },
+                                        "type": "component",
+                                      }
+                    }
                     range={
                               Array [
                                         -1,
@@ -445,61 +3844,463 @@ ShallowWrapper {
                     samplePoints={100}
                     type="scatter"
           />
-          <p>
+          <p
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 30,
+                                            "type": "textnode",
+                                            "value": "Try changing the chart’s type from ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 32,
+                                                "type": "textnode",
+                                                "value": "scatter",
+                                              },
+                                            ],
+                                            "id": 31,
+                                            "name": "code",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 33,
+                                            "type": "textnode",
+                                            "value": " to ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 35,
+                                                "type": "textnode",
+                                                "value": "line",
+                                              },
+                                            ],
+                                            "id": 34,
+                                            "name": "code",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 36,
+                                            "type": "textnode",
+                                            "value": ", ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 38,
+                                                "type": "textnode",
+                                                "value": "area",
+                                              },
+                                            ],
+                                            "id": 37,
+                                            "name": "code",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 39,
+                                            "type": "textnode",
+                                            "value": ", or ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 41,
+                                                "type": "textnode",
+                                                "value": "pie",
+                                              },
+                                            ],
+                                            "id": 40,
+                                            "name": "code",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 42,
+                                            "type": "textnode",
+                                            "value": ".",
+                                          },
+                                        ],
+                                        "id": 29,
+                                        "name": "p",
+                                        "type": "component",
+                                      }
+                    }
+          >
                     Try changing the chart’s type from 
-                    <code>
+                    <code
+                              idyllASTNode={
+                                        Object {
+                                                  "children": Array [
+                                                    Object {
+                                                      "id": 32,
+                                                      "type": "textnode",
+                                                      "value": "scatter",
+                                                    },
+                                                  ],
+                                                  "id": 31,
+                                                  "name": "code",
+                                                  "type": "component",
+                                                }
+                              }
+                    >
                               scatter
                     </code>
                      to 
-                    <code>
+                    <code
+                              idyllASTNode={
+                                        Object {
+                                                  "children": Array [
+                                                    Object {
+                                                      "id": 35,
+                                                      "type": "textnode",
+                                                      "value": "line",
+                                                    },
+                                                  ],
+                                                  "id": 34,
+                                                  "name": "code",
+                                                  "type": "component",
+                                                }
+                              }
+                    >
                               line
                     </code>
                     , 
-                    <code>
+                    <code
+                              idyllASTNode={
+                                        Object {
+                                                  "children": Array [
+                                                    Object {
+                                                      "id": 38,
+                                                      "type": "textnode",
+                                                      "value": "area",
+                                                    },
+                                                  ],
+                                                  "id": 37,
+                                                  "name": "code",
+                                                  "type": "component",
+                                                }
+                              }
+                    >
                               area
                     </code>
                     , or 
-                    <code>
+                    <code
+                              idyllASTNode={
+                                        Object {
+                                                  "children": Array [
+                                                    Object {
+                                                      "id": 41,
+                                                      "type": "textnode",
+                                                      "value": "pie",
+                                                    },
+                                                  ],
+                                                  "id": 40,
+                                                  "name": "code",
+                                                  "type": "component",
+                                                }
+                              }
+                    >
                               pie
                     </code>
                     .
           </p>
-          <p>
+          <p
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 44,
+                                            "type": "textnode",
+                                            "value": "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 46,
+                                                "type": "textnode",
+                                                "value": "\`2 * Math.PI\`",
+                                              },
+                                            ],
+                                            "id": 45,
+                                            "name": "code",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 47,
+                                            "type": "textnode",
+                                            "value": ").",
+                                          },
+                                        ],
+                                        "id": 43,
+                                        "name": "p",
+                                        "type": "component",
+                                      }
+                    }
+          >
                     A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (
-                    <code>
+                    <code
+                              idyllASTNode={
+                                        Object {
+                                                  "children": Array [
+                                                    Object {
+                                                      "id": 46,
+                                                      "type": "textnode",
+                                                      "value": "\`2 * Math.PI\`",
+                                                    },
+                                                  ],
+                                                  "id": 45,
+                                                  "name": "code",
+                                                  "type": "component",
+                                                }
+                              }
+                    >
                               \`2 * Math.PI\`
                     </code>
                     ).
           </p>
-          <p>
+          <p
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 49,
+                                            "type": "textnode",
+                                            "value": "There are a number of components available — see ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 51,
+                                                "type": "textnode",
+                                                "value": "Idyll’s documentation",
+                                              },
+                                            ],
+                                            "id": 50,
+                                            "name": "a",
+                                            "properties": Object {
+                                              "href": Object {
+                                                "type": "value",
+                                                "value": "https://idyll-lang.github.io/components-built-in",
+                                              },
+                                            },
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 52,
+                                            "type": "textnode",
+                                            "value": " for a full list — Additional components can be installed via ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 54,
+                                                "type": "textnode",
+                                                "value": "npm",
+                                              },
+                                            ],
+                                            "id": 53,
+                                            "name": "code",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 55,
+                                            "type": "textnode",
+                                            "value": " (any React component should work), and if you are comfortable with JavaScript you can write ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 57,
+                                                "type": "textnode",
+                                                "value": "custom components",
+                                              },
+                                            ],
+                                            "id": 56,
+                                            "name": "a",
+                                            "properties": Object {
+                                              "href": Object {
+                                                "type": "value",
+                                                "value": "https://idyll-lang.github.io/components-custom",
+                                              },
+                                            },
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 58,
+                                            "type": "textnode",
+                                            "value": " as well.",
+                                          },
+                                        ],
+                                        "id": 48,
+                                        "name": "p",
+                                        "type": "component",
+                                      }
+                    }
+          >
                     There are a number of components available — see 
                     <a
                               href="https://idyll-lang.github.io/components-built-in"
+                              idyllASTNode={
+                                        Object {
+                                                  "children": Array [
+                                                    Object {
+                                                      "id": 51,
+                                                      "type": "textnode",
+                                                      "value": "Idyll’s documentation",
+                                                    },
+                                                  ],
+                                                  "id": 50,
+                                                  "name": "a",
+                                                  "properties": Object {
+                                                    "href": Object {
+                                                      "type": "value",
+                                                      "value": "https://idyll-lang.github.io/components-built-in",
+                                                    },
+                                                  },
+                                                  "type": "component",
+                                                }
+                              }
                     >
                               Idyll’s documentation
                     </a>
                      for a full list — Additional components can be installed via 
-                    <code>
+                    <code
+                              idyllASTNode={
+                                        Object {
+                                                  "children": Array [
+                                                    Object {
+                                                      "id": 54,
+                                                      "type": "textnode",
+                                                      "value": "npm",
+                                                    },
+                                                  ],
+                                                  "id": 53,
+                                                  "name": "code",
+                                                  "type": "component",
+                                                }
+                              }
+                    >
                               npm
                     </code>
                      (any React component should work), and if you are comfortable with JavaScript you can write 
                     <a
                               href="https://idyll-lang.github.io/components-custom"
+                              idyllASTNode={
+                                        Object {
+                                                  "children": Array [
+                                                    Object {
+                                                      "id": 57,
+                                                      "type": "textnode",
+                                                      "value": "custom components",
+                                                    },
+                                                  ],
+                                                  "id": 56,
+                                                  "name": "a",
+                                                  "properties": Object {
+                                                    "href": Object {
+                                                      "type": "value",
+                                                      "value": "https://idyll-lang.github.io/components-custom",
+                                                    },
+                                                  },
+                                                  "type": "component",
+                                                }
+                              }
                     >
                               custom components
                     </a>
                      as well.
           </p>
-          <p>
+          <p
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 60,
+                                            "type": "textnode",
+                                            "value": "Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.",
+                                          },
+                                        ],
+                                        "id": 59,
+                                        "name": "p",
+                                        "type": "component",
+                                      }
+                    }
+          >
                     Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.
           </p>
-          <p>
+          <p
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 62,
+                                            "type": "textnode",
+                                            "value": "Instantiating a variable is similar to instantiating a component:",
+                                          },
+                                        ],
+                                        "id": 61,
+                                        "name": "p",
+                                        "type": "component",
+                                      }
+                    }
+          >
                     Instantiating a variable is similar to instantiating a component:
           </p>
-          <code>
+          <code
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 64,
+                                            "type": "textnode",
+                                            "value": "[var name:\\"x\\" value:1 /]",
+                                          },
+                                        ],
+                                        "id": 63,
+                                        "name": "code",
+                                        "type": "component",
+                                      }
+                    }
+          >
                     [var name:"x" value:1 /]
           </code>
-          <p>
+          <p
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 66,
+                                            "type": "textnode",
+                                            "value": "Once you’ve created a variable, it can be displayed inline with text
+                              (x = ",
+                                          },
+                                          Object {
+                                            "children": Array [],
+                                            "id": 67,
+                                            "name": "Display",
+                                            "properties": Object {
+                                              "var": Object {
+                                                "type": "variable",
+                                                "value": "x",
+                                              },
+                                            },
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 68,
+                                            "type": "textnode",
+                                            "value": "),
+                              or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:",
+                                          },
+                                        ],
+                                        "id": 65,
+                                        "name": "p",
+                                        "type": "component",
+                                      }
+                    }
+          >
                     Once you’ve created a variable, it can be displayed inline with text
                     (x = 
                     <Display
@@ -508,17 +4309,93 @@ ShallowWrapper {
                                                   "var": "x",
                                                 }
                               }
+                              idyllASTNode={
+                                        Object {
+                                                  "children": Array [],
+                                                  "id": 67,
+                                                  "name": "Display",
+                                                  "properties": Object {
+                                                    "var": Object {
+                                                      "type": "variable",
+                                                      "value": "x",
+                                                    },
+                                                  },
+                                                  "type": "component",
+                                                }
+                              }
                               var="x"
                     />
                     ),
                     or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:
           </p>
-          <code>
+          <code
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 70,
+                                            "type": "textnode",
+                                            "value": "[derived name:\\"xSquared\\" value:\`x * x\` /]",
+                                          },
+                                        ],
+                                        "id": 69,
+                                        "name": "code",
+                                        "type": "component",
+                                      }
+                    }
+          >
                     [derived name:"xSquared" value:\`x * x\` /]
           </code>
-          <p>
+          <p
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 72,
+                                            "type": "textnode",
+                                            "value": "Here I bind the value of ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 74,
+                                                "type": "textnode",
+                                                "value": "x",
+                                              },
+                                            ],
+                                            "id": 73,
+                                            "name": "code",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 75,
+                                            "type": "textnode",
+                                            "value": " to a range slider. Move the slider and watch the variables update.",
+                                          },
+                                        ],
+                                        "id": 71,
+                                        "name": "p",
+                                        "type": "component",
+                                      }
+                    }
+          >
                     Here I bind the value of 
-                    <code>
+                    <code
+                              idyllASTNode={
+                                        Object {
+                                                  "children": Array [
+                                                    Object {
+                                                      "id": 74,
+                                                      "type": "textnode",
+                                                      "value": "x",
+                                                    },
+                                                  ],
+                                                  "id": 73,
+                                                  "name": "code",
+                                                  "type": "component",
+                                                }
+                              }
+                    >
                               x
                     </code>
                      to a range slider. Move the slider and watch the variables update.
@@ -529,13 +4406,90 @@ ShallowWrapper {
                                         "value": "x",
                                       }
                     }
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 76,
+                                        "name": "Range",
+                                        "properties": Object {
+                                          "max": Object {
+                                            "type": "value",
+                                            "value": 100,
+                                          },
+                                          "min": Object {
+                                            "type": "value",
+                                            "value": 0,
+                                          },
+                                          "value": Object {
+                                            "type": "variable",
+                                            "value": "x",
+                                          },
+                                        },
+                                        "type": "component",
+                                      }
+                    }
                     max={100}
                     min={0}
                     step={1}
                     value="x"
           />
-          <p>
-                    <Equation>
+          <p
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 79,
+                                                "type": "textnode",
+                                                "value": "x",
+                                              },
+                                            ],
+                                            "id": 78,
+                                            "name": "equation",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 80,
+                                            "type": "textnode",
+                                            "value": ":
+                               ",
+                                          },
+                                          Object {
+                                            "children": Array [],
+                                            "id": 81,
+                                            "name": "Display",
+                                            "properties": Object {
+                                              "var": Object {
+                                                "type": "expression",
+                                                "value": "x",
+                                              },
+                                            },
+                                            "type": "component",
+                                          },
+                                        ],
+                                        "id": 77,
+                                        "name": "p",
+                                        "type": "component",
+                                      }
+                    }
+          >
+                    <Equation
+                              idyllASTNode={
+                                        Object {
+                                                  "children": Array [
+                                                    Object {
+                                                      "id": 79,
+                                                      "type": "textnode",
+                                                      "value": "x",
+                                                    },
+                                                  ],
+                                                  "id": 78,
+                                                  "name": "equation",
+                                                  "type": "component",
+                                                }
+                              }
+                    >
                               x
                     </Equation>
                     :
@@ -546,11 +4500,79 @@ ShallowWrapper {
                                                   "var": "x",
                                                 }
                               }
+                              idyllASTNode={
+                                        Object {
+                                                  "children": Array [],
+                                                  "id": 81,
+                                                  "name": "Display",
+                                                  "properties": Object {
+                                                    "var": Object {
+                                                      "type": "expression",
+                                                      "value": "x",
+                                                    },
+                                                  },
+                                                  "type": "component",
+                                                }
+                              }
                               var="x"
                     />
           </p>
-          <p>
-                    <Equation>
+          <p
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 84,
+                                                "type": "textnode",
+                                                "value": "x^2",
+                                              },
+                                            ],
+                                            "id": 83,
+                                            "name": "equation",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 85,
+                                            "type": "textnode",
+                                            "value": ":",
+                                          },
+                                          Object {
+                                            "children": Array [],
+                                            "id": 86,
+                                            "name": "Display",
+                                            "properties": Object {
+                                              "var": Object {
+                                                "type": "expression",
+                                                "value": "xSquared",
+                                              },
+                                            },
+                                            "type": "component",
+                                          },
+                                        ],
+                                        "id": 82,
+                                        "name": "p",
+                                        "type": "component",
+                                      }
+                    }
+          >
+                    <Equation
+                              idyllASTNode={
+                                        Object {
+                                                  "children": Array [
+                                                    Object {
+                                                      "id": 84,
+                                                      "type": "textnode",
+                                                      "value": "x^2",
+                                                    },
+                                                  ],
+                                                  "id": 83,
+                                                  "name": "equation",
+                                                  "type": "component",
+                                                }
+                              }
+                    >
                               x^2
                     </Equation>
                     :
@@ -560,10 +4582,39 @@ ShallowWrapper {
                                                   "var": "xSquared",
                                                 }
                               }
+                              idyllASTNode={
+                                        Object {
+                                                  "children": Array [],
+                                                  "id": 86,
+                                                  "name": "Display",
+                                                  "properties": Object {
+                                                    "var": Object {
+                                                      "type": "expression",
+                                                      "value": "xSquared",
+                                                    },
+                                                  },
+                                                  "type": "component",
+                                                }
+                              }
                               var="xSquared"
                     />
           </p>
-          <p>
+          <p
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 88,
+                                            "type": "textnode",
+                                            "value": "Test expression, displays:",
+                                          },
+                                        ],
+                                        "id": 87,
+                                        "name": "p",
+                                        "type": "component",
+                                      }
+                    }
+          >
                     Test expression, displays:
           </p>
           <Display
@@ -573,6 +4624,24 @@ ShallowWrapper {
                                       }
                     }
                     id="varDisplay"
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 89,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "varDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "expression",
+                                            "value": "x",
+                                          },
+                                        },
+                                        "type": "component",
+                                      }
+                    }
                     value="x"
           />
           <Display
@@ -582,6 +4651,24 @@ ShallowWrapper {
                                       }
                     }
                     id="derivedVarDisplay"
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 90,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "derivedVarDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "expression",
+                                            "value": "xSquared",
+                                          },
+                                        },
+                                        "type": "component",
+                                      }
+                    }
                     value="xSquared"
           />
           <Display
@@ -591,6 +4678,24 @@ ShallowWrapper {
                                       }
                     }
                     id="derivedVarDisplay2"
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 91,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "derivedVarDisplay2",
+                                          },
+                                          "value": Object {
+                                            "type": "expression",
+                                            "value": "xCubed",
+                                          },
+                                        },
+                                        "type": "component",
+                                      }
+                    }
                     value="xCubed"
           />
           <Display
@@ -600,6 +4705,24 @@ ShallowWrapper {
                                       }
                     }
                     id="strDisplay"
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 92,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "strDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "expression",
+                                            "value": "\\"string\\"",
+                                          },
+                                        },
+                                        "type": "component",
+                                      }
+                    }
                     value="\\"string\\""
           />
           <Display
@@ -609,6 +4732,24 @@ ShallowWrapper {
                                       }
                     }
                     id="staticObjectDisplay"
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 93,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "staticObjectDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "expression",
+                                            "value": "{ static: \\"object\\" }",
+                                          },
+                                        },
+                                        "type": "component",
+                                      }
+                    }
                     value="{ static: \\"object\\" }"
           />
           <Display
@@ -618,6 +4759,24 @@ ShallowWrapper {
                                       }
                     }
                     id="dynamicObjectDisplay"
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 94,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "dynamicObjectDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "expression",
+                                            "value": "{ dynamic: x }",
+                                          },
+                                        },
+                                        "type": "component",
+                                      }
+                    }
                     value="{ dynamic: x }"
           />
           <Display
@@ -627,6 +4786,24 @@ ShallowWrapper {
                                       }
                     }
                     id="dataDisplay"
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 95,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "dataDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "expression",
+                                            "value": "myData",
+                                          },
+                                        },
+                                        "type": "component",
+                                      }
+                    }
                     value="myData"
           />
           <Display
@@ -636,6 +4813,24 @@ ShallowWrapper {
                                       }
                     }
                     id="bareDataDisplay"
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 96,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "bareDataDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "variable",
+                                            "value": "myData",
+                                          },
+                                        },
+                                        "type": "component",
+                                      }
+                    }
                     value="myData"
           />
           <Display
@@ -645,6 +4840,24 @@ ShallowWrapper {
                                       }
                     }
                     id="bareVarDisplay"
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 97,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "bareVarDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "variable",
+                                            "value": "x",
+                                          },
+                                        },
+                                        "type": "component",
+                                      }
+                    }
                     value="x"
           />
           <Display
@@ -654,6 +4867,24 @@ ShallowWrapper {
                                       }
                     }
                     id="bareDerivedDisplay"
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 98,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "bareDerivedDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "variable",
+                                            "value": "xSquared",
+                                          },
+                                        },
+                                        "type": "component",
+                                      }
+                    }
                     value="xSquared"
           />
           <Display
@@ -663,6 +4894,24 @@ ShallowWrapper {
                                       }
                     }
                     id="bareDerivedDisplay2"
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 99,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "bareDerivedDisplay2",
+                                          },
+                                          "value": Object {
+                                            "type": "variable",
+                                            "value": "xCubed",
+                                          },
+                                        },
+                                        "type": "component",
+                                      }
+                    }
                     value="xCubed"
           />
           <Display
@@ -672,6 +4921,24 @@ ShallowWrapper {
                                       }
                     }
                     id="objectVarDisplay"
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 100,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "objectVarDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "expression",
+                                            "value": " objectVar ",
+                                          },
+                                        },
+                                        "type": "component",
+                                      }
+                    }
                     value=" objectVar "
           />
           <Display
@@ -681,6 +4948,24 @@ ShallowWrapper {
                                       }
                     }
                     id="bareObjectVarDisplay"
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 101,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "bareObjectVarDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "variable",
+                                            "value": "objectVar",
+                                          },
+                                        },
+                                        "type": "component",
+                                      }
+                    }
                     value="objectVar"
           />
           <Display
@@ -690,6 +4975,24 @@ ShallowWrapper {
                                       }
                     }
                     id="arrayVarDisplay"
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 102,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "arrayVarDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "expression",
+                                            "value": " arrayVar ",
+                                          },
+                                        },
+                                        "type": "component",
+                                      }
+                    }
                     value=" arrayVar "
           />
           <Display
@@ -699,10 +5002,52 @@ ShallowWrapper {
                                       }
                     }
                     id="bareArrayVarDisplay"
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 103,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "bareArrayVarDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "variable",
+                                            "value": "arrayVar",
+                                          },
+                                        },
+                                        "type": "component",
+                                      }
+                    }
                     value="arrayVar"
           />
-          <br />
-          <p>
+          <br
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 104,
+                                        "name": "br",
+                                        "type": "component",
+                                      }
+                    }
+          />
+          <p
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 106,
+                                            "type": "textnode",
+                                            "value": "Here is an example of how you could use a variable to control the frequency of a sine wave:",
+                                          },
+                                        ],
+                                        "id": 105,
+                                        "name": "p",
+                                        "type": "component",
+                                      }
+                    }
+          >
                     Here is an example of how you could use a variable to control the frequency of a sine wave:
           </p>
           <Chart
@@ -715,6 +5060,28 @@ ShallowWrapper {
                     domain="[0, 2 * Math.PI]"
                     domainPadding={0}
                     equation="(t) => Math.sin(t * frequency)"
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 107,
+                                        "name": "Chart",
+                                        "properties": Object {
+                                          "domain": Object {
+                                            "type": "expression",
+                                            "value": "[0, 2 * Math.PI]",
+                                          },
+                                          "equation": Object {
+                                            "type": "expression",
+                                            "value": "(t) => Math.sin(t * frequency)",
+                                          },
+                                          "samplePoints": Object {
+                                            "type": "value",
+                                            "value": 1000,
+                                          },
+                                        },
+                                        "type": "component",
+                                      }
+                    }
                     range={
                               Array [
                                         -1,
@@ -735,12 +5102,70 @@ ShallowWrapper {
                                         "value": "frequency",
                                       }
                     }
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 108,
+                                        "name": "Range",
+                                        "properties": Object {
+                                          "max": Object {
+                                            "type": "expression",
+                                            "value": "2 * Math.PI",
+                                          },
+                                          "min": Object {
+                                            "type": "value",
+                                            "value": 0.5,
+                                          },
+                                          "step": Object {
+                                            "type": "value",
+                                            "value": 0.0001,
+                                          },
+                                          "value": Object {
+                                            "type": "variable",
+                                            "value": "frequency",
+                                          },
+                                        },
+                                        "type": "component",
+                                      }
+                    }
                     max="2 * Math.PI"
                     min={0.5}
                     step={0.0001}
                     value="frequency"
           />
-          <p>
+          <p
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [
+                                          Object {
+                                            "children": Array [],
+                                            "id": 110,
+                                            "name": "Display",
+                                            "properties": Object {
+                                              "id": Object {
+                                                "type": "value",
+                                                "value": "lateVarDisplay",
+                                              },
+                                              "value": Object {
+                                                "type": "variable",
+                                                "value": "lateVar",
+                                              },
+                                            },
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 111,
+                                            "type": "textnode",
+                                            "value": "
+                              Late Var Range:",
+                                          },
+                                        ],
+                                        "id": 109,
+                                        "name": "p",
+                                        "type": "component",
+                                      }
+                    }
+          >
                     <Display
                               __vars__={
                                         Object {
@@ -748,6 +5173,24 @@ ShallowWrapper {
                                                 }
                               }
                               id="lateVarDisplay"
+                              idyllASTNode={
+                                        Object {
+                                                  "children": Array [],
+                                                  "id": 110,
+                                                  "name": "Display",
+                                                  "properties": Object {
+                                                    "id": Object {
+                                                      "type": "value",
+                                                      "value": "lateVarDisplay",
+                                                    },
+                                                    "value": Object {
+                                                      "type": "variable",
+                                                      "value": "lateVar",
+                                                    },
+                                                  },
+                                                  "type": "component",
+                                                }
+                              }
                               value="lateVar"
                     />
                     
@@ -759,21 +5202,144 @@ ShallowWrapper {
                                         "value": "lateVar",
                                       }
                     }
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [],
+                                        "id": 112,
+                                        "name": "Range",
+                                        "properties": Object {
+                                          "max": Object {
+                                            "type": "value",
+                                            "value": 100,
+                                          },
+                                          "min": Object {
+                                            "type": "value",
+                                            "value": 2,
+                                          },
+                                          "value": Object {
+                                            "type": "variable",
+                                            "value": "lateVar",
+                                          },
+                                        },
+                                        "type": "component",
+                                      }
+                    }
                     max={100}
                     min={2}
                     step={1}
                     value="lateVar"
           />
-          <p>
+          <p
+                    idyllASTNode={
+                              Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 114,
+                                            "type": "textnode",
+                                            "value": "Read more about Idyll at ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 116,
+                                                "type": "textnode",
+                                                "value": "https://idyll-lang.github.io/",
+                                              },
+                                            ],
+                                            "id": 115,
+                                            "name": "a",
+                                            "properties": Object {
+                                              "href": Object {
+                                                "type": "value",
+                                                "value": "https://idyll-lang.github.io/",
+                                              },
+                                            },
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 117,
+                                            "type": "textnode",
+                                            "value": ", and come say “Hi!” in our ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 119,
+                                                "type": "textnode",
+                                                "value": "chatroom on gitter",
+                                              },
+                                            ],
+                                            "id": 118,
+                                            "name": "a",
+                                            "properties": Object {
+                                              "href": Object {
+                                                "type": "value",
+                                                "value": "https://gitter.im/idyll-lang/Lobby",
+                                              },
+                                            },
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 120,
+                                            "type": "textnode",
+                                            "value": ".",
+                                          },
+                                        ],
+                                        "id": 113,
+                                        "name": "p",
+                                        "type": "component",
+                                      }
+                    }
+          >
                     Read more about Idyll at 
                     <a
                               href="https://idyll-lang.github.io/"
+                              idyllASTNode={
+                                        Object {
+                                                  "children": Array [
+                                                    Object {
+                                                      "id": 116,
+                                                      "type": "textnode",
+                                                      "value": "https://idyll-lang.github.io/",
+                                                    },
+                                                  ],
+                                                  "id": 115,
+                                                  "name": "a",
+                                                  "properties": Object {
+                                                    "href": Object {
+                                                      "type": "value",
+                                                      "value": "https://idyll-lang.github.io/",
+                                                    },
+                                                  },
+                                                  "type": "component",
+                                                }
+                              }
                     >
                               https://idyll-lang.github.io/
                     </a>
                     , and come say “Hi!” in our 
                     <a
                               href="https://gitter.im/idyll-lang/Lobby"
+                              idyllASTNode={
+                                        Object {
+                                                  "children": Array [
+                                                    Object {
+                                                      "id": 119,
+                                                      "type": "textnode",
+                                                      "value": "chatroom on gitter",
+                                                    },
+                                                  ],
+                                                  "id": 118,
+                                                  "name": "a",
+                                                  "properties": Object {
+                                                    "href": Object {
+                                                      "type": "value",
+                                                      "value": "https://gitter.im/idyll-lang/Lobby",
+                                                    },
+                                                  },
+                                                  "type": "component",
+                                                }
+                              }
                     >
                               chatroom on gitter
                     </a>
@@ -790,29 +5356,197 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "children": Array [
-            <h1>
+            <h1
+              idyllASTNode={
+                            Object {
+                                          "children": Array [
+                                            Object {
+                                              "id": 12,
+                                              "type": "textnode",
+                                              "value": "Welcome to Idyll",
+                                            },
+                                          ],
+                                          "id": 11,
+                                          "name": "h1",
+                                          "type": "component",
+                                        }
+              }
+>
               Welcome to Idyll
 </h1>,
-            <h3>
+            <h3
+              idyllASTNode={
+                            Object {
+                                          "children": Array [
+                                            Object {
+                                              "id": 14,
+                                              "type": "textnode",
+                                              "value": "Idyll is a language for creating interactive documents on the web.",
+                                            },
+                                          ],
+                                          "id": 13,
+                                          "name": "h3",
+                                          "type": "component",
+                                        }
+              }
+>
               Idyll is a language for creating interactive documents on the web.
 </h3>,
-            <p>
+            <p
+              idyllASTNode={
+                            Object {
+                                          "children": Array [
+                                            Object {
+                                              "id": 16,
+                                              "type": "textnode",
+                                              "value": "This document is being rendered from ",
+                                            },
+                                            Object {
+                                              "children": Array [
+                                                Object {
+                                                  "id": 18,
+                                                  "type": "textnode",
+                                                  "value": "Idyll markup",
+                                                },
+                                              ],
+                                              "id": 17,
+                                              "name": "strong",
+                                              "type": "component",
+                                            },
+                                            Object {
+                                              "id": 19,
+                                              "type": "textnode",
+                                              "value": ". If you’ve used ",
+                                            },
+                                            Object {
+                                              "children": Array [
+                                                Object {
+                                                  "id": 21,
+                                                  "type": "textnode",
+                                                  "value": "markdown",
+                                                },
+                                              ],
+                                              "id": 20,
+                                              "name": "a",
+                                              "properties": Object {
+                                                "href": Object {
+                                                  "type": "value",
+                                                  "value": "https://daringfireball.net/projects/markdown/",
+                                                },
+                                              },
+                                              "type": "component",
+                                            },
+                                            Object {
+                                              "id": 22,
+                                              "type": "textnode",
+                                              "value": ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.",
+                                            },
+                                          ],
+                                          "id": 15,
+                                          "name": "p",
+                                          "type": "component",
+                                        }
+              }
+>
               This document is being rendered from 
-              <strong>
+              <strong
+                            idyllASTNode={
+                                          Object {
+                                                        "children": Array [
+                                                          Object {
+                                                            "id": 18,
+                                                            "type": "textnode",
+                                                            "value": "Idyll markup",
+                                                          },
+                                                        ],
+                                                        "id": 17,
+                                                        "name": "strong",
+                                                        "type": "component",
+                                                      }
+                            }
+              >
                             Idyll markup
               </strong>
               . If you’ve used 
               <a
                             href="https://daringfireball.net/projects/markdown/"
+                            idyllASTNode={
+                                          Object {
+                                                        "children": Array [
+                                                          Object {
+                                                            "id": 21,
+                                                            "type": "textnode",
+                                                            "value": "markdown",
+                                                          },
+                                                        ],
+                                                        "id": 20,
+                                                        "name": "a",
+                                                        "properties": Object {
+                                                          "href": Object {
+                                                            "type": "value",
+                                                            "value": "https://daringfireball.net/projects/markdown/",
+                                                          },
+                                                        },
+                                                        "type": "component",
+                                                      }
+                            }
               >
                             markdown
               </a>
               , Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.
 </p>,
-            <p>
+            <p
+              idyllASTNode={
+                            Object {
+                                          "children": Array [
+                                            Object {
+                                              "id": 24,
+                                              "type": "textnode",
+                                              "value": "To make things a little more interesting you can add JavaScript components to your text.
+                            For example, a ",
+                                            },
+                                            Object {
+                                              "children": Array [
+                                                Object {
+                                                  "id": 26,
+                                                  "type": "textnode",
+                                                  "value": "[Chart /]",
+                                                },
+                                              ],
+                                              "id": 25,
+                                              "name": "code",
+                                              "type": "component",
+                                            },
+                                            Object {
+                                              "id": 27,
+                                              "type": "textnode",
+                                              "value": " component can be used to render a simple visualization:",
+                                            },
+                                          ],
+                                          "id": 23,
+                                          "name": "p",
+                                          "type": "component",
+                                        }
+              }
+>
               To make things a little more interesting you can add JavaScript components to your text.
               For example, a 
-              <code>
+              <code
+                            idyllASTNode={
+                                          Object {
+                                                        "children": Array [
+                                                          Object {
+                                                            "id": 26,
+                                                            "type": "textnode",
+                                                            "value": "[Chart /]",
+                                                          },
+                                                        ],
+                                                        "id": 25,
+                                                        "name": "code",
+                                                        "type": "component",
+                                                      }
+                            }
+              >
                             [Chart /]
               </code>
                component can be used to render a simple visualization:
@@ -825,6 +5559,20 @@ ShallowWrapper {
                                         ]
               }
               domainPadding={0}
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 28,
+                                          "name": "Chart",
+                                          "properties": Object {
+                                            "type": Object {
+                                              "type": "value",
+                                              "value": "scatter",
+                                            },
+                                          },
+                                          "type": "component",
+                                        }
+              }
               range={
                             Array [
                                           -1,
@@ -834,61 +5582,463 @@ ShallowWrapper {
               samplePoints={100}
               type="scatter"
 />,
-            <p>
+            <p
+              idyllASTNode={
+                            Object {
+                                          "children": Array [
+                                            Object {
+                                              "id": 30,
+                                              "type": "textnode",
+                                              "value": "Try changing the chart’s type from ",
+                                            },
+                                            Object {
+                                              "children": Array [
+                                                Object {
+                                                  "id": 32,
+                                                  "type": "textnode",
+                                                  "value": "scatter",
+                                                },
+                                              ],
+                                              "id": 31,
+                                              "name": "code",
+                                              "type": "component",
+                                            },
+                                            Object {
+                                              "id": 33,
+                                              "type": "textnode",
+                                              "value": " to ",
+                                            },
+                                            Object {
+                                              "children": Array [
+                                                Object {
+                                                  "id": 35,
+                                                  "type": "textnode",
+                                                  "value": "line",
+                                                },
+                                              ],
+                                              "id": 34,
+                                              "name": "code",
+                                              "type": "component",
+                                            },
+                                            Object {
+                                              "id": 36,
+                                              "type": "textnode",
+                                              "value": ", ",
+                                            },
+                                            Object {
+                                              "children": Array [
+                                                Object {
+                                                  "id": 38,
+                                                  "type": "textnode",
+                                                  "value": "area",
+                                                },
+                                              ],
+                                              "id": 37,
+                                              "name": "code",
+                                              "type": "component",
+                                            },
+                                            Object {
+                                              "id": 39,
+                                              "type": "textnode",
+                                              "value": ", or ",
+                                            },
+                                            Object {
+                                              "children": Array [
+                                                Object {
+                                                  "id": 41,
+                                                  "type": "textnode",
+                                                  "value": "pie",
+                                                },
+                                              ],
+                                              "id": 40,
+                                              "name": "code",
+                                              "type": "component",
+                                            },
+                                            Object {
+                                              "id": 42,
+                                              "type": "textnode",
+                                              "value": ".",
+                                            },
+                                          ],
+                                          "id": 29,
+                                          "name": "p",
+                                          "type": "component",
+                                        }
+              }
+>
               Try changing the chart’s type from 
-              <code>
+              <code
+                            idyllASTNode={
+                                          Object {
+                                                        "children": Array [
+                                                          Object {
+                                                            "id": 32,
+                                                            "type": "textnode",
+                                                            "value": "scatter",
+                                                          },
+                                                        ],
+                                                        "id": 31,
+                                                        "name": "code",
+                                                        "type": "component",
+                                                      }
+                            }
+              >
                             scatter
               </code>
                to 
-              <code>
+              <code
+                            idyllASTNode={
+                                          Object {
+                                                        "children": Array [
+                                                          Object {
+                                                            "id": 35,
+                                                            "type": "textnode",
+                                                            "value": "line",
+                                                          },
+                                                        ],
+                                                        "id": 34,
+                                                        "name": "code",
+                                                        "type": "component",
+                                                      }
+                            }
+              >
                             line
               </code>
               , 
-              <code>
+              <code
+                            idyllASTNode={
+                                          Object {
+                                                        "children": Array [
+                                                          Object {
+                                                            "id": 38,
+                                                            "type": "textnode",
+                                                            "value": "area",
+                                                          },
+                                                        ],
+                                                        "id": 37,
+                                                        "name": "code",
+                                                        "type": "component",
+                                                      }
+                            }
+              >
                             area
               </code>
               , or 
-              <code>
+              <code
+                            idyllASTNode={
+                                          Object {
+                                                        "children": Array [
+                                                          Object {
+                                                            "id": 41,
+                                                            "type": "textnode",
+                                                            "value": "pie",
+                                                          },
+                                                        ],
+                                                        "id": 40,
+                                                        "name": "code",
+                                                        "type": "component",
+                                                      }
+                            }
+              >
                             pie
               </code>
               .
 </p>,
-            <p>
+            <p
+              idyllASTNode={
+                            Object {
+                                          "children": Array [
+                                            Object {
+                                              "id": 44,
+                                              "type": "textnode",
+                                              "value": "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (",
+                                            },
+                                            Object {
+                                              "children": Array [
+                                                Object {
+                                                  "id": 46,
+                                                  "type": "textnode",
+                                                  "value": "\`2 * Math.PI\`",
+                                                },
+                                              ],
+                                              "id": 45,
+                                              "name": "code",
+                                              "type": "component",
+                                            },
+                                            Object {
+                                              "id": 47,
+                                              "type": "textnode",
+                                              "value": ").",
+                                            },
+                                          ],
+                                          "id": 43,
+                                          "name": "p",
+                                          "type": "component",
+                                        }
+              }
+>
               A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (
-              <code>
+              <code
+                            idyllASTNode={
+                                          Object {
+                                                        "children": Array [
+                                                          Object {
+                                                            "id": 46,
+                                                            "type": "textnode",
+                                                            "value": "\`2 * Math.PI\`",
+                                                          },
+                                                        ],
+                                                        "id": 45,
+                                                        "name": "code",
+                                                        "type": "component",
+                                                      }
+                            }
+              >
                             \`2 * Math.PI\`
               </code>
               ).
 </p>,
-            <p>
+            <p
+              idyllASTNode={
+                            Object {
+                                          "children": Array [
+                                            Object {
+                                              "id": 49,
+                                              "type": "textnode",
+                                              "value": "There are a number of components available — see ",
+                                            },
+                                            Object {
+                                              "children": Array [
+                                                Object {
+                                                  "id": 51,
+                                                  "type": "textnode",
+                                                  "value": "Idyll’s documentation",
+                                                },
+                                              ],
+                                              "id": 50,
+                                              "name": "a",
+                                              "properties": Object {
+                                                "href": Object {
+                                                  "type": "value",
+                                                  "value": "https://idyll-lang.github.io/components-built-in",
+                                                },
+                                              },
+                                              "type": "component",
+                                            },
+                                            Object {
+                                              "id": 52,
+                                              "type": "textnode",
+                                              "value": " for a full list — Additional components can be installed via ",
+                                            },
+                                            Object {
+                                              "children": Array [
+                                                Object {
+                                                  "id": 54,
+                                                  "type": "textnode",
+                                                  "value": "npm",
+                                                },
+                                              ],
+                                              "id": 53,
+                                              "name": "code",
+                                              "type": "component",
+                                            },
+                                            Object {
+                                              "id": 55,
+                                              "type": "textnode",
+                                              "value": " (any React component should work), and if you are comfortable with JavaScript you can write ",
+                                            },
+                                            Object {
+                                              "children": Array [
+                                                Object {
+                                                  "id": 57,
+                                                  "type": "textnode",
+                                                  "value": "custom components",
+                                                },
+                                              ],
+                                              "id": 56,
+                                              "name": "a",
+                                              "properties": Object {
+                                                "href": Object {
+                                                  "type": "value",
+                                                  "value": "https://idyll-lang.github.io/components-custom",
+                                                },
+                                              },
+                                              "type": "component",
+                                            },
+                                            Object {
+                                              "id": 58,
+                                              "type": "textnode",
+                                              "value": " as well.",
+                                            },
+                                          ],
+                                          "id": 48,
+                                          "name": "p",
+                                          "type": "component",
+                                        }
+              }
+>
               There are a number of components available — see 
               <a
                             href="https://idyll-lang.github.io/components-built-in"
+                            idyllASTNode={
+                                          Object {
+                                                        "children": Array [
+                                                          Object {
+                                                            "id": 51,
+                                                            "type": "textnode",
+                                                            "value": "Idyll’s documentation",
+                                                          },
+                                                        ],
+                                                        "id": 50,
+                                                        "name": "a",
+                                                        "properties": Object {
+                                                          "href": Object {
+                                                            "type": "value",
+                                                            "value": "https://idyll-lang.github.io/components-built-in",
+                                                          },
+                                                        },
+                                                        "type": "component",
+                                                      }
+                            }
               >
                             Idyll’s documentation
               </a>
                for a full list — Additional components can be installed via 
-              <code>
+              <code
+                            idyllASTNode={
+                                          Object {
+                                                        "children": Array [
+                                                          Object {
+                                                            "id": 54,
+                                                            "type": "textnode",
+                                                            "value": "npm",
+                                                          },
+                                                        ],
+                                                        "id": 53,
+                                                        "name": "code",
+                                                        "type": "component",
+                                                      }
+                            }
+              >
                             npm
               </code>
                (any React component should work), and if you are comfortable with JavaScript you can write 
               <a
                             href="https://idyll-lang.github.io/components-custom"
+                            idyllASTNode={
+                                          Object {
+                                                        "children": Array [
+                                                          Object {
+                                                            "id": 57,
+                                                            "type": "textnode",
+                                                            "value": "custom components",
+                                                          },
+                                                        ],
+                                                        "id": 56,
+                                                        "name": "a",
+                                                        "properties": Object {
+                                                          "href": Object {
+                                                            "type": "value",
+                                                            "value": "https://idyll-lang.github.io/components-custom",
+                                                          },
+                                                        },
+                                                        "type": "component",
+                                                      }
+                            }
               >
                             custom components
               </a>
                as well.
 </p>,
-            <p>
+            <p
+              idyllASTNode={
+                            Object {
+                                          "children": Array [
+                                            Object {
+                                              "id": 60,
+                                              "type": "textnode",
+                                              "value": "Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.",
+                                            },
+                                          ],
+                                          "id": 59,
+                                          "name": "p",
+                                          "type": "component",
+                                        }
+              }
+>
               Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.
 </p>,
-            <p>
+            <p
+              idyllASTNode={
+                            Object {
+                                          "children": Array [
+                                            Object {
+                                              "id": 62,
+                                              "type": "textnode",
+                                              "value": "Instantiating a variable is similar to instantiating a component:",
+                                            },
+                                          ],
+                                          "id": 61,
+                                          "name": "p",
+                                          "type": "component",
+                                        }
+              }
+>
               Instantiating a variable is similar to instantiating a component:
 </p>,
-            <code>
+            <code
+              idyllASTNode={
+                            Object {
+                                          "children": Array [
+                                            Object {
+                                              "id": 64,
+                                              "type": "textnode",
+                                              "value": "[var name:\\"x\\" value:1 /]",
+                                            },
+                                          ],
+                                          "id": 63,
+                                          "name": "code",
+                                          "type": "component",
+                                        }
+              }
+>
               [var name:"x" value:1 /]
 </code>,
-            <p>
+            <p
+              idyllASTNode={
+                            Object {
+                                          "children": Array [
+                                            Object {
+                                              "id": 66,
+                                              "type": "textnode",
+                                              "value": "Once you’ve created a variable, it can be displayed inline with text
+                            (x = ",
+                                            },
+                                            Object {
+                                              "children": Array [],
+                                              "id": 67,
+                                              "name": "Display",
+                                              "properties": Object {
+                                                "var": Object {
+                                                  "type": "variable",
+                                                  "value": "x",
+                                                },
+                                              },
+                                              "type": "component",
+                                            },
+                                            Object {
+                                              "id": 68,
+                                              "type": "textnode",
+                                              "value": "),
+                            or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:",
+                                            },
+                                          ],
+                                          "id": 65,
+                                          "name": "p",
+                                          "type": "component",
+                                        }
+              }
+>
               Once you’ve created a variable, it can be displayed inline with text
               (x = 
               <Display
@@ -897,17 +6047,93 @@ ShallowWrapper {
                                                         "var": "x",
                                                       }
                             }
+                            idyllASTNode={
+                                          Object {
+                                                        "children": Array [],
+                                                        "id": 67,
+                                                        "name": "Display",
+                                                        "properties": Object {
+                                                          "var": Object {
+                                                            "type": "variable",
+                                                            "value": "x",
+                                                          },
+                                                        },
+                                                        "type": "component",
+                                                      }
+                            }
                             var="x"
               />
               ),
               or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:
 </p>,
-            <code>
+            <code
+              idyllASTNode={
+                            Object {
+                                          "children": Array [
+                                            Object {
+                                              "id": 70,
+                                              "type": "textnode",
+                                              "value": "[derived name:\\"xSquared\\" value:\`x * x\` /]",
+                                            },
+                                          ],
+                                          "id": 69,
+                                          "name": "code",
+                                          "type": "component",
+                                        }
+              }
+>
               [derived name:"xSquared" value:\`x * x\` /]
 </code>,
-            <p>
+            <p
+              idyllASTNode={
+                            Object {
+                                          "children": Array [
+                                            Object {
+                                              "id": 72,
+                                              "type": "textnode",
+                                              "value": "Here I bind the value of ",
+                                            },
+                                            Object {
+                                              "children": Array [
+                                                Object {
+                                                  "id": 74,
+                                                  "type": "textnode",
+                                                  "value": "x",
+                                                },
+                                              ],
+                                              "id": 73,
+                                              "name": "code",
+                                              "type": "component",
+                                            },
+                                            Object {
+                                              "id": 75,
+                                              "type": "textnode",
+                                              "value": " to a range slider. Move the slider and watch the variables update.",
+                                            },
+                                          ],
+                                          "id": 71,
+                                          "name": "p",
+                                          "type": "component",
+                                        }
+              }
+>
               Here I bind the value of 
-              <code>
+              <code
+                            idyllASTNode={
+                                          Object {
+                                                        "children": Array [
+                                                          Object {
+                                                            "id": 74,
+                                                            "type": "textnode",
+                                                            "value": "x",
+                                                          },
+                                                        ],
+                                                        "id": 73,
+                                                        "name": "code",
+                                                        "type": "component",
+                                                      }
+                            }
+              >
                             x
               </code>
                to a range slider. Move the slider and watch the variables update.
@@ -918,13 +6144,90 @@ ShallowWrapper {
                                           "value": "x",
                                         }
               }
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 76,
+                                          "name": "Range",
+                                          "properties": Object {
+                                            "max": Object {
+                                              "type": "value",
+                                              "value": 100,
+                                            },
+                                            "min": Object {
+                                              "type": "value",
+                                              "value": 0,
+                                            },
+                                            "value": Object {
+                                              "type": "variable",
+                                              "value": "x",
+                                            },
+                                          },
+                                          "type": "component",
+                                        }
+              }
               max={100}
               min={0}
               step={1}
               value="x"
 />,
-            <p>
-              <Equation>
+            <p
+              idyllASTNode={
+                            Object {
+                                          "children": Array [
+                                            Object {
+                                              "children": Array [
+                                                Object {
+                                                  "id": 79,
+                                                  "type": "textnode",
+                                                  "value": "x",
+                                                },
+                                              ],
+                                              "id": 78,
+                                              "name": "equation",
+                                              "type": "component",
+                                            },
+                                            Object {
+                                              "id": 80,
+                                              "type": "textnode",
+                                              "value": ":
+                             ",
+                                            },
+                                            Object {
+                                              "children": Array [],
+                                              "id": 81,
+                                              "name": "Display",
+                                              "properties": Object {
+                                                "var": Object {
+                                                  "type": "expression",
+                                                  "value": "x",
+                                                },
+                                              },
+                                              "type": "component",
+                                            },
+                                          ],
+                                          "id": 77,
+                                          "name": "p",
+                                          "type": "component",
+                                        }
+              }
+>
+              <Equation
+                            idyllASTNode={
+                                          Object {
+                                                        "children": Array [
+                                                          Object {
+                                                            "id": 79,
+                                                            "type": "textnode",
+                                                            "value": "x",
+                                                          },
+                                                        ],
+                                                        "id": 78,
+                                                        "name": "equation",
+                                                        "type": "component",
+                                                      }
+                            }
+              >
                             x
               </Equation>
               :
@@ -935,11 +6238,79 @@ ShallowWrapper {
                                                         "var": "x",
                                                       }
                             }
+                            idyllASTNode={
+                                          Object {
+                                                        "children": Array [],
+                                                        "id": 81,
+                                                        "name": "Display",
+                                                        "properties": Object {
+                                                          "var": Object {
+                                                            "type": "expression",
+                                                            "value": "x",
+                                                          },
+                                                        },
+                                                        "type": "component",
+                                                      }
+                            }
                             var="x"
               />
 </p>,
-            <p>
-              <Equation>
+            <p
+              idyllASTNode={
+                            Object {
+                                          "children": Array [
+                                            Object {
+                                              "children": Array [
+                                                Object {
+                                                  "id": 84,
+                                                  "type": "textnode",
+                                                  "value": "x^2",
+                                                },
+                                              ],
+                                              "id": 83,
+                                              "name": "equation",
+                                              "type": "component",
+                                            },
+                                            Object {
+                                              "id": 85,
+                                              "type": "textnode",
+                                              "value": ":",
+                                            },
+                                            Object {
+                                              "children": Array [],
+                                              "id": 86,
+                                              "name": "Display",
+                                              "properties": Object {
+                                                "var": Object {
+                                                  "type": "expression",
+                                                  "value": "xSquared",
+                                                },
+                                              },
+                                              "type": "component",
+                                            },
+                                          ],
+                                          "id": 82,
+                                          "name": "p",
+                                          "type": "component",
+                                        }
+              }
+>
+              <Equation
+                            idyllASTNode={
+                                          Object {
+                                                        "children": Array [
+                                                          Object {
+                                                            "id": 84,
+                                                            "type": "textnode",
+                                                            "value": "x^2",
+                                                          },
+                                                        ],
+                                                        "id": 83,
+                                                        "name": "equation",
+                                                        "type": "component",
+                                                      }
+                            }
+              >
                             x^2
               </Equation>
               :
@@ -949,10 +6320,39 @@ ShallowWrapper {
                                                         "var": "xSquared",
                                                       }
                             }
+                            idyllASTNode={
+                                          Object {
+                                                        "children": Array [],
+                                                        "id": 86,
+                                                        "name": "Display",
+                                                        "properties": Object {
+                                                          "var": Object {
+                                                            "type": "expression",
+                                                            "value": "xSquared",
+                                                          },
+                                                        },
+                                                        "type": "component",
+                                                      }
+                            }
                             var="xSquared"
               />
 </p>,
-            <p>
+            <p
+              idyllASTNode={
+                            Object {
+                                          "children": Array [
+                                            Object {
+                                              "id": 88,
+                                              "type": "textnode",
+                                              "value": "Test expression, displays:",
+                                            },
+                                          ],
+                                          "id": 87,
+                                          "name": "p",
+                                          "type": "component",
+                                        }
+              }
+>
               Test expression, displays:
 </p>,
             <Display
@@ -962,6 +6362,24 @@ ShallowWrapper {
                                         }
               }
               id="varDisplay"
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 89,
+                                          "name": "Display",
+                                          "properties": Object {
+                                            "id": Object {
+                                              "type": "value",
+                                              "value": "varDisplay",
+                                            },
+                                            "value": Object {
+                                              "type": "expression",
+                                              "value": "x",
+                                            },
+                                          },
+                                          "type": "component",
+                                        }
+              }
               value="x"
 />,
             <Display
@@ -971,6 +6389,24 @@ ShallowWrapper {
                                         }
               }
               id="derivedVarDisplay"
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 90,
+                                          "name": "Display",
+                                          "properties": Object {
+                                            "id": Object {
+                                              "type": "value",
+                                              "value": "derivedVarDisplay",
+                                            },
+                                            "value": Object {
+                                              "type": "expression",
+                                              "value": "xSquared",
+                                            },
+                                          },
+                                          "type": "component",
+                                        }
+              }
               value="xSquared"
 />,
             <Display
@@ -980,6 +6416,24 @@ ShallowWrapper {
                                         }
               }
               id="derivedVarDisplay2"
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 91,
+                                          "name": "Display",
+                                          "properties": Object {
+                                            "id": Object {
+                                              "type": "value",
+                                              "value": "derivedVarDisplay2",
+                                            },
+                                            "value": Object {
+                                              "type": "expression",
+                                              "value": "xCubed",
+                                            },
+                                          },
+                                          "type": "component",
+                                        }
+              }
               value="xCubed"
 />,
             <Display
@@ -989,6 +6443,24 @@ ShallowWrapper {
                                         }
               }
               id="strDisplay"
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 92,
+                                          "name": "Display",
+                                          "properties": Object {
+                                            "id": Object {
+                                              "type": "value",
+                                              "value": "strDisplay",
+                                            },
+                                            "value": Object {
+                                              "type": "expression",
+                                              "value": "\\"string\\"",
+                                            },
+                                          },
+                                          "type": "component",
+                                        }
+              }
               value="\\"string\\""
 />,
             <Display
@@ -998,6 +6470,24 @@ ShallowWrapper {
                                         }
               }
               id="staticObjectDisplay"
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 93,
+                                          "name": "Display",
+                                          "properties": Object {
+                                            "id": Object {
+                                              "type": "value",
+                                              "value": "staticObjectDisplay",
+                                            },
+                                            "value": Object {
+                                              "type": "expression",
+                                              "value": "{ static: \\"object\\" }",
+                                            },
+                                          },
+                                          "type": "component",
+                                        }
+              }
               value="{ static: \\"object\\" }"
 />,
             <Display
@@ -1007,6 +6497,24 @@ ShallowWrapper {
                                         }
               }
               id="dynamicObjectDisplay"
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 94,
+                                          "name": "Display",
+                                          "properties": Object {
+                                            "id": Object {
+                                              "type": "value",
+                                              "value": "dynamicObjectDisplay",
+                                            },
+                                            "value": Object {
+                                              "type": "expression",
+                                              "value": "{ dynamic: x }",
+                                            },
+                                          },
+                                          "type": "component",
+                                        }
+              }
               value="{ dynamic: x }"
 />,
             <Display
@@ -1016,6 +6524,24 @@ ShallowWrapper {
                                         }
               }
               id="dataDisplay"
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 95,
+                                          "name": "Display",
+                                          "properties": Object {
+                                            "id": Object {
+                                              "type": "value",
+                                              "value": "dataDisplay",
+                                            },
+                                            "value": Object {
+                                              "type": "expression",
+                                              "value": "myData",
+                                            },
+                                          },
+                                          "type": "component",
+                                        }
+              }
               value="myData"
 />,
             <Display
@@ -1025,6 +6551,24 @@ ShallowWrapper {
                                         }
               }
               id="bareDataDisplay"
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 96,
+                                          "name": "Display",
+                                          "properties": Object {
+                                            "id": Object {
+                                              "type": "value",
+                                              "value": "bareDataDisplay",
+                                            },
+                                            "value": Object {
+                                              "type": "variable",
+                                              "value": "myData",
+                                            },
+                                          },
+                                          "type": "component",
+                                        }
+              }
               value="myData"
 />,
             <Display
@@ -1034,6 +6578,24 @@ ShallowWrapper {
                                         }
               }
               id="bareVarDisplay"
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 97,
+                                          "name": "Display",
+                                          "properties": Object {
+                                            "id": Object {
+                                              "type": "value",
+                                              "value": "bareVarDisplay",
+                                            },
+                                            "value": Object {
+                                              "type": "variable",
+                                              "value": "x",
+                                            },
+                                          },
+                                          "type": "component",
+                                        }
+              }
               value="x"
 />,
             <Display
@@ -1043,6 +6605,24 @@ ShallowWrapper {
                                         }
               }
               id="bareDerivedDisplay"
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 98,
+                                          "name": "Display",
+                                          "properties": Object {
+                                            "id": Object {
+                                              "type": "value",
+                                              "value": "bareDerivedDisplay",
+                                            },
+                                            "value": Object {
+                                              "type": "variable",
+                                              "value": "xSquared",
+                                            },
+                                          },
+                                          "type": "component",
+                                        }
+              }
               value="xSquared"
 />,
             <Display
@@ -1052,6 +6632,24 @@ ShallowWrapper {
                                         }
               }
               id="bareDerivedDisplay2"
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 99,
+                                          "name": "Display",
+                                          "properties": Object {
+                                            "id": Object {
+                                              "type": "value",
+                                              "value": "bareDerivedDisplay2",
+                                            },
+                                            "value": Object {
+                                              "type": "variable",
+                                              "value": "xCubed",
+                                            },
+                                          },
+                                          "type": "component",
+                                        }
+              }
               value="xCubed"
 />,
             <Display
@@ -1061,6 +6659,24 @@ ShallowWrapper {
                                         }
               }
               id="objectVarDisplay"
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 100,
+                                          "name": "Display",
+                                          "properties": Object {
+                                            "id": Object {
+                                              "type": "value",
+                                              "value": "objectVarDisplay",
+                                            },
+                                            "value": Object {
+                                              "type": "expression",
+                                              "value": " objectVar ",
+                                            },
+                                          },
+                                          "type": "component",
+                                        }
+              }
               value=" objectVar "
 />,
             <Display
@@ -1070,6 +6686,24 @@ ShallowWrapper {
                                         }
               }
               id="bareObjectVarDisplay"
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 101,
+                                          "name": "Display",
+                                          "properties": Object {
+                                            "id": Object {
+                                              "type": "value",
+                                              "value": "bareObjectVarDisplay",
+                                            },
+                                            "value": Object {
+                                              "type": "variable",
+                                              "value": "objectVar",
+                                            },
+                                          },
+                                          "type": "component",
+                                        }
+              }
               value="objectVar"
 />,
             <Display
@@ -1079,6 +6713,24 @@ ShallowWrapper {
                                         }
               }
               id="arrayVarDisplay"
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 102,
+                                          "name": "Display",
+                                          "properties": Object {
+                                            "id": Object {
+                                              "type": "value",
+                                              "value": "arrayVarDisplay",
+                                            },
+                                            "value": Object {
+                                              "type": "expression",
+                                              "value": " arrayVar ",
+                                            },
+                                          },
+                                          "type": "component",
+                                        }
+              }
               value=" arrayVar "
 />,
             <Display
@@ -1088,10 +6740,52 @@ ShallowWrapper {
                                         }
               }
               id="bareArrayVarDisplay"
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 103,
+                                          "name": "Display",
+                                          "properties": Object {
+                                            "id": Object {
+                                              "type": "value",
+                                              "value": "bareArrayVarDisplay",
+                                            },
+                                            "value": Object {
+                                              "type": "variable",
+                                              "value": "arrayVar",
+                                            },
+                                          },
+                                          "type": "component",
+                                        }
+              }
               value="arrayVar"
 />,
-            <br />,
-            <p>
+            <br
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 104,
+                                          "name": "br",
+                                          "type": "component",
+                                        }
+              }
+/>,
+            <p
+              idyllASTNode={
+                            Object {
+                                          "children": Array [
+                                            Object {
+                                              "id": 106,
+                                              "type": "textnode",
+                                              "value": "Here is an example of how you could use a variable to control the frequency of a sine wave:",
+                                            },
+                                          ],
+                                          "id": 105,
+                                          "name": "p",
+                                          "type": "component",
+                                        }
+              }
+>
               Here is an example of how you could use a variable to control the frequency of a sine wave:
 </p>,
             <Chart
@@ -1104,6 +6798,28 @@ ShallowWrapper {
               domain="[0, 2 * Math.PI]"
               domainPadding={0}
               equation="(t) => Math.sin(t * frequency)"
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 107,
+                                          "name": "Chart",
+                                          "properties": Object {
+                                            "domain": Object {
+                                              "type": "expression",
+                                              "value": "[0, 2 * Math.PI]",
+                                            },
+                                            "equation": Object {
+                                              "type": "expression",
+                                              "value": "(t) => Math.sin(t * frequency)",
+                                            },
+                                            "samplePoints": Object {
+                                              "type": "value",
+                                              "value": 1000,
+                                            },
+                                          },
+                                          "type": "component",
+                                        }
+              }
               range={
                             Array [
                                           -1,
@@ -1124,12 +6840,70 @@ ShallowWrapper {
                                           "value": "frequency",
                                         }
               }
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 108,
+                                          "name": "Range",
+                                          "properties": Object {
+                                            "max": Object {
+                                              "type": "expression",
+                                              "value": "2 * Math.PI",
+                                            },
+                                            "min": Object {
+                                              "type": "value",
+                                              "value": 0.5,
+                                            },
+                                            "step": Object {
+                                              "type": "value",
+                                              "value": 0.0001,
+                                            },
+                                            "value": Object {
+                                              "type": "variable",
+                                              "value": "frequency",
+                                            },
+                                          },
+                                          "type": "component",
+                                        }
+              }
               max="2 * Math.PI"
               min={0.5}
               step={0.0001}
               value="frequency"
 />,
-            <p>
+            <p
+              idyllASTNode={
+                            Object {
+                                          "children": Array [
+                                            Object {
+                                              "children": Array [],
+                                              "id": 110,
+                                              "name": "Display",
+                                              "properties": Object {
+                                                "id": Object {
+                                                  "type": "value",
+                                                  "value": "lateVarDisplay",
+                                                },
+                                                "value": Object {
+                                                  "type": "variable",
+                                                  "value": "lateVar",
+                                                },
+                                              },
+                                              "type": "component",
+                                            },
+                                            Object {
+                                              "id": 111,
+                                              "type": "textnode",
+                                              "value": "
+                            Late Var Range:",
+                                            },
+                                          ],
+                                          "id": 109,
+                                          "name": "p",
+                                          "type": "component",
+                                        }
+              }
+>
               <Display
                             __vars__={
                                           Object {
@@ -1137,6 +6911,24 @@ ShallowWrapper {
                                                       }
                             }
                             id="lateVarDisplay"
+                            idyllASTNode={
+                                          Object {
+                                                        "children": Array [],
+                                                        "id": 110,
+                                                        "name": "Display",
+                                                        "properties": Object {
+                                                          "id": Object {
+                                                            "type": "value",
+                                                            "value": "lateVarDisplay",
+                                                          },
+                                                          "value": Object {
+                                                            "type": "variable",
+                                                            "value": "lateVar",
+                                                          },
+                                                        },
+                                                        "type": "component",
+                                                      }
+                            }
                             value="lateVar"
               />
               
@@ -1148,27 +6940,1081 @@ ShallowWrapper {
                                           "value": "lateVar",
                                         }
               }
+              idyllASTNode={
+                            Object {
+                                          "children": Array [],
+                                          "id": 112,
+                                          "name": "Range",
+                                          "properties": Object {
+                                            "max": Object {
+                                              "type": "value",
+                                              "value": 100,
+                                            },
+                                            "min": Object {
+                                              "type": "value",
+                                              "value": 2,
+                                            },
+                                            "value": Object {
+                                              "type": "variable",
+                                              "value": "lateVar",
+                                            },
+                                          },
+                                          "type": "component",
+                                        }
+              }
               max={100}
               min={2}
               step={1}
               value="lateVar"
 />,
-            <p>
+            <p
+              idyllASTNode={
+                            Object {
+                                          "children": Array [
+                                            Object {
+                                              "id": 114,
+                                              "type": "textnode",
+                                              "value": "Read more about Idyll at ",
+                                            },
+                                            Object {
+                                              "children": Array [
+                                                Object {
+                                                  "id": 116,
+                                                  "type": "textnode",
+                                                  "value": "https://idyll-lang.github.io/",
+                                                },
+                                              ],
+                                              "id": 115,
+                                              "name": "a",
+                                              "properties": Object {
+                                                "href": Object {
+                                                  "type": "value",
+                                                  "value": "https://idyll-lang.github.io/",
+                                                },
+                                              },
+                                              "type": "component",
+                                            },
+                                            Object {
+                                              "id": 117,
+                                              "type": "textnode",
+                                              "value": ", and come say “Hi!” in our ",
+                                            },
+                                            Object {
+                                              "children": Array [
+                                                Object {
+                                                  "id": 119,
+                                                  "type": "textnode",
+                                                  "value": "chatroom on gitter",
+                                                },
+                                              ],
+                                              "id": 118,
+                                              "name": "a",
+                                              "properties": Object {
+                                                "href": Object {
+                                                  "type": "value",
+                                                  "value": "https://gitter.im/idyll-lang/Lobby",
+                                                },
+                                              },
+                                              "type": "component",
+                                            },
+                                            Object {
+                                              "id": 120,
+                                              "type": "textnode",
+                                              "value": ".",
+                                            },
+                                          ],
+                                          "id": 113,
+                                          "name": "p",
+                                          "type": "component",
+                                        }
+              }
+>
               Read more about Idyll at 
               <a
                             href="https://idyll-lang.github.io/"
+                            idyllASTNode={
+                                          Object {
+                                                        "children": Array [
+                                                          Object {
+                                                            "id": 116,
+                                                            "type": "textnode",
+                                                            "value": "https://idyll-lang.github.io/",
+                                                          },
+                                                        ],
+                                                        "id": 115,
+                                                        "name": "a",
+                                                        "properties": Object {
+                                                          "href": Object {
+                                                            "type": "value",
+                                                            "value": "https://idyll-lang.github.io/",
+                                                          },
+                                                        },
+                                                        "type": "component",
+                                                      }
+                            }
               >
                             https://idyll-lang.github.io/
               </a>
               , and come say “Hi!” in our 
               <a
                             href="https://gitter.im/idyll-lang/Lobby"
+                            idyllASTNode={
+                                          Object {
+                                                        "children": Array [
+                                                          Object {
+                                                            "id": 119,
+                                                            "type": "textnode",
+                                                            "value": "chatroom on gitter",
+                                                          },
+                                                        ],
+                                                        "id": 118,
+                                                        "name": "a",
+                                                        "properties": Object {
+                                                          "href": Object {
+                                                            "type": "value",
+                                                            "value": "https://gitter.im/idyll-lang/Lobby",
+                                                          },
+                                                        },
+                                                        "type": "component",
+                                                      }
+                            }
               >
                             chatroom on gitter
               </a>
               .
 </p>,
           ],
+          "idyllASTNode": Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "id": 12,
+                    "type": "textnode",
+                    "value": "Welcome to Idyll",
+                  },
+                ],
+                "id": 11,
+                "name": "h1",
+                "type": "component",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "id": 14,
+                    "type": "textnode",
+                    "value": "Idyll is a language for creating interactive documents on the web.",
+                  },
+                ],
+                "id": 13,
+                "name": "h3",
+                "type": "component",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "id": 16,
+                    "type": "textnode",
+                    "value": "This document is being rendered from ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 18,
+                        "type": "textnode",
+                        "value": "Idyll markup",
+                      },
+                    ],
+                    "id": 17,
+                    "name": "strong",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 19,
+                    "type": "textnode",
+                    "value": ". If you’ve used ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 21,
+                        "type": "textnode",
+                        "value": "markdown",
+                      },
+                    ],
+                    "id": 20,
+                    "name": "a",
+                    "properties": Object {
+                      "href": Object {
+                        "type": "value",
+                        "value": "https://daringfireball.net/projects/markdown/",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 22,
+                    "type": "textnode",
+                    "value": ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.",
+                  },
+                ],
+                "id": 15,
+                "name": "p",
+                "type": "component",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "id": 24,
+                    "type": "textnode",
+                    "value": "To make things a little more interesting you can add JavaScript components to your text.
+For example, a ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 26,
+                        "type": "textnode",
+                        "value": "[Chart /]",
+                      },
+                    ],
+                    "id": 25,
+                    "name": "code",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 27,
+                    "type": "textnode",
+                    "value": " component can be used to render a simple visualization:",
+                  },
+                ],
+                "id": 23,
+                "name": "p",
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 28,
+                "name": "Chart",
+                "properties": Object {
+                  "type": Object {
+                    "type": "value",
+                    "value": "scatter",
+                  },
+                },
+                "type": "component",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "id": 30,
+                    "type": "textnode",
+                    "value": "Try changing the chart’s type from ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 32,
+                        "type": "textnode",
+                        "value": "scatter",
+                      },
+                    ],
+                    "id": 31,
+                    "name": "code",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 33,
+                    "type": "textnode",
+                    "value": " to ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 35,
+                        "type": "textnode",
+                        "value": "line",
+                      },
+                    ],
+                    "id": 34,
+                    "name": "code",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 36,
+                    "type": "textnode",
+                    "value": ", ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 38,
+                        "type": "textnode",
+                        "value": "area",
+                      },
+                    ],
+                    "id": 37,
+                    "name": "code",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 39,
+                    "type": "textnode",
+                    "value": ", or ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 41,
+                        "type": "textnode",
+                        "value": "pie",
+                      },
+                    ],
+                    "id": 40,
+                    "name": "code",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 42,
+                    "type": "textnode",
+                    "value": ".",
+                  },
+                ],
+                "id": 29,
+                "name": "p",
+                "type": "component",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "id": 44,
+                    "type": "textnode",
+                    "value": "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 46,
+                        "type": "textnode",
+                        "value": "\`2 * Math.PI\`",
+                      },
+                    ],
+                    "id": 45,
+                    "name": "code",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 47,
+                    "type": "textnode",
+                    "value": ").",
+                  },
+                ],
+                "id": 43,
+                "name": "p",
+                "type": "component",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "id": 49,
+                    "type": "textnode",
+                    "value": "There are a number of components available — see ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 51,
+                        "type": "textnode",
+                        "value": "Idyll’s documentation",
+                      },
+                    ],
+                    "id": 50,
+                    "name": "a",
+                    "properties": Object {
+                      "href": Object {
+                        "type": "value",
+                        "value": "https://idyll-lang.github.io/components-built-in",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 52,
+                    "type": "textnode",
+                    "value": " for a full list — Additional components can be installed via ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 54,
+                        "type": "textnode",
+                        "value": "npm",
+                      },
+                    ],
+                    "id": 53,
+                    "name": "code",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 55,
+                    "type": "textnode",
+                    "value": " (any React component should work), and if you are comfortable with JavaScript you can write ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 57,
+                        "type": "textnode",
+                        "value": "custom components",
+                      },
+                    ],
+                    "id": 56,
+                    "name": "a",
+                    "properties": Object {
+                      "href": Object {
+                        "type": "value",
+                        "value": "https://idyll-lang.github.io/components-custom",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 58,
+                    "type": "textnode",
+                    "value": " as well.",
+                  },
+                ],
+                "id": 48,
+                "name": "p",
+                "type": "component",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "id": 60,
+                    "type": "textnode",
+                    "value": "Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.",
+                  },
+                ],
+                "id": 59,
+                "name": "p",
+                "type": "component",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "id": 62,
+                    "type": "textnode",
+                    "value": "Instantiating a variable is similar to instantiating a component:",
+                  },
+                ],
+                "id": 61,
+                "name": "p",
+                "type": "component",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "id": 64,
+                    "type": "textnode",
+                    "value": "[var name:\\"x\\" value:1 /]",
+                  },
+                ],
+                "id": 63,
+                "name": "code",
+                "type": "component",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "id": 66,
+                    "type": "textnode",
+                    "value": "Once you’ve created a variable, it can be displayed inline with text
+(x = ",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 67,
+                    "name": "Display",
+                    "properties": Object {
+                      "var": Object {
+                        "type": "variable",
+                        "value": "x",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 68,
+                    "type": "textnode",
+                    "value": "),
+or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:",
+                  },
+                ],
+                "id": 65,
+                "name": "p",
+                "type": "component",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "id": 70,
+                    "type": "textnode",
+                    "value": "[derived name:\\"xSquared\\" value:\`x * x\` /]",
+                  },
+                ],
+                "id": 69,
+                "name": "code",
+                "type": "component",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "id": 72,
+                    "type": "textnode",
+                    "value": "Here I bind the value of ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 74,
+                        "type": "textnode",
+                        "value": "x",
+                      },
+                    ],
+                    "id": 73,
+                    "name": "code",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 75,
+                    "type": "textnode",
+                    "value": " to a range slider. Move the slider and watch the variables update.",
+                  },
+                ],
+                "id": 71,
+                "name": "p",
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 76,
+                "name": "Range",
+                "properties": Object {
+                  "max": Object {
+                    "type": "value",
+                    "value": 100,
+                  },
+                  "min": Object {
+                    "type": "value",
+                    "value": 0,
+                  },
+                  "value": Object {
+                    "type": "variable",
+                    "value": "x",
+                  },
+                },
+                "type": "component",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 79,
+                        "type": "textnode",
+                        "value": "x",
+                      },
+                    ],
+                    "id": 78,
+                    "name": "equation",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 80,
+                    "type": "textnode",
+                    "value": ":
+ ",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 81,
+                    "name": "Display",
+                    "properties": Object {
+                      "var": Object {
+                        "type": "expression",
+                        "value": "x",
+                      },
+                    },
+                    "type": "component",
+                  },
+                ],
+                "id": 77,
+                "name": "p",
+                "type": "component",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 84,
+                        "type": "textnode",
+                        "value": "x^2",
+                      },
+                    ],
+                    "id": 83,
+                    "name": "equation",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 85,
+                    "type": "textnode",
+                    "value": ":",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 86,
+                    "name": "Display",
+                    "properties": Object {
+                      "var": Object {
+                        "type": "expression",
+                        "value": "xSquared",
+                      },
+                    },
+                    "type": "component",
+                  },
+                ],
+                "id": 82,
+                "name": "p",
+                "type": "component",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "id": 88,
+                    "type": "textnode",
+                    "value": "Test expression, displays:",
+                  },
+                ],
+                "id": 87,
+                "name": "p",
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 89,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "varDisplay",
+                  },
+                  "value": Object {
+                    "type": "expression",
+                    "value": "x",
+                  },
+                },
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 90,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "derivedVarDisplay",
+                  },
+                  "value": Object {
+                    "type": "expression",
+                    "value": "xSquared",
+                  },
+                },
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 91,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "derivedVarDisplay2",
+                  },
+                  "value": Object {
+                    "type": "expression",
+                    "value": "xCubed",
+                  },
+                },
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 92,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "strDisplay",
+                  },
+                  "value": Object {
+                    "type": "expression",
+                    "value": "\\"string\\"",
+                  },
+                },
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 93,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "staticObjectDisplay",
+                  },
+                  "value": Object {
+                    "type": "expression",
+                    "value": "{ static: \\"object\\" }",
+                  },
+                },
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 94,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "dynamicObjectDisplay",
+                  },
+                  "value": Object {
+                    "type": "expression",
+                    "value": "{ dynamic: x }",
+                  },
+                },
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 95,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "dataDisplay",
+                  },
+                  "value": Object {
+                    "type": "expression",
+                    "value": "myData",
+                  },
+                },
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 96,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "bareDataDisplay",
+                  },
+                  "value": Object {
+                    "type": "variable",
+                    "value": "myData",
+                  },
+                },
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 97,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "bareVarDisplay",
+                  },
+                  "value": Object {
+                    "type": "variable",
+                    "value": "x",
+                  },
+                },
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 98,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "bareDerivedDisplay",
+                  },
+                  "value": Object {
+                    "type": "variable",
+                    "value": "xSquared",
+                  },
+                },
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 99,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "bareDerivedDisplay2",
+                  },
+                  "value": Object {
+                    "type": "variable",
+                    "value": "xCubed",
+                  },
+                },
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 100,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "objectVarDisplay",
+                  },
+                  "value": Object {
+                    "type": "expression",
+                    "value": " objectVar ",
+                  },
+                },
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 101,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "bareObjectVarDisplay",
+                  },
+                  "value": Object {
+                    "type": "variable",
+                    "value": "objectVar",
+                  },
+                },
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 102,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "arrayVarDisplay",
+                  },
+                  "value": Object {
+                    "type": "expression",
+                    "value": " arrayVar ",
+                  },
+                },
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 103,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "bareArrayVarDisplay",
+                  },
+                  "value": Object {
+                    "type": "variable",
+                    "value": "arrayVar",
+                  },
+                },
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 104,
+                "name": "br",
+                "type": "component",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "id": 106,
+                    "type": "textnode",
+                    "value": "Here is an example of how you could use a variable to control the frequency of a sine wave:",
+                  },
+                ],
+                "id": 105,
+                "name": "p",
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 107,
+                "name": "Chart",
+                "properties": Object {
+                  "domain": Object {
+                    "type": "expression",
+                    "value": "[0, 2 * Math.PI]",
+                  },
+                  "equation": Object {
+                    "type": "expression",
+                    "value": "(t) => Math.sin(t * frequency)",
+                  },
+                  "samplePoints": Object {
+                    "type": "value",
+                    "value": 1000,
+                  },
+                },
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 108,
+                "name": "Range",
+                "properties": Object {
+                  "max": Object {
+                    "type": "expression",
+                    "value": "2 * Math.PI",
+                  },
+                  "min": Object {
+                    "type": "value",
+                    "value": 0.5,
+                  },
+                  "step": Object {
+                    "type": "value",
+                    "value": 0.0001,
+                  },
+                  "value": Object {
+                    "type": "variable",
+                    "value": "frequency",
+                  },
+                },
+                "type": "component",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [],
+                    "id": 110,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "lateVarDisplay",
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "lateVar",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 111,
+                    "type": "textnode",
+                    "value": "
+Late Var Range:",
+                  },
+                ],
+                "id": 109,
+                "name": "p",
+                "type": "component",
+              },
+              Object {
+                "children": Array [],
+                "id": 112,
+                "name": "Range",
+                "properties": Object {
+                  "max": Object {
+                    "type": "value",
+                    "value": 100,
+                  },
+                  "min": Object {
+                    "type": "value",
+                    "value": 2,
+                  },
+                  "value": Object {
+                    "type": "variable",
+                    "value": "lateVar",
+                  },
+                },
+                "type": "component",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "id": 114,
+                    "type": "textnode",
+                    "value": "Read more about Idyll at ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 116,
+                        "type": "textnode",
+                        "value": "https://idyll-lang.github.io/",
+                      },
+                    ],
+                    "id": 115,
+                    "name": "a",
+                    "properties": Object {
+                      "href": Object {
+                        "type": "value",
+                        "value": "https://idyll-lang.github.io/",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 117,
+                    "type": "textnode",
+                    "value": ", and come say “Hi!” in our ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 119,
+                        "type": "textnode",
+                        "value": "chatroom on gitter",
+                      },
+                    ],
+                    "id": 118,
+                    "name": "a",
+                    "properties": Object {
+                      "href": Object {
+                        "type": "value",
+                        "value": "https://gitter.im/idyll-lang/Lobby",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 120,
+                    "type": "textnode",
+                    "value": ".",
+                  },
+                ],
+                "id": 113,
+                "name": "p",
+                "type": "component",
+              },
+            ],
+            "id": 10,
+            "name": "TextContainer",
+            "type": "component",
+          },
         },
         "ref": null,
         "rendered": Array [
@@ -1180,6 +8026,18 @@ ShallowWrapper {
               "children": Array [
                 "Welcome to Idyll",
               ],
+              "idyllASTNode": Object {
+                "children": Array [
+                  Object {
+                    "id": 12,
+                    "type": "textnode",
+                    "value": "Welcome to Idyll",
+                  },
+                ],
+                "id": 11,
+                "name": "h1",
+                "type": "component",
+              },
             },
             "ref": null,
             "rendered": Array [
@@ -1195,6 +8053,18 @@ ShallowWrapper {
               "children": Array [
                 "Idyll is a language for creating interactive documents on the web.",
               ],
+              "idyllASTNode": Object {
+                "children": Array [
+                  Object {
+                    "id": 14,
+                    "type": "textnode",
+                    "value": "Idyll is a language for creating interactive documents on the web.",
+                  },
+                ],
+                "id": 13,
+                "name": "h3",
+                "type": "component",
+              },
             },
             "ref": null,
             "rendered": Array [
@@ -1209,17 +8079,104 @@ ShallowWrapper {
             "props": Object {
               "children": Array [
                 "This document is being rendered from ",
-                <strong>
+                <strong
+                  idyllASTNode={
+                                    Object {
+                                                      "children": Array [
+                                                        Object {
+                                                          "id": 18,
+                                                          "type": "textnode",
+                                                          "value": "Idyll markup",
+                                                        },
+                                                      ],
+                                                      "id": 17,
+                                                      "name": "strong",
+                                                      "type": "component",
+                                                    }
+                  }
+>
                   Idyll markup
 </strong>,
                 ". If you’ve used ",
                 <a
                   href="https://daringfireball.net/projects/markdown/"
+                  idyllASTNode={
+                                    Object {
+                                                      "children": Array [
+                                                        Object {
+                                                          "id": 21,
+                                                          "type": "textnode",
+                                                          "value": "markdown",
+                                                        },
+                                                      ],
+                                                      "id": 20,
+                                                      "name": "a",
+                                                      "properties": Object {
+                                                        "href": Object {
+                                                          "type": "value",
+                                                          "value": "https://daringfireball.net/projects/markdown/",
+                                                        },
+                                                      },
+                                                      "type": "component",
+                                                    }
+                  }
 >
                   markdown
 </a>,
                 ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.",
               ],
+              "idyllASTNode": Object {
+                "children": Array [
+                  Object {
+                    "id": 16,
+                    "type": "textnode",
+                    "value": "This document is being rendered from ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 18,
+                        "type": "textnode",
+                        "value": "Idyll markup",
+                      },
+                    ],
+                    "id": 17,
+                    "name": "strong",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 19,
+                    "type": "textnode",
+                    "value": ". If you’ve used ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 21,
+                        "type": "textnode",
+                        "value": "markdown",
+                      },
+                    ],
+                    "id": 20,
+                    "name": "a",
+                    "properties": Object {
+                      "href": Object {
+                        "type": "value",
+                        "value": "https://daringfireball.net/projects/markdown/",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 22,
+                    "type": "textnode",
+                    "value": ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.",
+                  },
+                ],
+                "id": 15,
+                "name": "p",
+                "type": "component",
+              },
             },
             "ref": null,
             "rendered": Array [
@@ -1232,6 +8189,18 @@ ShallowWrapper {
                   "children": Array [
                     "Idyll markup",
                   ],
+                  "idyllASTNode": Object {
+                    "children": Array [
+                      Object {
+                        "id": 18,
+                        "type": "textnode",
+                        "value": "Idyll markup",
+                      },
+                    ],
+                    "id": 17,
+                    "name": "strong",
+                    "type": "component",
+                  },
                 },
                 "ref": null,
                 "rendered": Array [
@@ -1249,6 +8218,24 @@ ShallowWrapper {
                     "markdown",
                   ],
                   "href": "https://daringfireball.net/projects/markdown/",
+                  "idyllASTNode": Object {
+                    "children": Array [
+                      Object {
+                        "id": 21,
+                        "type": "textnode",
+                        "value": "markdown",
+                      },
+                    ],
+                    "id": 20,
+                    "name": "a",
+                    "properties": Object {
+                      "href": Object {
+                        "type": "value",
+                        "value": "https://daringfireball.net/projects/markdown/",
+                      },
+                    },
+                    "type": "component",
+                  },
                 },
                 "ref": null,
                 "rendered": Array [
@@ -1268,11 +8255,56 @@ ShallowWrapper {
               "children": Array [
                 "To make things a little more interesting you can add JavaScript components to your text.
 For example, a ",
-                <code>
+                <code
+                  idyllASTNode={
+                                    Object {
+                                                      "children": Array [
+                                                        Object {
+                                                          "id": 26,
+                                                          "type": "textnode",
+                                                          "value": "[Chart /]",
+                                                        },
+                                                      ],
+                                                      "id": 25,
+                                                      "name": "code",
+                                                      "type": "component",
+                                                    }
+                  }
+>
                   [Chart /]
 </code>,
                 " component can be used to render a simple visualization:",
               ],
+              "idyllASTNode": Object {
+                "children": Array [
+                  Object {
+                    "id": 24,
+                    "type": "textnode",
+                    "value": "To make things a little more interesting you can add JavaScript components to your text.
+For example, a ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 26,
+                        "type": "textnode",
+                        "value": "[Chart /]",
+                      },
+                    ],
+                    "id": 25,
+                    "name": "code",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 27,
+                    "type": "textnode",
+                    "value": " component can be used to render a simple visualization:",
+                  },
+                ],
+                "id": 23,
+                "name": "p",
+                "type": "component",
+              },
             },
             "ref": null,
             "rendered": Array [
@@ -1286,6 +8318,18 @@ For example, a ",
                   "children": Array [
                     "[Chart /]",
                   ],
+                  "idyllASTNode": Object {
+                    "children": Array [
+                      Object {
+                        "id": 26,
+                        "type": "textnode",
+                        "value": "[Chart /]",
+                      },
+                    ],
+                    "id": 25,
+                    "name": "code",
+                    "type": "component",
+                  },
                 },
                 "ref": null,
                 "rendered": Array [
@@ -1308,6 +8352,18 @@ For example, a ",
                 1,
               ],
               "domainPadding": 0,
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 28,
+                "name": "Chart",
+                "properties": Object {
+                  "type": Object {
+                    "type": "value",
+                    "value": "scatter",
+                  },
+                },
+                "type": "component",
+              },
               "range": Array [
                 -1,
                 1,
@@ -1326,23 +8382,163 @@ For example, a ",
             "props": Object {
               "children": Array [
                 "Try changing the chart’s type from ",
-                <code>
+                <code
+                  idyllASTNode={
+                                    Object {
+                                                      "children": Array [
+                                                        Object {
+                                                          "id": 32,
+                                                          "type": "textnode",
+                                                          "value": "scatter",
+                                                        },
+                                                      ],
+                                                      "id": 31,
+                                                      "name": "code",
+                                                      "type": "component",
+                                                    }
+                  }
+>
                   scatter
 </code>,
                 " to ",
-                <code>
+                <code
+                  idyllASTNode={
+                                    Object {
+                                                      "children": Array [
+                                                        Object {
+                                                          "id": 35,
+                                                          "type": "textnode",
+                                                          "value": "line",
+                                                        },
+                                                      ],
+                                                      "id": 34,
+                                                      "name": "code",
+                                                      "type": "component",
+                                                    }
+                  }
+>
                   line
 </code>,
                 ", ",
-                <code>
+                <code
+                  idyllASTNode={
+                                    Object {
+                                                      "children": Array [
+                                                        Object {
+                                                          "id": 38,
+                                                          "type": "textnode",
+                                                          "value": "area",
+                                                        },
+                                                      ],
+                                                      "id": 37,
+                                                      "name": "code",
+                                                      "type": "component",
+                                                    }
+                  }
+>
                   area
 </code>,
                 ", or ",
-                <code>
+                <code
+                  idyllASTNode={
+                                    Object {
+                                                      "children": Array [
+                                                        Object {
+                                                          "id": 41,
+                                                          "type": "textnode",
+                                                          "value": "pie",
+                                                        },
+                                                      ],
+                                                      "id": 40,
+                                                      "name": "code",
+                                                      "type": "component",
+                                                    }
+                  }
+>
                   pie
 </code>,
                 ".",
               ],
+              "idyllASTNode": Object {
+                "children": Array [
+                  Object {
+                    "id": 30,
+                    "type": "textnode",
+                    "value": "Try changing the chart’s type from ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 32,
+                        "type": "textnode",
+                        "value": "scatter",
+                      },
+                    ],
+                    "id": 31,
+                    "name": "code",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 33,
+                    "type": "textnode",
+                    "value": " to ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 35,
+                        "type": "textnode",
+                        "value": "line",
+                      },
+                    ],
+                    "id": 34,
+                    "name": "code",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 36,
+                    "type": "textnode",
+                    "value": ", ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 38,
+                        "type": "textnode",
+                        "value": "area",
+                      },
+                    ],
+                    "id": 37,
+                    "name": "code",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 39,
+                    "type": "textnode",
+                    "value": ", or ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 41,
+                        "type": "textnode",
+                        "value": "pie",
+                      },
+                    ],
+                    "id": 40,
+                    "name": "code",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 42,
+                    "type": "textnode",
+                    "value": ".",
+                  },
+                ],
+                "id": 29,
+                "name": "p",
+                "type": "component",
+              },
             },
             "ref": null,
             "rendered": Array [
@@ -1355,6 +8551,18 @@ For example, a ",
                   "children": Array [
                     "scatter",
                   ],
+                  "idyllASTNode": Object {
+                    "children": Array [
+                      Object {
+                        "id": 32,
+                        "type": "textnode",
+                        "value": "scatter",
+                      },
+                    ],
+                    "id": 31,
+                    "name": "code",
+                    "type": "component",
+                  },
                 },
                 "ref": null,
                 "rendered": Array [
@@ -1371,6 +8579,18 @@ For example, a ",
                   "children": Array [
                     "line",
                   ],
+                  "idyllASTNode": Object {
+                    "children": Array [
+                      Object {
+                        "id": 35,
+                        "type": "textnode",
+                        "value": "line",
+                      },
+                    ],
+                    "id": 34,
+                    "name": "code",
+                    "type": "component",
+                  },
                 },
                 "ref": null,
                 "rendered": Array [
@@ -1387,6 +8607,18 @@ For example, a ",
                   "children": Array [
                     "area",
                   ],
+                  "idyllASTNode": Object {
+                    "children": Array [
+                      Object {
+                        "id": 38,
+                        "type": "textnode",
+                        "value": "area",
+                      },
+                    ],
+                    "id": 37,
+                    "name": "code",
+                    "type": "component",
+                  },
                 },
                 "ref": null,
                 "rendered": Array [
@@ -1403,6 +8635,18 @@ For example, a ",
                   "children": Array [
                     "pie",
                   ],
+                  "idyllASTNode": Object {
+                    "children": Array [
+                      Object {
+                        "id": 41,
+                        "type": "textnode",
+                        "value": "pie",
+                      },
+                    ],
+                    "id": 40,
+                    "name": "code",
+                    "type": "component",
+                  },
                 },
                 "ref": null,
                 "rendered": Array [
@@ -1421,11 +8665,55 @@ For example, a ",
             "props": Object {
               "children": Array [
                 "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (",
-                <code>
+                <code
+                  idyllASTNode={
+                                    Object {
+                                                      "children": Array [
+                                                        Object {
+                                                          "id": 46,
+                                                          "type": "textnode",
+                                                          "value": "\`2 * Math.PI\`",
+                                                        },
+                                                      ],
+                                                      "id": 45,
+                                                      "name": "code",
+                                                      "type": "component",
+                                                    }
+                  }
+>
                   \`2 * Math.PI\`
 </code>,
                 ").",
               ],
+              "idyllASTNode": Object {
+                "children": Array [
+                  Object {
+                    "id": 44,
+                    "type": "textnode",
+                    "value": "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 46,
+                        "type": "textnode",
+                        "value": "\`2 * Math.PI\`",
+                      },
+                    ],
+                    "id": 45,
+                    "name": "code",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 47,
+                    "type": "textnode",
+                    "value": ").",
+                  },
+                ],
+                "id": 43,
+                "name": "p",
+                "type": "component",
+              },
             },
             "ref": null,
             "rendered": Array [
@@ -1438,6 +8726,18 @@ For example, a ",
                   "children": Array [
                     "\`2 * Math.PI\`",
                   ],
+                  "idyllASTNode": Object {
+                    "children": Array [
+                      Object {
+                        "id": 46,
+                        "type": "textnode",
+                        "value": "\`2 * Math.PI\`",
+                      },
+                    ],
+                    "id": 45,
+                    "name": "code",
+                    "type": "component",
+                  },
                 },
                 "ref": null,
                 "rendered": Array [
@@ -1458,21 +8758,151 @@ For example, a ",
                 "There are a number of components available — see ",
                 <a
                   href="https://idyll-lang.github.io/components-built-in"
+                  idyllASTNode={
+                                    Object {
+                                                      "children": Array [
+                                                        Object {
+                                                          "id": 51,
+                                                          "type": "textnode",
+                                                          "value": "Idyll’s documentation",
+                                                        },
+                                                      ],
+                                                      "id": 50,
+                                                      "name": "a",
+                                                      "properties": Object {
+                                                        "href": Object {
+                                                          "type": "value",
+                                                          "value": "https://idyll-lang.github.io/components-built-in",
+                                                        },
+                                                      },
+                                                      "type": "component",
+                                                    }
+                  }
 >
                   Idyll’s documentation
 </a>,
                 " for a full list — Additional components can be installed via ",
-                <code>
+                <code
+                  idyllASTNode={
+                                    Object {
+                                                      "children": Array [
+                                                        Object {
+                                                          "id": 54,
+                                                          "type": "textnode",
+                                                          "value": "npm",
+                                                        },
+                                                      ],
+                                                      "id": 53,
+                                                      "name": "code",
+                                                      "type": "component",
+                                                    }
+                  }
+>
                   npm
 </code>,
                 " (any React component should work), and if you are comfortable with JavaScript you can write ",
                 <a
                   href="https://idyll-lang.github.io/components-custom"
+                  idyllASTNode={
+                                    Object {
+                                                      "children": Array [
+                                                        Object {
+                                                          "id": 57,
+                                                          "type": "textnode",
+                                                          "value": "custom components",
+                                                        },
+                                                      ],
+                                                      "id": 56,
+                                                      "name": "a",
+                                                      "properties": Object {
+                                                        "href": Object {
+                                                          "type": "value",
+                                                          "value": "https://idyll-lang.github.io/components-custom",
+                                                        },
+                                                      },
+                                                      "type": "component",
+                                                    }
+                  }
 >
                   custom components
 </a>,
                 " as well.",
               ],
+              "idyllASTNode": Object {
+                "children": Array [
+                  Object {
+                    "id": 49,
+                    "type": "textnode",
+                    "value": "There are a number of components available — see ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 51,
+                        "type": "textnode",
+                        "value": "Idyll’s documentation",
+                      },
+                    ],
+                    "id": 50,
+                    "name": "a",
+                    "properties": Object {
+                      "href": Object {
+                        "type": "value",
+                        "value": "https://idyll-lang.github.io/components-built-in",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 52,
+                    "type": "textnode",
+                    "value": " for a full list — Additional components can be installed via ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 54,
+                        "type": "textnode",
+                        "value": "npm",
+                      },
+                    ],
+                    "id": 53,
+                    "name": "code",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 55,
+                    "type": "textnode",
+                    "value": " (any React component should work), and if you are comfortable with JavaScript you can write ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 57,
+                        "type": "textnode",
+                        "value": "custom components",
+                      },
+                    ],
+                    "id": 56,
+                    "name": "a",
+                    "properties": Object {
+                      "href": Object {
+                        "type": "value",
+                        "value": "https://idyll-lang.github.io/components-custom",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 58,
+                    "type": "textnode",
+                    "value": " as well.",
+                  },
+                ],
+                "id": 48,
+                "name": "p",
+                "type": "component",
+              },
             },
             "ref": null,
             "rendered": Array [
@@ -1486,6 +8916,24 @@ For example, a ",
                     "Idyll’s documentation",
                   ],
                   "href": "https://idyll-lang.github.io/components-built-in",
+                  "idyllASTNode": Object {
+                    "children": Array [
+                      Object {
+                        "id": 51,
+                        "type": "textnode",
+                        "value": "Idyll’s documentation",
+                      },
+                    ],
+                    "id": 50,
+                    "name": "a",
+                    "properties": Object {
+                      "href": Object {
+                        "type": "value",
+                        "value": "https://idyll-lang.github.io/components-built-in",
+                      },
+                    },
+                    "type": "component",
+                  },
                 },
                 "ref": null,
                 "rendered": Array [
@@ -1502,6 +8950,18 @@ For example, a ",
                   "children": Array [
                     "npm",
                   ],
+                  "idyllASTNode": Object {
+                    "children": Array [
+                      Object {
+                        "id": 54,
+                        "type": "textnode",
+                        "value": "npm",
+                      },
+                    ],
+                    "id": 53,
+                    "name": "code",
+                    "type": "component",
+                  },
                 },
                 "ref": null,
                 "rendered": Array [
@@ -1519,6 +8979,24 @@ For example, a ",
                     "custom components",
                   ],
                   "href": "https://idyll-lang.github.io/components-custom",
+                  "idyllASTNode": Object {
+                    "children": Array [
+                      Object {
+                        "id": 57,
+                        "type": "textnode",
+                        "value": "custom components",
+                      },
+                    ],
+                    "id": 56,
+                    "name": "a",
+                    "properties": Object {
+                      "href": Object {
+                        "type": "value",
+                        "value": "https://idyll-lang.github.io/components-custom",
+                      },
+                    },
+                    "type": "component",
+                  },
                 },
                 "ref": null,
                 "rendered": Array [
@@ -1538,6 +9016,18 @@ For example, a ",
               "children": Array [
                 "Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.",
               ],
+              "idyllASTNode": Object {
+                "children": Array [
+                  Object {
+                    "id": 60,
+                    "type": "textnode",
+                    "value": "Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.",
+                  },
+                ],
+                "id": 59,
+                "name": "p",
+                "type": "component",
+              },
             },
             "ref": null,
             "rendered": Array [
@@ -1553,6 +9043,18 @@ For example, a ",
               "children": Array [
                 "Instantiating a variable is similar to instantiating a component:",
               ],
+              "idyllASTNode": Object {
+                "children": Array [
+                  Object {
+                    "id": 62,
+                    "type": "textnode",
+                    "value": "Instantiating a variable is similar to instantiating a component:",
+                  },
+                ],
+                "id": 61,
+                "name": "p",
+                "type": "component",
+              },
             },
             "ref": null,
             "rendered": Array [
@@ -1568,6 +9070,18 @@ For example, a ",
               "children": Array [
                 "[var name:\\"x\\" value:1 /]",
               ],
+              "idyllASTNode": Object {
+                "children": Array [
+                  Object {
+                    "id": 64,
+                    "type": "textnode",
+                    "value": "[var name:\\"x\\" value:1 /]",
+                  },
+                ],
+                "id": 63,
+                "name": "code",
+                "type": "component",
+              },
             },
             "ref": null,
             "rendered": Array [
@@ -1589,11 +9103,56 @@ For example, a ",
                                                       "var": "x",
                                                     }
                   }
+                  idyllASTNode={
+                                    Object {
+                                                      "children": Array [],
+                                                      "id": 67,
+                                                      "name": "Display",
+                                                      "properties": Object {
+                                                        "var": Object {
+                                                          "type": "variable",
+                                                          "value": "x",
+                                                        },
+                                                      },
+                                                      "type": "component",
+                                                    }
+                  }
                   var="x"
 />,
                 "),
 or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:",
               ],
+              "idyllASTNode": Object {
+                "children": Array [
+                  Object {
+                    "id": 66,
+                    "type": "textnode",
+                    "value": "Once you’ve created a variable, it can be displayed inline with text
+(x = ",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 67,
+                    "name": "Display",
+                    "properties": Object {
+                      "var": Object {
+                        "type": "variable",
+                        "value": "x",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 68,
+                    "type": "textnode",
+                    "value": "),
+or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:",
+                  },
+                ],
+                "id": 65,
+                "name": "p",
+                "type": "component",
+              },
             },
             "ref": null,
             "rendered": Array [
@@ -1608,6 +9167,18 @@ or be used to parameterize components. Derived variables can be used to create v
                     "var": "x",
                   },
                   "children": undefined,
+                  "idyllASTNode": Object {
+                    "children": Array [],
+                    "id": 67,
+                    "name": "Display",
+                    "properties": Object {
+                      "var": Object {
+                        "type": "variable",
+                        "value": "x",
+                      },
+                    },
+                    "type": "component",
+                  },
                   "var": "x",
                 },
                 "ref": null,
@@ -1627,6 +9198,18 @@ or be used to parameterize components. Derived variables can be used to create v
               "children": Array [
                 "[derived name:\\"xSquared\\" value:\`x * x\` /]",
               ],
+              "idyllASTNode": Object {
+                "children": Array [
+                  Object {
+                    "id": 70,
+                    "type": "textnode",
+                    "value": "[derived name:\\"xSquared\\" value:\`x * x\` /]",
+                  },
+                ],
+                "id": 69,
+                "name": "code",
+                "type": "component",
+              },
             },
             "ref": null,
             "rendered": Array [
@@ -1641,11 +9224,55 @@ or be used to parameterize components. Derived variables can be used to create v
             "props": Object {
               "children": Array [
                 "Here I bind the value of ",
-                <code>
+                <code
+                  idyllASTNode={
+                                    Object {
+                                                      "children": Array [
+                                                        Object {
+                                                          "id": 74,
+                                                          "type": "textnode",
+                                                          "value": "x",
+                                                        },
+                                                      ],
+                                                      "id": 73,
+                                                      "name": "code",
+                                                      "type": "component",
+                                                    }
+                  }
+>
                   x
 </code>,
                 " to a range slider. Move the slider and watch the variables update.",
               ],
+              "idyllASTNode": Object {
+                "children": Array [
+                  Object {
+                    "id": 72,
+                    "type": "textnode",
+                    "value": "Here I bind the value of ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 74,
+                        "type": "textnode",
+                        "value": "x",
+                      },
+                    ],
+                    "id": 73,
+                    "name": "code",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 75,
+                    "type": "textnode",
+                    "value": " to a range slider. Move the slider and watch the variables update.",
+                  },
+                ],
+                "id": 71,
+                "name": "p",
+                "type": "component",
+              },
             },
             "ref": null,
             "rendered": Array [
@@ -1658,6 +9285,18 @@ or be used to parameterize components. Derived variables can be used to create v
                   "children": Array [
                     "x",
                   ],
+                  "idyllASTNode": Object {
+                    "children": Array [
+                      Object {
+                        "id": 74,
+                        "type": "textnode",
+                        "value": "x",
+                      },
+                    ],
+                    "id": 73,
+                    "name": "code",
+                    "type": "component",
+                  },
                 },
                 "ref": null,
                 "rendered": Array [
@@ -1678,6 +9317,26 @@ or be used to parameterize components. Derived variables can be used to create v
                 "value": "x",
               },
               "children": undefined,
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 76,
+                "name": "Range",
+                "properties": Object {
+                  "max": Object {
+                    "type": "value",
+                    "value": 100,
+                  },
+                  "min": Object {
+                    "type": "value",
+                    "value": 0,
+                  },
+                  "value": Object {
+                    "type": "variable",
+                    "value": "x",
+                  },
+                },
+                "type": "component",
+              },
               "max": 100,
               "min": 0,
               "step": 1,
@@ -1693,7 +9352,22 @@ or be used to parameterize components. Derived variables can be used to create v
             "nodeType": "host",
             "props": Object {
               "children": Array [
-                <Equation>
+                <Equation
+                  idyllASTNode={
+                                    Object {
+                                                      "children": Array [
+                                                        Object {
+                                                          "id": 79,
+                                                          "type": "textnode",
+                                                          "value": "x",
+                                                        },
+                                                      ],
+                                                      "id": 78,
+                                                      "name": "equation",
+                                                      "type": "component",
+                                                    }
+                  }
+>
                   x
 </Equation>,
                 ":
@@ -1704,9 +9378,60 @@ or be used to parameterize components. Derived variables can be used to create v
                                                       "var": "x",
                                                     }
                   }
+                  idyllASTNode={
+                                    Object {
+                                                      "children": Array [],
+                                                      "id": 81,
+                                                      "name": "Display",
+                                                      "properties": Object {
+                                                        "var": Object {
+                                                          "type": "expression",
+                                                          "value": "x",
+                                                        },
+                                                      },
+                                                      "type": "component",
+                                                    }
+                  }
                   var="x"
 />,
               ],
+              "idyllASTNode": Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 79,
+                        "type": "textnode",
+                        "value": "x",
+                      },
+                    ],
+                    "id": 78,
+                    "name": "equation",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 80,
+                    "type": "textnode",
+                    "value": ":
+ ",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 81,
+                    "name": "Display",
+                    "properties": Object {
+                      "var": Object {
+                        "type": "expression",
+                        "value": "x",
+                      },
+                    },
+                    "type": "component",
+                  },
+                ],
+                "id": 77,
+                "name": "p",
+                "type": "component",
+              },
             },
             "ref": null,
             "rendered": Array [
@@ -1718,6 +9443,18 @@ or be used to parameterize components. Derived variables can be used to create v
                   "children": Array [
                     "x",
                   ],
+                  "idyllASTNode": Object {
+                    "children": Array [
+                      Object {
+                        "id": 79,
+                        "type": "textnode",
+                        "value": "x",
+                      },
+                    ],
+                    "id": 78,
+                    "name": "equation",
+                    "type": "component",
+                  },
                 },
                 "ref": null,
                 "rendered": Array [
@@ -1736,6 +9473,18 @@ or be used to parameterize components. Derived variables can be used to create v
                     "var": "x",
                   },
                   "children": undefined,
+                  "idyllASTNode": Object {
+                    "children": Array [],
+                    "id": 81,
+                    "name": "Display",
+                    "properties": Object {
+                      "var": Object {
+                        "type": "expression",
+                        "value": "x",
+                      },
+                    },
+                    "type": "component",
+                  },
                   "var": "x",
                 },
                 "ref": null,
@@ -1751,7 +9500,22 @@ or be used to parameterize components. Derived variables can be used to create v
             "nodeType": "host",
             "props": Object {
               "children": Array [
-                <Equation>
+                <Equation
+                  idyllASTNode={
+                                    Object {
+                                                      "children": Array [
+                                                        Object {
+                                                          "id": 84,
+                                                          "type": "textnode",
+                                                          "value": "x^2",
+                                                        },
+                                                      ],
+                                                      "id": 83,
+                                                      "name": "equation",
+                                                      "type": "component",
+                                                    }
+                  }
+>
                   x^2
 </Equation>,
                 ":",
@@ -1761,9 +9525,59 @@ or be used to parameterize components. Derived variables can be used to create v
                                                       "var": "xSquared",
                                                     }
                   }
+                  idyllASTNode={
+                                    Object {
+                                                      "children": Array [],
+                                                      "id": 86,
+                                                      "name": "Display",
+                                                      "properties": Object {
+                                                        "var": Object {
+                                                          "type": "expression",
+                                                          "value": "xSquared",
+                                                        },
+                                                      },
+                                                      "type": "component",
+                                                    }
+                  }
                   var="xSquared"
 />,
               ],
+              "idyllASTNode": Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 84,
+                        "type": "textnode",
+                        "value": "x^2",
+                      },
+                    ],
+                    "id": 83,
+                    "name": "equation",
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 85,
+                    "type": "textnode",
+                    "value": ":",
+                  },
+                  Object {
+                    "children": Array [],
+                    "id": 86,
+                    "name": "Display",
+                    "properties": Object {
+                      "var": Object {
+                        "type": "expression",
+                        "value": "xSquared",
+                      },
+                    },
+                    "type": "component",
+                  },
+                ],
+                "id": 82,
+                "name": "p",
+                "type": "component",
+              },
             },
             "ref": null,
             "rendered": Array [
@@ -1775,6 +9589,18 @@ or be used to parameterize components. Derived variables can be used to create v
                   "children": Array [
                     "x^2",
                   ],
+                  "idyllASTNode": Object {
+                    "children": Array [
+                      Object {
+                        "id": 84,
+                        "type": "textnode",
+                        "value": "x^2",
+                      },
+                    ],
+                    "id": 83,
+                    "name": "equation",
+                    "type": "component",
+                  },
                 },
                 "ref": null,
                 "rendered": Array [
@@ -1792,6 +9618,18 @@ or be used to parameterize components. Derived variables can be used to create v
                     "var": "xSquared",
                   },
                   "children": undefined,
+                  "idyllASTNode": Object {
+                    "children": Array [],
+                    "id": 86,
+                    "name": "Display",
+                    "properties": Object {
+                      "var": Object {
+                        "type": "expression",
+                        "value": "xSquared",
+                      },
+                    },
+                    "type": "component",
+                  },
                   "var": "xSquared",
                 },
                 "ref": null,
@@ -1809,6 +9647,18 @@ or be used to parameterize components. Derived variables can be used to create v
               "children": Array [
                 "Test expression, displays:",
               ],
+              "idyllASTNode": Object {
+                "children": Array [
+                  Object {
+                    "id": 88,
+                    "type": "textnode",
+                    "value": "Test expression, displays:",
+                  },
+                ],
+                "id": 87,
+                "name": "p",
+                "type": "component",
+              },
             },
             "ref": null,
             "rendered": Array [
@@ -1826,6 +9676,22 @@ or be used to parameterize components. Derived variables can be used to create v
               },
               "children": undefined,
               "id": "varDisplay",
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 89,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "varDisplay",
+                  },
+                  "value": Object {
+                    "type": "expression",
+                    "value": "x",
+                  },
+                },
+                "type": "component",
+              },
               "value": "x",
             },
             "ref": null,
@@ -1842,6 +9708,22 @@ or be used to parameterize components. Derived variables can be used to create v
               },
               "children": undefined,
               "id": "derivedVarDisplay",
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 90,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "derivedVarDisplay",
+                  },
+                  "value": Object {
+                    "type": "expression",
+                    "value": "xSquared",
+                  },
+                },
+                "type": "component",
+              },
               "value": "xSquared",
             },
             "ref": null,
@@ -1858,6 +9740,22 @@ or be used to parameterize components. Derived variables can be used to create v
               },
               "children": undefined,
               "id": "derivedVarDisplay2",
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 91,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "derivedVarDisplay2",
+                  },
+                  "value": Object {
+                    "type": "expression",
+                    "value": "xCubed",
+                  },
+                },
+                "type": "component",
+              },
               "value": "xCubed",
             },
             "ref": null,
@@ -1874,6 +9772,22 @@ or be used to parameterize components. Derived variables can be used to create v
               },
               "children": undefined,
               "id": "strDisplay",
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 92,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "strDisplay",
+                  },
+                  "value": Object {
+                    "type": "expression",
+                    "value": "\\"string\\"",
+                  },
+                },
+                "type": "component",
+              },
               "value": "\\"string\\"",
             },
             "ref": null,
@@ -1890,6 +9804,22 @@ or be used to parameterize components. Derived variables can be used to create v
               },
               "children": undefined,
               "id": "staticObjectDisplay",
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 93,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "staticObjectDisplay",
+                  },
+                  "value": Object {
+                    "type": "expression",
+                    "value": "{ static: \\"object\\" }",
+                  },
+                },
+                "type": "component",
+              },
               "value": "{ static: \\"object\\" }",
             },
             "ref": null,
@@ -1906,6 +9836,22 @@ or be used to parameterize components. Derived variables can be used to create v
               },
               "children": undefined,
               "id": "dynamicObjectDisplay",
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 94,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "dynamicObjectDisplay",
+                  },
+                  "value": Object {
+                    "type": "expression",
+                    "value": "{ dynamic: x }",
+                  },
+                },
+                "type": "component",
+              },
               "value": "{ dynamic: x }",
             },
             "ref": null,
@@ -1922,6 +9868,22 @@ or be used to parameterize components. Derived variables can be used to create v
               },
               "children": undefined,
               "id": "dataDisplay",
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 95,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "dataDisplay",
+                  },
+                  "value": Object {
+                    "type": "expression",
+                    "value": "myData",
+                  },
+                },
+                "type": "component",
+              },
               "value": "myData",
             },
             "ref": null,
@@ -1938,6 +9900,22 @@ or be used to parameterize components. Derived variables can be used to create v
               },
               "children": undefined,
               "id": "bareDataDisplay",
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 96,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "bareDataDisplay",
+                  },
+                  "value": Object {
+                    "type": "variable",
+                    "value": "myData",
+                  },
+                },
+                "type": "component",
+              },
               "value": "myData",
             },
             "ref": null,
@@ -1954,6 +9932,22 @@ or be used to parameterize components. Derived variables can be used to create v
               },
               "children": undefined,
               "id": "bareVarDisplay",
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 97,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "bareVarDisplay",
+                  },
+                  "value": Object {
+                    "type": "variable",
+                    "value": "x",
+                  },
+                },
+                "type": "component",
+              },
               "value": "x",
             },
             "ref": null,
@@ -1970,6 +9964,22 @@ or be used to parameterize components. Derived variables can be used to create v
               },
               "children": undefined,
               "id": "bareDerivedDisplay",
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 98,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "bareDerivedDisplay",
+                  },
+                  "value": Object {
+                    "type": "variable",
+                    "value": "xSquared",
+                  },
+                },
+                "type": "component",
+              },
               "value": "xSquared",
             },
             "ref": null,
@@ -1986,6 +9996,22 @@ or be used to parameterize components. Derived variables can be used to create v
               },
               "children": undefined,
               "id": "bareDerivedDisplay2",
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 99,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "bareDerivedDisplay2",
+                  },
+                  "value": Object {
+                    "type": "variable",
+                    "value": "xCubed",
+                  },
+                },
+                "type": "component",
+              },
               "value": "xCubed",
             },
             "ref": null,
@@ -2002,6 +10028,22 @@ or be used to parameterize components. Derived variables can be used to create v
               },
               "children": undefined,
               "id": "objectVarDisplay",
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 100,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "objectVarDisplay",
+                  },
+                  "value": Object {
+                    "type": "expression",
+                    "value": " objectVar ",
+                  },
+                },
+                "type": "component",
+              },
               "value": " objectVar ",
             },
             "ref": null,
@@ -2018,6 +10060,22 @@ or be used to parameterize components. Derived variables can be used to create v
               },
               "children": undefined,
               "id": "bareObjectVarDisplay",
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 101,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "bareObjectVarDisplay",
+                  },
+                  "value": Object {
+                    "type": "variable",
+                    "value": "objectVar",
+                  },
+                },
+                "type": "component",
+              },
               "value": "objectVar",
             },
             "ref": null,
@@ -2034,6 +10092,22 @@ or be used to parameterize components. Derived variables can be used to create v
               },
               "children": undefined,
               "id": "arrayVarDisplay",
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 102,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "arrayVarDisplay",
+                  },
+                  "value": Object {
+                    "type": "expression",
+                    "value": " arrayVar ",
+                  },
+                },
+                "type": "component",
+              },
               "value": " arrayVar ",
             },
             "ref": null,
@@ -2050,6 +10124,22 @@ or be used to parameterize components. Derived variables can be used to create v
               },
               "children": undefined,
               "id": "bareArrayVarDisplay",
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 103,
+                "name": "Display",
+                "properties": Object {
+                  "id": Object {
+                    "type": "value",
+                    "value": "bareArrayVarDisplay",
+                  },
+                  "value": Object {
+                    "type": "variable",
+                    "value": "arrayVar",
+                  },
+                },
+                "type": "component",
+              },
               "value": "arrayVar",
             },
             "ref": null,
@@ -2062,6 +10152,12 @@ or be used to parameterize components. Derived variables can be used to create v
             "nodeType": "host",
             "props": Object {
               "children": undefined,
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 104,
+                "name": "br",
+                "type": "component",
+              },
             },
             "ref": null,
             "rendered": null,
@@ -2075,6 +10171,18 @@ or be used to parameterize components. Derived variables can be used to create v
               "children": Array [
                 "Here is an example of how you could use a variable to control the frequency of a sine wave:",
               ],
+              "idyllASTNode": Object {
+                "children": Array [
+                  Object {
+                    "id": 106,
+                    "type": "textnode",
+                    "value": "Here is an example of how you could use a variable to control the frequency of a sine wave:",
+                  },
+                ],
+                "id": 105,
+                "name": "p",
+                "type": "component",
+              },
             },
             "ref": null,
             "rendered": Array [
@@ -2095,6 +10203,26 @@ or be used to parameterize components. Derived variables can be used to create v
               "domain": "[0, 2 * Math.PI]",
               "domainPadding": 0,
               "equation": "(t) => Math.sin(t * frequency)",
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 107,
+                "name": "Chart",
+                "properties": Object {
+                  "domain": Object {
+                    "type": "expression",
+                    "value": "[0, 2 * Math.PI]",
+                  },
+                  "equation": Object {
+                    "type": "expression",
+                    "value": "(t) => Math.sin(t * frequency)",
+                  },
+                  "samplePoints": Object {
+                    "type": "value",
+                    "value": 1000,
+                  },
+                },
+                "type": "component",
+              },
               "range": Array [
                 -1,
                 1,
@@ -2118,6 +10246,30 @@ or be used to parameterize components. Derived variables can be used to create v
                 "value": "frequency",
               },
               "children": undefined,
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 108,
+                "name": "Range",
+                "properties": Object {
+                  "max": Object {
+                    "type": "expression",
+                    "value": "2 * Math.PI",
+                  },
+                  "min": Object {
+                    "type": "value",
+                    "value": 0.5,
+                  },
+                  "step": Object {
+                    "type": "value",
+                    "value": 0.0001,
+                  },
+                  "value": Object {
+                    "type": "variable",
+                    "value": "frequency",
+                  },
+                },
+                "type": "component",
+              },
               "max": "2 * Math.PI",
               "min": 0.5,
               "step": 0.0001,
@@ -2140,11 +10292,58 @@ or be used to parameterize components. Derived variables can be used to create v
                                                     }
                   }
                   id="lateVarDisplay"
+                  idyllASTNode={
+                                    Object {
+                                                      "children": Array [],
+                                                      "id": 110,
+                                                      "name": "Display",
+                                                      "properties": Object {
+                                                        "id": Object {
+                                                          "type": "value",
+                                                          "value": "lateVarDisplay",
+                                                        },
+                                                        "value": Object {
+                                                          "type": "variable",
+                                                          "value": "lateVar",
+                                                        },
+                                                      },
+                                                      "type": "component",
+                                                    }
+                  }
                   value="lateVar"
 />,
                 "
 Late Var Range:",
               ],
+              "idyllASTNode": Object {
+                "children": Array [
+                  Object {
+                    "children": Array [],
+                    "id": 110,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "lateVarDisplay",
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "lateVar",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 111,
+                    "type": "textnode",
+                    "value": "
+Late Var Range:",
+                  },
+                ],
+                "id": 109,
+                "name": "p",
+                "type": "component",
+              },
             },
             "ref": null,
             "rendered": Array [
@@ -2158,6 +10357,22 @@ Late Var Range:",
                   },
                   "children": undefined,
                   "id": "lateVarDisplay",
+                  "idyllASTNode": Object {
+                    "children": Array [],
+                    "id": 110,
+                    "name": "Display",
+                    "properties": Object {
+                      "id": Object {
+                        "type": "value",
+                        "value": "lateVarDisplay",
+                      },
+                      "value": Object {
+                        "type": "variable",
+                        "value": "lateVar",
+                      },
+                    },
+                    "type": "component",
+                  },
                   "value": "lateVar",
                 },
                 "ref": null,
@@ -2178,6 +10393,26 @@ Late Var Range:",
                 "value": "lateVar",
               },
               "children": undefined,
+              "idyllASTNode": Object {
+                "children": Array [],
+                "id": 112,
+                "name": "Range",
+                "properties": Object {
+                  "max": Object {
+                    "type": "value",
+                    "value": 100,
+                  },
+                  "min": Object {
+                    "type": "value",
+                    "value": 2,
+                  },
+                  "value": Object {
+                    "type": "variable",
+                    "value": "lateVar",
+                  },
+                },
+                "type": "component",
+              },
               "max": 100,
               "min": 2,
               "step": 1,
@@ -2196,17 +10431,115 @@ Late Var Range:",
                 "Read more about Idyll at ",
                 <a
                   href="https://idyll-lang.github.io/"
+                  idyllASTNode={
+                                    Object {
+                                                      "children": Array [
+                                                        Object {
+                                                          "id": 116,
+                                                          "type": "textnode",
+                                                          "value": "https://idyll-lang.github.io/",
+                                                        },
+                                                      ],
+                                                      "id": 115,
+                                                      "name": "a",
+                                                      "properties": Object {
+                                                        "href": Object {
+                                                          "type": "value",
+                                                          "value": "https://idyll-lang.github.io/",
+                                                        },
+                                                      },
+                                                      "type": "component",
+                                                    }
+                  }
 >
                   https://idyll-lang.github.io/
 </a>,
                 ", and come say “Hi!” in our ",
                 <a
                   href="https://gitter.im/idyll-lang/Lobby"
+                  idyllASTNode={
+                                    Object {
+                                                      "children": Array [
+                                                        Object {
+                                                          "id": 119,
+                                                          "type": "textnode",
+                                                          "value": "chatroom on gitter",
+                                                        },
+                                                      ],
+                                                      "id": 118,
+                                                      "name": "a",
+                                                      "properties": Object {
+                                                        "href": Object {
+                                                          "type": "value",
+                                                          "value": "https://gitter.im/idyll-lang/Lobby",
+                                                        },
+                                                      },
+                                                      "type": "component",
+                                                    }
+                  }
 >
                   chatroom on gitter
 </a>,
                 ".",
               ],
+              "idyllASTNode": Object {
+                "children": Array [
+                  Object {
+                    "id": 114,
+                    "type": "textnode",
+                    "value": "Read more about Idyll at ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 116,
+                        "type": "textnode",
+                        "value": "https://idyll-lang.github.io/",
+                      },
+                    ],
+                    "id": 115,
+                    "name": "a",
+                    "properties": Object {
+                      "href": Object {
+                        "type": "value",
+                        "value": "https://idyll-lang.github.io/",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 117,
+                    "type": "textnode",
+                    "value": ", and come say “Hi!” in our ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": 119,
+                        "type": "textnode",
+                        "value": "chatroom on gitter",
+                      },
+                    ],
+                    "id": 118,
+                    "name": "a",
+                    "properties": Object {
+                      "href": Object {
+                        "type": "value",
+                        "value": "https://gitter.im/idyll-lang/Lobby",
+                      },
+                    },
+                    "type": "component",
+                  },
+                  Object {
+                    "id": 120,
+                    "type": "textnode",
+                    "value": ".",
+                  },
+                ],
+                "id": 113,
+                "name": "p",
+                "type": "component",
+              },
             },
             "ref": null,
             "rendered": Array [
@@ -2220,6 +10553,24 @@ Late Var Range:",
                     "https://idyll-lang.github.io/",
                   ],
                   "href": "https://idyll-lang.github.io/",
+                  "idyllASTNode": Object {
+                    "children": Array [
+                      Object {
+                        "id": 116,
+                        "type": "textnode",
+                        "value": "https://idyll-lang.github.io/",
+                      },
+                    ],
+                    "id": 115,
+                    "name": "a",
+                    "properties": Object {
+                      "href": Object {
+                        "type": "value",
+                        "value": "https://idyll-lang.github.io/",
+                      },
+                    },
+                    "type": "component",
+                  },
                 },
                 "ref": null,
                 "rendered": Array [
@@ -2237,6 +10588,24 @@ Late Var Range:",
                     "chatroom on gitter",
                   ],
                   "href": "https://gitter.im/idyll-lang/Lobby",
+                  "idyllASTNode": Object {
+                    "children": Array [
+                      Object {
+                        "id": 119,
+                        "type": "textnode",
+                        "value": "chatroom on gitter",
+                      },
+                    ],
+                    "id": 118,
+                    "name": "a",
+                    "properties": Object {
+                      "href": Object {
+                        "type": "value",
+                        "value": "https://gitter.im/idyll-lang/Lobby",
+                      },
+                    },
+                    "type": "component",
+                  },
                 },
                 "ref": null,
                 "rendered": Array [
@@ -2261,30 +10630,1132 @@ Late Var Range:",
       "nodeType": "host",
       "props": Object {
         "children": Array [
-          <TextContainer>
-            <h1>
+          <TextContainer
+            idyllASTNode={
+                        Object {
+                                    "children": Array [
+                                      Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 12,
+                                            "type": "textnode",
+                                            "value": "Welcome to Idyll",
+                                          },
+                                        ],
+                                        "id": 11,
+                                        "name": "h1",
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 14,
+                                            "type": "textnode",
+                                            "value": "Idyll is a language for creating interactive documents on the web.",
+                                          },
+                                        ],
+                                        "id": 13,
+                                        "name": "h3",
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 16,
+                                            "type": "textnode",
+                                            "value": "This document is being rendered from ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 18,
+                                                "type": "textnode",
+                                                "value": "Idyll markup",
+                                              },
+                                            ],
+                                            "id": 17,
+                                            "name": "strong",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 19,
+                                            "type": "textnode",
+                                            "value": ". If you’ve used ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 21,
+                                                "type": "textnode",
+                                                "value": "markdown",
+                                              },
+                                            ],
+                                            "id": 20,
+                                            "name": "a",
+                                            "properties": Object {
+                                              "href": Object {
+                                                "type": "value",
+                                                "value": "https://daringfireball.net/projects/markdown/",
+                                              },
+                                            },
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 22,
+                                            "type": "textnode",
+                                            "value": ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.",
+                                          },
+                                        ],
+                                        "id": 15,
+                                        "name": "p",
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 24,
+                                            "type": "textnode",
+                                            "value": "To make things a little more interesting you can add JavaScript components to your text.
+                        For example, a ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 26,
+                                                "type": "textnode",
+                                                "value": "[Chart /]",
+                                              },
+                                            ],
+                                            "id": 25,
+                                            "name": "code",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 27,
+                                            "type": "textnode",
+                                            "value": " component can be used to render a simple visualization:",
+                                          },
+                                        ],
+                                        "id": 23,
+                                        "name": "p",
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 28,
+                                        "name": "Chart",
+                                        "properties": Object {
+                                          "type": Object {
+                                            "type": "value",
+                                            "value": "scatter",
+                                          },
+                                        },
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 30,
+                                            "type": "textnode",
+                                            "value": "Try changing the chart’s type from ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 32,
+                                                "type": "textnode",
+                                                "value": "scatter",
+                                              },
+                                            ],
+                                            "id": 31,
+                                            "name": "code",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 33,
+                                            "type": "textnode",
+                                            "value": " to ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 35,
+                                                "type": "textnode",
+                                                "value": "line",
+                                              },
+                                            ],
+                                            "id": 34,
+                                            "name": "code",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 36,
+                                            "type": "textnode",
+                                            "value": ", ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 38,
+                                                "type": "textnode",
+                                                "value": "area",
+                                              },
+                                            ],
+                                            "id": 37,
+                                            "name": "code",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 39,
+                                            "type": "textnode",
+                                            "value": ", or ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 41,
+                                                "type": "textnode",
+                                                "value": "pie",
+                                              },
+                                            ],
+                                            "id": 40,
+                                            "name": "code",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 42,
+                                            "type": "textnode",
+                                            "value": ".",
+                                          },
+                                        ],
+                                        "id": 29,
+                                        "name": "p",
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 44,
+                                            "type": "textnode",
+                                            "value": "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 46,
+                                                "type": "textnode",
+                                                "value": "\`2 * Math.PI\`",
+                                              },
+                                            ],
+                                            "id": 45,
+                                            "name": "code",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 47,
+                                            "type": "textnode",
+                                            "value": ").",
+                                          },
+                                        ],
+                                        "id": 43,
+                                        "name": "p",
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 49,
+                                            "type": "textnode",
+                                            "value": "There are a number of components available — see ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 51,
+                                                "type": "textnode",
+                                                "value": "Idyll’s documentation",
+                                              },
+                                            ],
+                                            "id": 50,
+                                            "name": "a",
+                                            "properties": Object {
+                                              "href": Object {
+                                                "type": "value",
+                                                "value": "https://idyll-lang.github.io/components-built-in",
+                                              },
+                                            },
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 52,
+                                            "type": "textnode",
+                                            "value": " for a full list — Additional components can be installed via ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 54,
+                                                "type": "textnode",
+                                                "value": "npm",
+                                              },
+                                            ],
+                                            "id": 53,
+                                            "name": "code",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 55,
+                                            "type": "textnode",
+                                            "value": " (any React component should work), and if you are comfortable with JavaScript you can write ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 57,
+                                                "type": "textnode",
+                                                "value": "custom components",
+                                              },
+                                            ],
+                                            "id": 56,
+                                            "name": "a",
+                                            "properties": Object {
+                                              "href": Object {
+                                                "type": "value",
+                                                "value": "https://idyll-lang.github.io/components-custom",
+                                              },
+                                            },
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 58,
+                                            "type": "textnode",
+                                            "value": " as well.",
+                                          },
+                                        ],
+                                        "id": 48,
+                                        "name": "p",
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 60,
+                                            "type": "textnode",
+                                            "value": "Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.",
+                                          },
+                                        ],
+                                        "id": 59,
+                                        "name": "p",
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 62,
+                                            "type": "textnode",
+                                            "value": "Instantiating a variable is similar to instantiating a component:",
+                                          },
+                                        ],
+                                        "id": 61,
+                                        "name": "p",
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 64,
+                                            "type": "textnode",
+                                            "value": "[var name:\\"x\\" value:1 /]",
+                                          },
+                                        ],
+                                        "id": 63,
+                                        "name": "code",
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 66,
+                                            "type": "textnode",
+                                            "value": "Once you’ve created a variable, it can be displayed inline with text
+                        (x = ",
+                                          },
+                                          Object {
+                                            "children": Array [],
+                                            "id": 67,
+                                            "name": "Display",
+                                            "properties": Object {
+                                              "var": Object {
+                                                "type": "variable",
+                                                "value": "x",
+                                              },
+                                            },
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 68,
+                                            "type": "textnode",
+                                            "value": "),
+                        or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:",
+                                          },
+                                        ],
+                                        "id": 65,
+                                        "name": "p",
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 70,
+                                            "type": "textnode",
+                                            "value": "[derived name:\\"xSquared\\" value:\`x * x\` /]",
+                                          },
+                                        ],
+                                        "id": 69,
+                                        "name": "code",
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 72,
+                                            "type": "textnode",
+                                            "value": "Here I bind the value of ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 74,
+                                                "type": "textnode",
+                                                "value": "x",
+                                              },
+                                            ],
+                                            "id": 73,
+                                            "name": "code",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 75,
+                                            "type": "textnode",
+                                            "value": " to a range slider. Move the slider and watch the variables update.",
+                                          },
+                                        ],
+                                        "id": 71,
+                                        "name": "p",
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 76,
+                                        "name": "Range",
+                                        "properties": Object {
+                                          "max": Object {
+                                            "type": "value",
+                                            "value": 100,
+                                          },
+                                          "min": Object {
+                                            "type": "value",
+                                            "value": 0,
+                                          },
+                                          "value": Object {
+                                            "type": "variable",
+                                            "value": "x",
+                                          },
+                                        },
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 79,
+                                                "type": "textnode",
+                                                "value": "x",
+                                              },
+                                            ],
+                                            "id": 78,
+                                            "name": "equation",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 80,
+                                            "type": "textnode",
+                                            "value": ":
+                         ",
+                                          },
+                                          Object {
+                                            "children": Array [],
+                                            "id": 81,
+                                            "name": "Display",
+                                            "properties": Object {
+                                              "var": Object {
+                                                "type": "expression",
+                                                "value": "x",
+                                              },
+                                            },
+                                            "type": "component",
+                                          },
+                                        ],
+                                        "id": 77,
+                                        "name": "p",
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 84,
+                                                "type": "textnode",
+                                                "value": "x^2",
+                                              },
+                                            ],
+                                            "id": 83,
+                                            "name": "equation",
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 85,
+                                            "type": "textnode",
+                                            "value": ":",
+                                          },
+                                          Object {
+                                            "children": Array [],
+                                            "id": 86,
+                                            "name": "Display",
+                                            "properties": Object {
+                                              "var": Object {
+                                                "type": "expression",
+                                                "value": "xSquared",
+                                              },
+                                            },
+                                            "type": "component",
+                                          },
+                                        ],
+                                        "id": 82,
+                                        "name": "p",
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 88,
+                                            "type": "textnode",
+                                            "value": "Test expression, displays:",
+                                          },
+                                        ],
+                                        "id": 87,
+                                        "name": "p",
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 89,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "varDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "expression",
+                                            "value": "x",
+                                          },
+                                        },
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 90,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "derivedVarDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "expression",
+                                            "value": "xSquared",
+                                          },
+                                        },
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 91,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "derivedVarDisplay2",
+                                          },
+                                          "value": Object {
+                                            "type": "expression",
+                                            "value": "xCubed",
+                                          },
+                                        },
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 92,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "strDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "expression",
+                                            "value": "\\"string\\"",
+                                          },
+                                        },
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 93,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "staticObjectDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "expression",
+                                            "value": "{ static: \\"object\\" }",
+                                          },
+                                        },
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 94,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "dynamicObjectDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "expression",
+                                            "value": "{ dynamic: x }",
+                                          },
+                                        },
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 95,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "dataDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "expression",
+                                            "value": "myData",
+                                          },
+                                        },
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 96,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "bareDataDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "variable",
+                                            "value": "myData",
+                                          },
+                                        },
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 97,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "bareVarDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "variable",
+                                            "value": "x",
+                                          },
+                                        },
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 98,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "bareDerivedDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "variable",
+                                            "value": "xSquared",
+                                          },
+                                        },
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 99,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "bareDerivedDisplay2",
+                                          },
+                                          "value": Object {
+                                            "type": "variable",
+                                            "value": "xCubed",
+                                          },
+                                        },
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 100,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "objectVarDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "expression",
+                                            "value": " objectVar ",
+                                          },
+                                        },
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 101,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "bareObjectVarDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "variable",
+                                            "value": "objectVar",
+                                          },
+                                        },
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 102,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "arrayVarDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "expression",
+                                            "value": " arrayVar ",
+                                          },
+                                        },
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 103,
+                                        "name": "Display",
+                                        "properties": Object {
+                                          "id": Object {
+                                            "type": "value",
+                                            "value": "bareArrayVarDisplay",
+                                          },
+                                          "value": Object {
+                                            "type": "variable",
+                                            "value": "arrayVar",
+                                          },
+                                        },
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 104,
+                                        "name": "br",
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 106,
+                                            "type": "textnode",
+                                            "value": "Here is an example of how you could use a variable to control the frequency of a sine wave:",
+                                          },
+                                        ],
+                                        "id": 105,
+                                        "name": "p",
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 107,
+                                        "name": "Chart",
+                                        "properties": Object {
+                                          "domain": Object {
+                                            "type": "expression",
+                                            "value": "[0, 2 * Math.PI]",
+                                          },
+                                          "equation": Object {
+                                            "type": "expression",
+                                            "value": "(t) => Math.sin(t * frequency)",
+                                          },
+                                          "samplePoints": Object {
+                                            "type": "value",
+                                            "value": 1000,
+                                          },
+                                        },
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 108,
+                                        "name": "Range",
+                                        "properties": Object {
+                                          "max": Object {
+                                            "type": "expression",
+                                            "value": "2 * Math.PI",
+                                          },
+                                          "min": Object {
+                                            "type": "value",
+                                            "value": 0.5,
+                                          },
+                                          "step": Object {
+                                            "type": "value",
+                                            "value": 0.0001,
+                                          },
+                                          "value": Object {
+                                            "type": "variable",
+                                            "value": "frequency",
+                                          },
+                                        },
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [
+                                          Object {
+                                            "children": Array [],
+                                            "id": 110,
+                                            "name": "Display",
+                                            "properties": Object {
+                                              "id": Object {
+                                                "type": "value",
+                                                "value": "lateVarDisplay",
+                                              },
+                                              "value": Object {
+                                                "type": "variable",
+                                                "value": "lateVar",
+                                              },
+                                            },
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 111,
+                                            "type": "textnode",
+                                            "value": "
+                        Late Var Range:",
+                                          },
+                                        ],
+                                        "id": 109,
+                                        "name": "p",
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [],
+                                        "id": 112,
+                                        "name": "Range",
+                                        "properties": Object {
+                                          "max": Object {
+                                            "type": "value",
+                                            "value": 100,
+                                          },
+                                          "min": Object {
+                                            "type": "value",
+                                            "value": 2,
+                                          },
+                                          "value": Object {
+                                            "type": "variable",
+                                            "value": "lateVar",
+                                          },
+                                        },
+                                        "type": "component",
+                                      },
+                                      Object {
+                                        "children": Array [
+                                          Object {
+                                            "id": 114,
+                                            "type": "textnode",
+                                            "value": "Read more about Idyll at ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 116,
+                                                "type": "textnode",
+                                                "value": "https://idyll-lang.github.io/",
+                                              },
+                                            ],
+                                            "id": 115,
+                                            "name": "a",
+                                            "properties": Object {
+                                              "href": Object {
+                                                "type": "value",
+                                                "value": "https://idyll-lang.github.io/",
+                                              },
+                                            },
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 117,
+                                            "type": "textnode",
+                                            "value": ", and come say “Hi!” in our ",
+                                          },
+                                          Object {
+                                            "children": Array [
+                                              Object {
+                                                "id": 119,
+                                                "type": "textnode",
+                                                "value": "chatroom on gitter",
+                                              },
+                                            ],
+                                            "id": 118,
+                                            "name": "a",
+                                            "properties": Object {
+                                              "href": Object {
+                                                "type": "value",
+                                                "value": "https://gitter.im/idyll-lang/Lobby",
+                                              },
+                                            },
+                                            "type": "component",
+                                          },
+                                          Object {
+                                            "id": 120,
+                                            "type": "textnode",
+                                            "value": ".",
+                                          },
+                                        ],
+                                        "id": 113,
+                                        "name": "p",
+                                        "type": "component",
+                                      },
+                                    ],
+                                    "id": 10,
+                                    "name": "TextContainer",
+                                    "type": "component",
+                                  }
+            }
+>
+            <h1
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 12,
+                                                    "type": "textnode",
+                                                    "value": "Welcome to Idyll",
+                                                  },
+                                                ],
+                                                "id": 11,
+                                                "name": "h1",
+                                                "type": "component",
+                                              }
+                        }
+            >
                         Welcome to Idyll
             </h1>
-            <h3>
+            <h3
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 14,
+                                                    "type": "textnode",
+                                                    "value": "Idyll is a language for creating interactive documents on the web.",
+                                                  },
+                                                ],
+                                                "id": 13,
+                                                "name": "h3",
+                                                "type": "component",
+                                              }
+                        }
+            >
                         Idyll is a language for creating interactive documents on the web.
             </h3>
-            <p>
+            <p
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 16,
+                                                    "type": "textnode",
+                                                    "value": "This document is being rendered from ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 18,
+                                                        "type": "textnode",
+                                                        "value": "Idyll markup",
+                                                      },
+                                                    ],
+                                                    "id": 17,
+                                                    "name": "strong",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 19,
+                                                    "type": "textnode",
+                                                    "value": ". If you’ve used ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 21,
+                                                        "type": "textnode",
+                                                        "value": "markdown",
+                                                      },
+                                                    ],
+                                                    "id": 20,
+                                                    "name": "a",
+                                                    "properties": Object {
+                                                      "href": Object {
+                                                        "type": "value",
+                                                        "value": "https://daringfireball.net/projects/markdown/",
+                                                      },
+                                                    },
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 22,
+                                                    "type": "textnode",
+                                                    "value": ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.",
+                                                  },
+                                                ],
+                                                "id": 15,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                        }
+            >
                         This document is being rendered from 
-                        <strong>
+                        <strong
+                                    idyllASTNode={
+                                                Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 18,
+                                                                "type": "textnode",
+                                                                "value": "Idyll markup",
+                                                              },
+                                                            ],
+                                                            "id": 17,
+                                                            "name": "strong",
+                                                            "type": "component",
+                                                          }
+                                    }
+                        >
                                     Idyll markup
                         </strong>
                         . If you’ve used 
                         <a
                                     href="https://daringfireball.net/projects/markdown/"
+                                    idyllASTNode={
+                                                Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 21,
+                                                                "type": "textnode",
+                                                                "value": "markdown",
+                                                              },
+                                                            ],
+                                                            "id": 20,
+                                                            "name": "a",
+                                                            "properties": Object {
+                                                              "href": Object {
+                                                                "type": "value",
+                                                                "value": "https://daringfireball.net/projects/markdown/",
+                                                              },
+                                                            },
+                                                            "type": "component",
+                                                          }
+                                    }
                         >
                                     markdown
                         </a>
                         , Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.
             </p>
-            <p>
+            <p
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 24,
+                                                    "type": "textnode",
+                                                    "value": "To make things a little more interesting you can add JavaScript components to your text.
+                                    For example, a ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 26,
+                                                        "type": "textnode",
+                                                        "value": "[Chart /]",
+                                                      },
+                                                    ],
+                                                    "id": 25,
+                                                    "name": "code",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 27,
+                                                    "type": "textnode",
+                                                    "value": " component can be used to render a simple visualization:",
+                                                  },
+                                                ],
+                                                "id": 23,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                        }
+            >
                         To make things a little more interesting you can add JavaScript components to your text.
                         For example, a 
-                        <code>
+                        <code
+                                    idyllASTNode={
+                                                Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 26,
+                                                                "type": "textnode",
+                                                                "value": "[Chart /]",
+                                                              },
+                                                            ],
+                                                            "id": 25,
+                                                            "name": "code",
+                                                            "type": "component",
+                                                          }
+                                    }
+                        >
                                     [Chart /]
                         </code>
                          component can be used to render a simple visualization:
@@ -2297,6 +11768,20 @@ Late Var Range:",
                                               ]
                         }
                         domainPadding={0}
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 28,
+                                                "name": "Chart",
+                                                "properties": Object {
+                                                  "type": Object {
+                                                    "type": "value",
+                                                    "value": "scatter",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                        }
                         range={
                                     Array [
                                                 -1,
@@ -2306,61 +11791,463 @@ Late Var Range:",
                         samplePoints={100}
                         type="scatter"
             />
-            <p>
+            <p
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 30,
+                                                    "type": "textnode",
+                                                    "value": "Try changing the chart’s type from ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 32,
+                                                        "type": "textnode",
+                                                        "value": "scatter",
+                                                      },
+                                                    ],
+                                                    "id": 31,
+                                                    "name": "code",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 33,
+                                                    "type": "textnode",
+                                                    "value": " to ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 35,
+                                                        "type": "textnode",
+                                                        "value": "line",
+                                                      },
+                                                    ],
+                                                    "id": 34,
+                                                    "name": "code",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 36,
+                                                    "type": "textnode",
+                                                    "value": ", ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 38,
+                                                        "type": "textnode",
+                                                        "value": "area",
+                                                      },
+                                                    ],
+                                                    "id": 37,
+                                                    "name": "code",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 39,
+                                                    "type": "textnode",
+                                                    "value": ", or ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 41,
+                                                        "type": "textnode",
+                                                        "value": "pie",
+                                                      },
+                                                    ],
+                                                    "id": 40,
+                                                    "name": "code",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 42,
+                                                    "type": "textnode",
+                                                    "value": ".",
+                                                  },
+                                                ],
+                                                "id": 29,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                        }
+            >
                         Try changing the chart’s type from 
-                        <code>
+                        <code
+                                    idyllASTNode={
+                                                Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 32,
+                                                                "type": "textnode",
+                                                                "value": "scatter",
+                                                              },
+                                                            ],
+                                                            "id": 31,
+                                                            "name": "code",
+                                                            "type": "component",
+                                                          }
+                                    }
+                        >
                                     scatter
                         </code>
                          to 
-                        <code>
+                        <code
+                                    idyllASTNode={
+                                                Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 35,
+                                                                "type": "textnode",
+                                                                "value": "line",
+                                                              },
+                                                            ],
+                                                            "id": 34,
+                                                            "name": "code",
+                                                            "type": "component",
+                                                          }
+                                    }
+                        >
                                     line
                         </code>
                         , 
-                        <code>
+                        <code
+                                    idyllASTNode={
+                                                Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 38,
+                                                                "type": "textnode",
+                                                                "value": "area",
+                                                              },
+                                                            ],
+                                                            "id": 37,
+                                                            "name": "code",
+                                                            "type": "component",
+                                                          }
+                                    }
+                        >
                                     area
                         </code>
                         , or 
-                        <code>
+                        <code
+                                    idyllASTNode={
+                                                Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 41,
+                                                                "type": "textnode",
+                                                                "value": "pie",
+                                                              },
+                                                            ],
+                                                            "id": 40,
+                                                            "name": "code",
+                                                            "type": "component",
+                                                          }
+                                    }
+                        >
                                     pie
                         </code>
                         .
             </p>
-            <p>
+            <p
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 44,
+                                                    "type": "textnode",
+                                                    "value": "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 46,
+                                                        "type": "textnode",
+                                                        "value": "\`2 * Math.PI\`",
+                                                      },
+                                                    ],
+                                                    "id": 45,
+                                                    "name": "code",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 47,
+                                                    "type": "textnode",
+                                                    "value": ").",
+                                                  },
+                                                ],
+                                                "id": 43,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                        }
+            >
                         A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (
-                        <code>
+                        <code
+                                    idyllASTNode={
+                                                Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 46,
+                                                                "type": "textnode",
+                                                                "value": "\`2 * Math.PI\`",
+                                                              },
+                                                            ],
+                                                            "id": 45,
+                                                            "name": "code",
+                                                            "type": "component",
+                                                          }
+                                    }
+                        >
                                     \`2 * Math.PI\`
                         </code>
                         ).
             </p>
-            <p>
+            <p
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 49,
+                                                    "type": "textnode",
+                                                    "value": "There are a number of components available — see ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 51,
+                                                        "type": "textnode",
+                                                        "value": "Idyll’s documentation",
+                                                      },
+                                                    ],
+                                                    "id": 50,
+                                                    "name": "a",
+                                                    "properties": Object {
+                                                      "href": Object {
+                                                        "type": "value",
+                                                        "value": "https://idyll-lang.github.io/components-built-in",
+                                                      },
+                                                    },
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 52,
+                                                    "type": "textnode",
+                                                    "value": " for a full list — Additional components can be installed via ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 54,
+                                                        "type": "textnode",
+                                                        "value": "npm",
+                                                      },
+                                                    ],
+                                                    "id": 53,
+                                                    "name": "code",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 55,
+                                                    "type": "textnode",
+                                                    "value": " (any React component should work), and if you are comfortable with JavaScript you can write ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 57,
+                                                        "type": "textnode",
+                                                        "value": "custom components",
+                                                      },
+                                                    ],
+                                                    "id": 56,
+                                                    "name": "a",
+                                                    "properties": Object {
+                                                      "href": Object {
+                                                        "type": "value",
+                                                        "value": "https://idyll-lang.github.io/components-custom",
+                                                      },
+                                                    },
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 58,
+                                                    "type": "textnode",
+                                                    "value": " as well.",
+                                                  },
+                                                ],
+                                                "id": 48,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                        }
+            >
                         There are a number of components available — see 
                         <a
                                     href="https://idyll-lang.github.io/components-built-in"
+                                    idyllASTNode={
+                                                Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 51,
+                                                                "type": "textnode",
+                                                                "value": "Idyll’s documentation",
+                                                              },
+                                                            ],
+                                                            "id": 50,
+                                                            "name": "a",
+                                                            "properties": Object {
+                                                              "href": Object {
+                                                                "type": "value",
+                                                                "value": "https://idyll-lang.github.io/components-built-in",
+                                                              },
+                                                            },
+                                                            "type": "component",
+                                                          }
+                                    }
                         >
                                     Idyll’s documentation
                         </a>
                          for a full list — Additional components can be installed via 
-                        <code>
+                        <code
+                                    idyllASTNode={
+                                                Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 54,
+                                                                "type": "textnode",
+                                                                "value": "npm",
+                                                              },
+                                                            ],
+                                                            "id": 53,
+                                                            "name": "code",
+                                                            "type": "component",
+                                                          }
+                                    }
+                        >
                                     npm
                         </code>
                          (any React component should work), and if you are comfortable with JavaScript you can write 
                         <a
                                     href="https://idyll-lang.github.io/components-custom"
+                                    idyllASTNode={
+                                                Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 57,
+                                                                "type": "textnode",
+                                                                "value": "custom components",
+                                                              },
+                                                            ],
+                                                            "id": 56,
+                                                            "name": "a",
+                                                            "properties": Object {
+                                                              "href": Object {
+                                                                "type": "value",
+                                                                "value": "https://idyll-lang.github.io/components-custom",
+                                                              },
+                                                            },
+                                                            "type": "component",
+                                                          }
+                                    }
                         >
                                     custom components
                         </a>
                          as well.
             </p>
-            <p>
+            <p
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 60,
+                                                    "type": "textnode",
+                                                    "value": "Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.",
+                                                  },
+                                                ],
+                                                "id": 59,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                        }
+            >
                         Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.
             </p>
-            <p>
+            <p
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 62,
+                                                    "type": "textnode",
+                                                    "value": "Instantiating a variable is similar to instantiating a component:",
+                                                  },
+                                                ],
+                                                "id": 61,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                        }
+            >
                         Instantiating a variable is similar to instantiating a component:
             </p>
-            <code>
+            <code
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 64,
+                                                    "type": "textnode",
+                                                    "value": "[var name:\\"x\\" value:1 /]",
+                                                  },
+                                                ],
+                                                "id": 63,
+                                                "name": "code",
+                                                "type": "component",
+                                              }
+                        }
+            >
                         [var name:"x" value:1 /]
             </code>
-            <p>
+            <p
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 66,
+                                                    "type": "textnode",
+                                                    "value": "Once you’ve created a variable, it can be displayed inline with text
+                                    (x = ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [],
+                                                    "id": 67,
+                                                    "name": "Display",
+                                                    "properties": Object {
+                                                      "var": Object {
+                                                        "type": "variable",
+                                                        "value": "x",
+                                                      },
+                                                    },
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 68,
+                                                    "type": "textnode",
+                                                    "value": "),
+                                    or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:",
+                                                  },
+                                                ],
+                                                "id": 65,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                        }
+            >
                         Once you’ve created a variable, it can be displayed inline with text
                         (x = 
                         <Display
@@ -2369,17 +12256,93 @@ Late Var Range:",
                                                             "var": "x",
                                                           }
                                     }
+                                    idyllASTNode={
+                                                Object {
+                                                            "children": Array [],
+                                                            "id": 67,
+                                                            "name": "Display",
+                                                            "properties": Object {
+                                                              "var": Object {
+                                                                "type": "variable",
+                                                                "value": "x",
+                                                              },
+                                                            },
+                                                            "type": "component",
+                                                          }
+                                    }
                                     var="x"
                         />
                         ),
                         or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:
             </p>
-            <code>
+            <code
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 70,
+                                                    "type": "textnode",
+                                                    "value": "[derived name:\\"xSquared\\" value:\`x * x\` /]",
+                                                  },
+                                                ],
+                                                "id": 69,
+                                                "name": "code",
+                                                "type": "component",
+                                              }
+                        }
+            >
                         [derived name:"xSquared" value:\`x * x\` /]
             </code>
-            <p>
+            <p
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 72,
+                                                    "type": "textnode",
+                                                    "value": "Here I bind the value of ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 74,
+                                                        "type": "textnode",
+                                                        "value": "x",
+                                                      },
+                                                    ],
+                                                    "id": 73,
+                                                    "name": "code",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 75,
+                                                    "type": "textnode",
+                                                    "value": " to a range slider. Move the slider and watch the variables update.",
+                                                  },
+                                                ],
+                                                "id": 71,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                        }
+            >
                         Here I bind the value of 
-                        <code>
+                        <code
+                                    idyllASTNode={
+                                                Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 74,
+                                                                "type": "textnode",
+                                                                "value": "x",
+                                                              },
+                                                            ],
+                                                            "id": 73,
+                                                            "name": "code",
+                                                            "type": "component",
+                                                          }
+                                    }
+                        >
                                     x
                         </code>
                          to a range slider. Move the slider and watch the variables update.
@@ -2390,13 +12353,90 @@ Late Var Range:",
                                                 "value": "x",
                                               }
                         }
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 76,
+                                                "name": "Range",
+                                                "properties": Object {
+                                                  "max": Object {
+                                                    "type": "value",
+                                                    "value": 100,
+                                                  },
+                                                  "min": Object {
+                                                    "type": "value",
+                                                    "value": 0,
+                                                  },
+                                                  "value": Object {
+                                                    "type": "variable",
+                                                    "value": "x",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                        }
                         max={100}
                         min={0}
                         step={1}
                         value="x"
             />
-            <p>
-                        <Equation>
+            <p
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 79,
+                                                        "type": "textnode",
+                                                        "value": "x",
+                                                      },
+                                                    ],
+                                                    "id": 78,
+                                                    "name": "equation",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 80,
+                                                    "type": "textnode",
+                                                    "value": ":
+                                     ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [],
+                                                    "id": 81,
+                                                    "name": "Display",
+                                                    "properties": Object {
+                                                      "var": Object {
+                                                        "type": "expression",
+                                                        "value": "x",
+                                                      },
+                                                    },
+                                                    "type": "component",
+                                                  },
+                                                ],
+                                                "id": 77,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                        }
+            >
+                        <Equation
+                                    idyllASTNode={
+                                                Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 79,
+                                                                "type": "textnode",
+                                                                "value": "x",
+                                                              },
+                                                            ],
+                                                            "id": 78,
+                                                            "name": "equation",
+                                                            "type": "component",
+                                                          }
+                                    }
+                        >
                                     x
                         </Equation>
                         :
@@ -2407,11 +12447,79 @@ Late Var Range:",
                                                             "var": "x",
                                                           }
                                     }
+                                    idyllASTNode={
+                                                Object {
+                                                            "children": Array [],
+                                                            "id": 81,
+                                                            "name": "Display",
+                                                            "properties": Object {
+                                                              "var": Object {
+                                                                "type": "expression",
+                                                                "value": "x",
+                                                              },
+                                                            },
+                                                            "type": "component",
+                                                          }
+                                    }
                                     var="x"
                         />
             </p>
-            <p>
-                        <Equation>
+            <p
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 84,
+                                                        "type": "textnode",
+                                                        "value": "x^2",
+                                                      },
+                                                    ],
+                                                    "id": 83,
+                                                    "name": "equation",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 85,
+                                                    "type": "textnode",
+                                                    "value": ":",
+                                                  },
+                                                  Object {
+                                                    "children": Array [],
+                                                    "id": 86,
+                                                    "name": "Display",
+                                                    "properties": Object {
+                                                      "var": Object {
+                                                        "type": "expression",
+                                                        "value": "xSquared",
+                                                      },
+                                                    },
+                                                    "type": "component",
+                                                  },
+                                                ],
+                                                "id": 82,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                        }
+            >
+                        <Equation
+                                    idyllASTNode={
+                                                Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 84,
+                                                                "type": "textnode",
+                                                                "value": "x^2",
+                                                              },
+                                                            ],
+                                                            "id": 83,
+                                                            "name": "equation",
+                                                            "type": "component",
+                                                          }
+                                    }
+                        >
                                     x^2
                         </Equation>
                         :
@@ -2421,10 +12529,39 @@ Late Var Range:",
                                                             "var": "xSquared",
                                                           }
                                     }
+                                    idyllASTNode={
+                                                Object {
+                                                            "children": Array [],
+                                                            "id": 86,
+                                                            "name": "Display",
+                                                            "properties": Object {
+                                                              "var": Object {
+                                                                "type": "expression",
+                                                                "value": "xSquared",
+                                                              },
+                                                            },
+                                                            "type": "component",
+                                                          }
+                                    }
                                     var="xSquared"
                         />
             </p>
-            <p>
+            <p
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 88,
+                                                    "type": "textnode",
+                                                    "value": "Test expression, displays:",
+                                                  },
+                                                ],
+                                                "id": 87,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                        }
+            >
                         Test expression, displays:
             </p>
             <Display
@@ -2434,6 +12571,24 @@ Late Var Range:",
                                               }
                         }
                         id="varDisplay"
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 89,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "varDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "expression",
+                                                    "value": "x",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                        }
                         value="x"
             />
             <Display
@@ -2443,6 +12598,24 @@ Late Var Range:",
                                               }
                         }
                         id="derivedVarDisplay"
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 90,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "derivedVarDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "expression",
+                                                    "value": "xSquared",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                        }
                         value="xSquared"
             />
             <Display
@@ -2452,6 +12625,24 @@ Late Var Range:",
                                               }
                         }
                         id="derivedVarDisplay2"
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 91,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "derivedVarDisplay2",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "expression",
+                                                    "value": "xCubed",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                        }
                         value="xCubed"
             />
             <Display
@@ -2461,6 +12652,24 @@ Late Var Range:",
                                               }
                         }
                         id="strDisplay"
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 92,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "strDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "expression",
+                                                    "value": "\\"string\\"",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                        }
                         value="\\"string\\""
             />
             <Display
@@ -2470,6 +12679,24 @@ Late Var Range:",
                                               }
                         }
                         id="staticObjectDisplay"
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 93,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "staticObjectDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "expression",
+                                                    "value": "{ static: \\"object\\" }",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                        }
                         value="{ static: \\"object\\" }"
             />
             <Display
@@ -2479,6 +12706,24 @@ Late Var Range:",
                                               }
                         }
                         id="dynamicObjectDisplay"
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 94,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "dynamicObjectDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "expression",
+                                                    "value": "{ dynamic: x }",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                        }
                         value="{ dynamic: x }"
             />
             <Display
@@ -2488,6 +12733,24 @@ Late Var Range:",
                                               }
                         }
                         id="dataDisplay"
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 95,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "dataDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "expression",
+                                                    "value": "myData",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                        }
                         value="myData"
             />
             <Display
@@ -2497,6 +12760,24 @@ Late Var Range:",
                                               }
                         }
                         id="bareDataDisplay"
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 96,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "bareDataDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "variable",
+                                                    "value": "myData",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                        }
                         value="myData"
             />
             <Display
@@ -2506,6 +12787,24 @@ Late Var Range:",
                                               }
                         }
                         id="bareVarDisplay"
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 97,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "bareVarDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "variable",
+                                                    "value": "x",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                        }
                         value="x"
             />
             <Display
@@ -2515,6 +12814,24 @@ Late Var Range:",
                                               }
                         }
                         id="bareDerivedDisplay"
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 98,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "bareDerivedDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "variable",
+                                                    "value": "xSquared",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                        }
                         value="xSquared"
             />
             <Display
@@ -2524,6 +12841,24 @@ Late Var Range:",
                                               }
                         }
                         id="bareDerivedDisplay2"
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 99,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "bareDerivedDisplay2",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "variable",
+                                                    "value": "xCubed",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                        }
                         value="xCubed"
             />
             <Display
@@ -2533,6 +12868,24 @@ Late Var Range:",
                                               }
                         }
                         id="objectVarDisplay"
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 100,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "objectVarDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "expression",
+                                                    "value": " objectVar ",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                        }
                         value=" objectVar "
             />
             <Display
@@ -2542,6 +12895,24 @@ Late Var Range:",
                                               }
                         }
                         id="bareObjectVarDisplay"
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 101,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "bareObjectVarDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "variable",
+                                                    "value": "objectVar",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                        }
                         value="objectVar"
             />
             <Display
@@ -2551,6 +12922,24 @@ Late Var Range:",
                                               }
                         }
                         id="arrayVarDisplay"
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 102,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "arrayVarDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "expression",
+                                                    "value": " arrayVar ",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                        }
                         value=" arrayVar "
             />
             <Display
@@ -2560,10 +12949,52 @@ Late Var Range:",
                                               }
                         }
                         id="bareArrayVarDisplay"
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 103,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "bareArrayVarDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "variable",
+                                                    "value": "arrayVar",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                        }
                         value="arrayVar"
             />
-            <br />
-            <p>
+            <br
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 104,
+                                                "name": "br",
+                                                "type": "component",
+                                              }
+                        }
+            />
+            <p
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 106,
+                                                    "type": "textnode",
+                                                    "value": "Here is an example of how you could use a variable to control the frequency of a sine wave:",
+                                                  },
+                                                ],
+                                                "id": 105,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                        }
+            >
                         Here is an example of how you could use a variable to control the frequency of a sine wave:
             </p>
             <Chart
@@ -2576,6 +13007,28 @@ Late Var Range:",
                         domain="[0, 2 * Math.PI]"
                         domainPadding={0}
                         equation="(t) => Math.sin(t * frequency)"
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 107,
+                                                "name": "Chart",
+                                                "properties": Object {
+                                                  "domain": Object {
+                                                    "type": "expression",
+                                                    "value": "[0, 2 * Math.PI]",
+                                                  },
+                                                  "equation": Object {
+                                                    "type": "expression",
+                                                    "value": "(t) => Math.sin(t * frequency)",
+                                                  },
+                                                  "samplePoints": Object {
+                                                    "type": "value",
+                                                    "value": 1000,
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                        }
                         range={
                                     Array [
                                                 -1,
@@ -2596,12 +13049,70 @@ Late Var Range:",
                                                 "value": "frequency",
                                               }
                         }
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 108,
+                                                "name": "Range",
+                                                "properties": Object {
+                                                  "max": Object {
+                                                    "type": "expression",
+                                                    "value": "2 * Math.PI",
+                                                  },
+                                                  "min": Object {
+                                                    "type": "value",
+                                                    "value": 0.5,
+                                                  },
+                                                  "step": Object {
+                                                    "type": "value",
+                                                    "value": 0.0001,
+                                                  },
+                                                  "value": Object {
+                                                    "type": "variable",
+                                                    "value": "frequency",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                        }
                         max="2 * Math.PI"
                         min={0.5}
                         step={0.0001}
                         value="frequency"
             />
-            <p>
+            <p
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "children": Array [],
+                                                    "id": 110,
+                                                    "name": "Display",
+                                                    "properties": Object {
+                                                      "id": Object {
+                                                        "type": "value",
+                                                        "value": "lateVarDisplay",
+                                                      },
+                                                      "value": Object {
+                                                        "type": "variable",
+                                                        "value": "lateVar",
+                                                      },
+                                                    },
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 111,
+                                                    "type": "textnode",
+                                                    "value": "
+                                    Late Var Range:",
+                                                  },
+                                                ],
+                                                "id": 109,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                        }
+            >
                         <Display
                                     __vars__={
                                                 Object {
@@ -2609,6 +13120,24 @@ Late Var Range:",
                                                           }
                                     }
                                     id="lateVarDisplay"
+                                    idyllASTNode={
+                                                Object {
+                                                            "children": Array [],
+                                                            "id": 110,
+                                                            "name": "Display",
+                                                            "properties": Object {
+                                                              "id": Object {
+                                                                "type": "value",
+                                                                "value": "lateVarDisplay",
+                                                              },
+                                                              "value": Object {
+                                                                "type": "variable",
+                                                                "value": "lateVar",
+                                                              },
+                                                            },
+                                                            "type": "component",
+                                                          }
+                                    }
                                     value="lateVar"
                         />
                         
@@ -2620,21 +13149,144 @@ Late Var Range:",
                                                 "value": "lateVar",
                                               }
                         }
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [],
+                                                "id": 112,
+                                                "name": "Range",
+                                                "properties": Object {
+                                                  "max": Object {
+                                                    "type": "value",
+                                                    "value": 100,
+                                                  },
+                                                  "min": Object {
+                                                    "type": "value",
+                                                    "value": 2,
+                                                  },
+                                                  "value": Object {
+                                                    "type": "variable",
+                                                    "value": "lateVar",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                        }
                         max={100}
                         min={2}
                         step={1}
                         value="lateVar"
             />
-            <p>
+            <p
+                        idyllASTNode={
+                                    Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 114,
+                                                    "type": "textnode",
+                                                    "value": "Read more about Idyll at ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 116,
+                                                        "type": "textnode",
+                                                        "value": "https://idyll-lang.github.io/",
+                                                      },
+                                                    ],
+                                                    "id": 115,
+                                                    "name": "a",
+                                                    "properties": Object {
+                                                      "href": Object {
+                                                        "type": "value",
+                                                        "value": "https://idyll-lang.github.io/",
+                                                      },
+                                                    },
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 117,
+                                                    "type": "textnode",
+                                                    "value": ", and come say “Hi!” in our ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 119,
+                                                        "type": "textnode",
+                                                        "value": "chatroom on gitter",
+                                                      },
+                                                    ],
+                                                    "id": 118,
+                                                    "name": "a",
+                                                    "properties": Object {
+                                                      "href": Object {
+                                                        "type": "value",
+                                                        "value": "https://gitter.im/idyll-lang/Lobby",
+                                                      },
+                                                    },
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 120,
+                                                    "type": "textnode",
+                                                    "value": ".",
+                                                  },
+                                                ],
+                                                "id": 113,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                        }
+            >
                         Read more about Idyll at 
                         <a
                                     href="https://idyll-lang.github.io/"
+                                    idyllASTNode={
+                                                Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 116,
+                                                                "type": "textnode",
+                                                                "value": "https://idyll-lang.github.io/",
+                                                              },
+                                                            ],
+                                                            "id": 115,
+                                                            "name": "a",
+                                                            "properties": Object {
+                                                              "href": Object {
+                                                                "type": "value",
+                                                                "value": "https://idyll-lang.github.io/",
+                                                              },
+                                                            },
+                                                            "type": "component",
+                                                          }
+                                    }
                         >
                                     https://idyll-lang.github.io/
                         </a>
                         , and come say “Hi!” in our 
                         <a
                                     href="https://gitter.im/idyll-lang/Lobby"
+                                    idyllASTNode={
+                                                Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 119,
+                                                                "type": "textnode",
+                                                                "value": "chatroom on gitter",
+                                                              },
+                                                            ],
+                                                            "id": 118,
+                                                            "name": "a",
+                                                            "properties": Object {
+                                                              "href": Object {
+                                                                "type": "value",
+                                                                "value": "https://gitter.im/idyll-lang/Lobby",
+                                                              },
+                                                            },
+                                                            "type": "component",
+                                                          }
+                                    }
                         >
                                     chatroom on gitter
                         </a>
@@ -2651,29 +13303,197 @@ Late Var Range:",
           "nodeType": "class",
           "props": Object {
             "children": Array [
-              <h1>
+              <h1
+                idyllASTNode={
+                                Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 12,
+                                                    "type": "textnode",
+                                                    "value": "Welcome to Idyll",
+                                                  },
+                                                ],
+                                                "id": 11,
+                                                "name": "h1",
+                                                "type": "component",
+                                              }
+                }
+>
                 Welcome to Idyll
 </h1>,
-              <h3>
+              <h3
+                idyllASTNode={
+                                Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 14,
+                                                    "type": "textnode",
+                                                    "value": "Idyll is a language for creating interactive documents on the web.",
+                                                  },
+                                                ],
+                                                "id": 13,
+                                                "name": "h3",
+                                                "type": "component",
+                                              }
+                }
+>
                 Idyll is a language for creating interactive documents on the web.
 </h3>,
-              <p>
+              <p
+                idyllASTNode={
+                                Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 16,
+                                                    "type": "textnode",
+                                                    "value": "This document is being rendered from ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 18,
+                                                        "type": "textnode",
+                                                        "value": "Idyll markup",
+                                                      },
+                                                    ],
+                                                    "id": 17,
+                                                    "name": "strong",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 19,
+                                                    "type": "textnode",
+                                                    "value": ". If you’ve used ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 21,
+                                                        "type": "textnode",
+                                                        "value": "markdown",
+                                                      },
+                                                    ],
+                                                    "id": 20,
+                                                    "name": "a",
+                                                    "properties": Object {
+                                                      "href": Object {
+                                                        "type": "value",
+                                                        "value": "https://daringfireball.net/projects/markdown/",
+                                                      },
+                                                    },
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 22,
+                                                    "type": "textnode",
+                                                    "value": ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.",
+                                                  },
+                                                ],
+                                                "id": 15,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                }
+>
                 This document is being rendered from 
-                <strong>
+                <strong
+                                idyllASTNode={
+                                                Object {
+                                                                "children": Array [
+                                                                  Object {
+                                                                    "id": 18,
+                                                                    "type": "textnode",
+                                                                    "value": "Idyll markup",
+                                                                  },
+                                                                ],
+                                                                "id": 17,
+                                                                "name": "strong",
+                                                                "type": "component",
+                                                              }
+                                }
+                >
                                 Idyll markup
                 </strong>
                 . If you’ve used 
                 <a
                                 href="https://daringfireball.net/projects/markdown/"
+                                idyllASTNode={
+                                                Object {
+                                                                "children": Array [
+                                                                  Object {
+                                                                    "id": 21,
+                                                                    "type": "textnode",
+                                                                    "value": "markdown",
+                                                                  },
+                                                                ],
+                                                                "id": 20,
+                                                                "name": "a",
+                                                                "properties": Object {
+                                                                  "href": Object {
+                                                                    "type": "value",
+                                                                    "value": "https://daringfireball.net/projects/markdown/",
+                                                                  },
+                                                                },
+                                                                "type": "component",
+                                                              }
+                                }
                 >
                                 markdown
                 </a>
                 , Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.
 </p>,
-              <p>
+              <p
+                idyllASTNode={
+                                Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 24,
+                                                    "type": "textnode",
+                                                    "value": "To make things a little more interesting you can add JavaScript components to your text.
+                                For example, a ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 26,
+                                                        "type": "textnode",
+                                                        "value": "[Chart /]",
+                                                      },
+                                                    ],
+                                                    "id": 25,
+                                                    "name": "code",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 27,
+                                                    "type": "textnode",
+                                                    "value": " component can be used to render a simple visualization:",
+                                                  },
+                                                ],
+                                                "id": 23,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                }
+>
                 To make things a little more interesting you can add JavaScript components to your text.
                 For example, a 
-                <code>
+                <code
+                                idyllASTNode={
+                                                Object {
+                                                                "children": Array [
+                                                                  Object {
+                                                                    "id": 26,
+                                                                    "type": "textnode",
+                                                                    "value": "[Chart /]",
+                                                                  },
+                                                                ],
+                                                                "id": 25,
+                                                                "name": "code",
+                                                                "type": "component",
+                                                              }
+                                }
+                >
                                 [Chart /]
                 </code>
                  component can be used to render a simple visualization:
@@ -2686,6 +13506,20 @@ Late Var Range:",
                                               ]
                 }
                 domainPadding={0}
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 28,
+                                                "name": "Chart",
+                                                "properties": Object {
+                                                  "type": Object {
+                                                    "type": "value",
+                                                    "value": "scatter",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                }
                 range={
                                 Array [
                                                 -1,
@@ -2695,61 +13529,463 @@ Late Var Range:",
                 samplePoints={100}
                 type="scatter"
 />,
-              <p>
+              <p
+                idyllASTNode={
+                                Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 30,
+                                                    "type": "textnode",
+                                                    "value": "Try changing the chart’s type from ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 32,
+                                                        "type": "textnode",
+                                                        "value": "scatter",
+                                                      },
+                                                    ],
+                                                    "id": 31,
+                                                    "name": "code",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 33,
+                                                    "type": "textnode",
+                                                    "value": " to ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 35,
+                                                        "type": "textnode",
+                                                        "value": "line",
+                                                      },
+                                                    ],
+                                                    "id": 34,
+                                                    "name": "code",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 36,
+                                                    "type": "textnode",
+                                                    "value": ", ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 38,
+                                                        "type": "textnode",
+                                                        "value": "area",
+                                                      },
+                                                    ],
+                                                    "id": 37,
+                                                    "name": "code",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 39,
+                                                    "type": "textnode",
+                                                    "value": ", or ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 41,
+                                                        "type": "textnode",
+                                                        "value": "pie",
+                                                      },
+                                                    ],
+                                                    "id": 40,
+                                                    "name": "code",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 42,
+                                                    "type": "textnode",
+                                                    "value": ".",
+                                                  },
+                                                ],
+                                                "id": 29,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                }
+>
                 Try changing the chart’s type from 
-                <code>
+                <code
+                                idyllASTNode={
+                                                Object {
+                                                                "children": Array [
+                                                                  Object {
+                                                                    "id": 32,
+                                                                    "type": "textnode",
+                                                                    "value": "scatter",
+                                                                  },
+                                                                ],
+                                                                "id": 31,
+                                                                "name": "code",
+                                                                "type": "component",
+                                                              }
+                                }
+                >
                                 scatter
                 </code>
                  to 
-                <code>
+                <code
+                                idyllASTNode={
+                                                Object {
+                                                                "children": Array [
+                                                                  Object {
+                                                                    "id": 35,
+                                                                    "type": "textnode",
+                                                                    "value": "line",
+                                                                  },
+                                                                ],
+                                                                "id": 34,
+                                                                "name": "code",
+                                                                "type": "component",
+                                                              }
+                                }
+                >
                                 line
                 </code>
                 , 
-                <code>
+                <code
+                                idyllASTNode={
+                                                Object {
+                                                                "children": Array [
+                                                                  Object {
+                                                                    "id": 38,
+                                                                    "type": "textnode",
+                                                                    "value": "area",
+                                                                  },
+                                                                ],
+                                                                "id": 37,
+                                                                "name": "code",
+                                                                "type": "component",
+                                                              }
+                                }
+                >
                                 area
                 </code>
                 , or 
-                <code>
+                <code
+                                idyllASTNode={
+                                                Object {
+                                                                "children": Array [
+                                                                  Object {
+                                                                    "id": 41,
+                                                                    "type": "textnode",
+                                                                    "value": "pie",
+                                                                  },
+                                                                ],
+                                                                "id": 40,
+                                                                "name": "code",
+                                                                "type": "component",
+                                                              }
+                                }
+                >
                                 pie
                 </code>
                 .
 </p>,
-              <p>
+              <p
+                idyllASTNode={
+                                Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 44,
+                                                    "type": "textnode",
+                                                    "value": "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 46,
+                                                        "type": "textnode",
+                                                        "value": "\`2 * Math.PI\`",
+                                                      },
+                                                    ],
+                                                    "id": 45,
+                                                    "name": "code",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 47,
+                                                    "type": "textnode",
+                                                    "value": ").",
+                                                  },
+                                                ],
+                                                "id": 43,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                }
+>
                 A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (
-                <code>
+                <code
+                                idyllASTNode={
+                                                Object {
+                                                                "children": Array [
+                                                                  Object {
+                                                                    "id": 46,
+                                                                    "type": "textnode",
+                                                                    "value": "\`2 * Math.PI\`",
+                                                                  },
+                                                                ],
+                                                                "id": 45,
+                                                                "name": "code",
+                                                                "type": "component",
+                                                              }
+                                }
+                >
                                 \`2 * Math.PI\`
                 </code>
                 ).
 </p>,
-              <p>
+              <p
+                idyllASTNode={
+                                Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 49,
+                                                    "type": "textnode",
+                                                    "value": "There are a number of components available — see ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 51,
+                                                        "type": "textnode",
+                                                        "value": "Idyll’s documentation",
+                                                      },
+                                                    ],
+                                                    "id": 50,
+                                                    "name": "a",
+                                                    "properties": Object {
+                                                      "href": Object {
+                                                        "type": "value",
+                                                        "value": "https://idyll-lang.github.io/components-built-in",
+                                                      },
+                                                    },
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 52,
+                                                    "type": "textnode",
+                                                    "value": " for a full list — Additional components can be installed via ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 54,
+                                                        "type": "textnode",
+                                                        "value": "npm",
+                                                      },
+                                                    ],
+                                                    "id": 53,
+                                                    "name": "code",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 55,
+                                                    "type": "textnode",
+                                                    "value": " (any React component should work), and if you are comfortable with JavaScript you can write ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 57,
+                                                        "type": "textnode",
+                                                        "value": "custom components",
+                                                      },
+                                                    ],
+                                                    "id": 56,
+                                                    "name": "a",
+                                                    "properties": Object {
+                                                      "href": Object {
+                                                        "type": "value",
+                                                        "value": "https://idyll-lang.github.io/components-custom",
+                                                      },
+                                                    },
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 58,
+                                                    "type": "textnode",
+                                                    "value": " as well.",
+                                                  },
+                                                ],
+                                                "id": 48,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                }
+>
                 There are a number of components available — see 
                 <a
                                 href="https://idyll-lang.github.io/components-built-in"
+                                idyllASTNode={
+                                                Object {
+                                                                "children": Array [
+                                                                  Object {
+                                                                    "id": 51,
+                                                                    "type": "textnode",
+                                                                    "value": "Idyll’s documentation",
+                                                                  },
+                                                                ],
+                                                                "id": 50,
+                                                                "name": "a",
+                                                                "properties": Object {
+                                                                  "href": Object {
+                                                                    "type": "value",
+                                                                    "value": "https://idyll-lang.github.io/components-built-in",
+                                                                  },
+                                                                },
+                                                                "type": "component",
+                                                              }
+                                }
                 >
                                 Idyll’s documentation
                 </a>
                  for a full list — Additional components can be installed via 
-                <code>
+                <code
+                                idyllASTNode={
+                                                Object {
+                                                                "children": Array [
+                                                                  Object {
+                                                                    "id": 54,
+                                                                    "type": "textnode",
+                                                                    "value": "npm",
+                                                                  },
+                                                                ],
+                                                                "id": 53,
+                                                                "name": "code",
+                                                                "type": "component",
+                                                              }
+                                }
+                >
                                 npm
                 </code>
                  (any React component should work), and if you are comfortable with JavaScript you can write 
                 <a
                                 href="https://idyll-lang.github.io/components-custom"
+                                idyllASTNode={
+                                                Object {
+                                                                "children": Array [
+                                                                  Object {
+                                                                    "id": 57,
+                                                                    "type": "textnode",
+                                                                    "value": "custom components",
+                                                                  },
+                                                                ],
+                                                                "id": 56,
+                                                                "name": "a",
+                                                                "properties": Object {
+                                                                  "href": Object {
+                                                                    "type": "value",
+                                                                    "value": "https://idyll-lang.github.io/components-custom",
+                                                                  },
+                                                                },
+                                                                "type": "component",
+                                                              }
+                                }
                 >
                                 custom components
                 </a>
                  as well.
 </p>,
-              <p>
+              <p
+                idyllASTNode={
+                                Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 60,
+                                                    "type": "textnode",
+                                                    "value": "Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.",
+                                                  },
+                                                ],
+                                                "id": 59,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                }
+>
                 Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.
 </p>,
-              <p>
+              <p
+                idyllASTNode={
+                                Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 62,
+                                                    "type": "textnode",
+                                                    "value": "Instantiating a variable is similar to instantiating a component:",
+                                                  },
+                                                ],
+                                                "id": 61,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                }
+>
                 Instantiating a variable is similar to instantiating a component:
 </p>,
-              <code>
+              <code
+                idyllASTNode={
+                                Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 64,
+                                                    "type": "textnode",
+                                                    "value": "[var name:\\"x\\" value:1 /]",
+                                                  },
+                                                ],
+                                                "id": 63,
+                                                "name": "code",
+                                                "type": "component",
+                                              }
+                }
+>
                 [var name:"x" value:1 /]
 </code>,
-              <p>
+              <p
+                idyllASTNode={
+                                Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 66,
+                                                    "type": "textnode",
+                                                    "value": "Once you’ve created a variable, it can be displayed inline with text
+                                (x = ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [],
+                                                    "id": 67,
+                                                    "name": "Display",
+                                                    "properties": Object {
+                                                      "var": Object {
+                                                        "type": "variable",
+                                                        "value": "x",
+                                                      },
+                                                    },
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 68,
+                                                    "type": "textnode",
+                                                    "value": "),
+                                or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:",
+                                                  },
+                                                ],
+                                                "id": 65,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                }
+>
                 Once you’ve created a variable, it can be displayed inline with text
                 (x = 
                 <Display
@@ -2758,17 +13994,93 @@ Late Var Range:",
                                                                 "var": "x",
                                                               }
                                 }
+                                idyllASTNode={
+                                                Object {
+                                                                "children": Array [],
+                                                                "id": 67,
+                                                                "name": "Display",
+                                                                "properties": Object {
+                                                                  "var": Object {
+                                                                    "type": "variable",
+                                                                    "value": "x",
+                                                                  },
+                                                                },
+                                                                "type": "component",
+                                                              }
+                                }
                                 var="x"
                 />
                 ),
                 or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:
 </p>,
-              <code>
+              <code
+                idyllASTNode={
+                                Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 70,
+                                                    "type": "textnode",
+                                                    "value": "[derived name:\\"xSquared\\" value:\`x * x\` /]",
+                                                  },
+                                                ],
+                                                "id": 69,
+                                                "name": "code",
+                                                "type": "component",
+                                              }
+                }
+>
                 [derived name:"xSquared" value:\`x * x\` /]
 </code>,
-              <p>
+              <p
+                idyllASTNode={
+                                Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 72,
+                                                    "type": "textnode",
+                                                    "value": "Here I bind the value of ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 74,
+                                                        "type": "textnode",
+                                                        "value": "x",
+                                                      },
+                                                    ],
+                                                    "id": 73,
+                                                    "name": "code",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 75,
+                                                    "type": "textnode",
+                                                    "value": " to a range slider. Move the slider and watch the variables update.",
+                                                  },
+                                                ],
+                                                "id": 71,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                }
+>
                 Here I bind the value of 
-                <code>
+                <code
+                                idyllASTNode={
+                                                Object {
+                                                                "children": Array [
+                                                                  Object {
+                                                                    "id": 74,
+                                                                    "type": "textnode",
+                                                                    "value": "x",
+                                                                  },
+                                                                ],
+                                                                "id": 73,
+                                                                "name": "code",
+                                                                "type": "component",
+                                                              }
+                                }
+                >
                                 x
                 </code>
                  to a range slider. Move the slider and watch the variables update.
@@ -2779,13 +14091,90 @@ Late Var Range:",
                                                 "value": "x",
                                               }
                 }
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 76,
+                                                "name": "Range",
+                                                "properties": Object {
+                                                  "max": Object {
+                                                    "type": "value",
+                                                    "value": 100,
+                                                  },
+                                                  "min": Object {
+                                                    "type": "value",
+                                                    "value": 0,
+                                                  },
+                                                  "value": Object {
+                                                    "type": "variable",
+                                                    "value": "x",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                }
                 max={100}
                 min={0}
                 step={1}
                 value="x"
 />,
-              <p>
-                <Equation>
+              <p
+                idyllASTNode={
+                                Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 79,
+                                                        "type": "textnode",
+                                                        "value": "x",
+                                                      },
+                                                    ],
+                                                    "id": 78,
+                                                    "name": "equation",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 80,
+                                                    "type": "textnode",
+                                                    "value": ":
+                                 ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [],
+                                                    "id": 81,
+                                                    "name": "Display",
+                                                    "properties": Object {
+                                                      "var": Object {
+                                                        "type": "expression",
+                                                        "value": "x",
+                                                      },
+                                                    },
+                                                    "type": "component",
+                                                  },
+                                                ],
+                                                "id": 77,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                }
+>
+                <Equation
+                                idyllASTNode={
+                                                Object {
+                                                                "children": Array [
+                                                                  Object {
+                                                                    "id": 79,
+                                                                    "type": "textnode",
+                                                                    "value": "x",
+                                                                  },
+                                                                ],
+                                                                "id": 78,
+                                                                "name": "equation",
+                                                                "type": "component",
+                                                              }
+                                }
+                >
                                 x
                 </Equation>
                 :
@@ -2796,11 +14185,79 @@ Late Var Range:",
                                                                 "var": "x",
                                                               }
                                 }
+                                idyllASTNode={
+                                                Object {
+                                                                "children": Array [],
+                                                                "id": 81,
+                                                                "name": "Display",
+                                                                "properties": Object {
+                                                                  "var": Object {
+                                                                    "type": "expression",
+                                                                    "value": "x",
+                                                                  },
+                                                                },
+                                                                "type": "component",
+                                                              }
+                                }
                                 var="x"
                 />
 </p>,
-              <p>
-                <Equation>
+              <p
+                idyllASTNode={
+                                Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 84,
+                                                        "type": "textnode",
+                                                        "value": "x^2",
+                                                      },
+                                                    ],
+                                                    "id": 83,
+                                                    "name": "equation",
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 85,
+                                                    "type": "textnode",
+                                                    "value": ":",
+                                                  },
+                                                  Object {
+                                                    "children": Array [],
+                                                    "id": 86,
+                                                    "name": "Display",
+                                                    "properties": Object {
+                                                      "var": Object {
+                                                        "type": "expression",
+                                                        "value": "xSquared",
+                                                      },
+                                                    },
+                                                    "type": "component",
+                                                  },
+                                                ],
+                                                "id": 82,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                }
+>
+                <Equation
+                                idyllASTNode={
+                                                Object {
+                                                                "children": Array [
+                                                                  Object {
+                                                                    "id": 84,
+                                                                    "type": "textnode",
+                                                                    "value": "x^2",
+                                                                  },
+                                                                ],
+                                                                "id": 83,
+                                                                "name": "equation",
+                                                                "type": "component",
+                                                              }
+                                }
+                >
                                 x^2
                 </Equation>
                 :
@@ -2810,10 +14267,39 @@ Late Var Range:",
                                                                 "var": "xSquared",
                                                               }
                                 }
+                                idyllASTNode={
+                                                Object {
+                                                                "children": Array [],
+                                                                "id": 86,
+                                                                "name": "Display",
+                                                                "properties": Object {
+                                                                  "var": Object {
+                                                                    "type": "expression",
+                                                                    "value": "xSquared",
+                                                                  },
+                                                                },
+                                                                "type": "component",
+                                                              }
+                                }
                                 var="xSquared"
                 />
 </p>,
-              <p>
+              <p
+                idyllASTNode={
+                                Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 88,
+                                                    "type": "textnode",
+                                                    "value": "Test expression, displays:",
+                                                  },
+                                                ],
+                                                "id": 87,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                }
+>
                 Test expression, displays:
 </p>,
               <Display
@@ -2823,6 +14309,24 @@ Late Var Range:",
                                               }
                 }
                 id="varDisplay"
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 89,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "varDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "expression",
+                                                    "value": "x",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                }
                 value="x"
 />,
               <Display
@@ -2832,6 +14336,24 @@ Late Var Range:",
                                               }
                 }
                 id="derivedVarDisplay"
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 90,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "derivedVarDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "expression",
+                                                    "value": "xSquared",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                }
                 value="xSquared"
 />,
               <Display
@@ -2841,6 +14363,24 @@ Late Var Range:",
                                               }
                 }
                 id="derivedVarDisplay2"
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 91,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "derivedVarDisplay2",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "expression",
+                                                    "value": "xCubed",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                }
                 value="xCubed"
 />,
               <Display
@@ -2850,6 +14390,24 @@ Late Var Range:",
                                               }
                 }
                 id="strDisplay"
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 92,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "strDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "expression",
+                                                    "value": "\\"string\\"",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                }
                 value="\\"string\\""
 />,
               <Display
@@ -2859,6 +14417,24 @@ Late Var Range:",
                                               }
                 }
                 id="staticObjectDisplay"
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 93,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "staticObjectDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "expression",
+                                                    "value": "{ static: \\"object\\" }",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                }
                 value="{ static: \\"object\\" }"
 />,
               <Display
@@ -2868,6 +14444,24 @@ Late Var Range:",
                                               }
                 }
                 id="dynamicObjectDisplay"
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 94,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "dynamicObjectDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "expression",
+                                                    "value": "{ dynamic: x }",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                }
                 value="{ dynamic: x }"
 />,
               <Display
@@ -2877,6 +14471,24 @@ Late Var Range:",
                                               }
                 }
                 id="dataDisplay"
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 95,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "dataDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "expression",
+                                                    "value": "myData",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                }
                 value="myData"
 />,
               <Display
@@ -2886,6 +14498,24 @@ Late Var Range:",
                                               }
                 }
                 id="bareDataDisplay"
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 96,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "bareDataDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "variable",
+                                                    "value": "myData",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                }
                 value="myData"
 />,
               <Display
@@ -2895,6 +14525,24 @@ Late Var Range:",
                                               }
                 }
                 id="bareVarDisplay"
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 97,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "bareVarDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "variable",
+                                                    "value": "x",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                }
                 value="x"
 />,
               <Display
@@ -2904,6 +14552,24 @@ Late Var Range:",
                                               }
                 }
                 id="bareDerivedDisplay"
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 98,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "bareDerivedDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "variable",
+                                                    "value": "xSquared",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                }
                 value="xSquared"
 />,
               <Display
@@ -2913,6 +14579,24 @@ Late Var Range:",
                                               }
                 }
                 id="bareDerivedDisplay2"
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 99,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "bareDerivedDisplay2",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "variable",
+                                                    "value": "xCubed",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                }
                 value="xCubed"
 />,
               <Display
@@ -2922,6 +14606,24 @@ Late Var Range:",
                                               }
                 }
                 id="objectVarDisplay"
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 100,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "objectVarDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "expression",
+                                                    "value": " objectVar ",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                }
                 value=" objectVar "
 />,
               <Display
@@ -2931,6 +14633,24 @@ Late Var Range:",
                                               }
                 }
                 id="bareObjectVarDisplay"
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 101,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "bareObjectVarDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "variable",
+                                                    "value": "objectVar",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                }
                 value="objectVar"
 />,
               <Display
@@ -2940,6 +14660,24 @@ Late Var Range:",
                                               }
                 }
                 id="arrayVarDisplay"
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 102,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "arrayVarDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "expression",
+                                                    "value": " arrayVar ",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                }
                 value=" arrayVar "
 />,
               <Display
@@ -2949,10 +14687,52 @@ Late Var Range:",
                                               }
                 }
                 id="bareArrayVarDisplay"
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 103,
+                                                "name": "Display",
+                                                "properties": Object {
+                                                  "id": Object {
+                                                    "type": "value",
+                                                    "value": "bareArrayVarDisplay",
+                                                  },
+                                                  "value": Object {
+                                                    "type": "variable",
+                                                    "value": "arrayVar",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                }
                 value="arrayVar"
 />,
-              <br />,
-              <p>
+              <br
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 104,
+                                                "name": "br",
+                                                "type": "component",
+                                              }
+                }
+/>,
+              <p
+                idyllASTNode={
+                                Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 106,
+                                                    "type": "textnode",
+                                                    "value": "Here is an example of how you could use a variable to control the frequency of a sine wave:",
+                                                  },
+                                                ],
+                                                "id": 105,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                }
+>
                 Here is an example of how you could use a variable to control the frequency of a sine wave:
 </p>,
               <Chart
@@ -2965,6 +14745,28 @@ Late Var Range:",
                 domain="[0, 2 * Math.PI]"
                 domainPadding={0}
                 equation="(t) => Math.sin(t * frequency)"
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 107,
+                                                "name": "Chart",
+                                                "properties": Object {
+                                                  "domain": Object {
+                                                    "type": "expression",
+                                                    "value": "[0, 2 * Math.PI]",
+                                                  },
+                                                  "equation": Object {
+                                                    "type": "expression",
+                                                    "value": "(t) => Math.sin(t * frequency)",
+                                                  },
+                                                  "samplePoints": Object {
+                                                    "type": "value",
+                                                    "value": 1000,
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                }
                 range={
                                 Array [
                                                 -1,
@@ -2985,12 +14787,70 @@ Late Var Range:",
                                                 "value": "frequency",
                                               }
                 }
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 108,
+                                                "name": "Range",
+                                                "properties": Object {
+                                                  "max": Object {
+                                                    "type": "expression",
+                                                    "value": "2 * Math.PI",
+                                                  },
+                                                  "min": Object {
+                                                    "type": "value",
+                                                    "value": 0.5,
+                                                  },
+                                                  "step": Object {
+                                                    "type": "value",
+                                                    "value": 0.0001,
+                                                  },
+                                                  "value": Object {
+                                                    "type": "variable",
+                                                    "value": "frequency",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                }
                 max="2 * Math.PI"
                 min={0.5}
                 step={0.0001}
                 value="frequency"
 />,
-              <p>
+              <p
+                idyllASTNode={
+                                Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "children": Array [],
+                                                    "id": 110,
+                                                    "name": "Display",
+                                                    "properties": Object {
+                                                      "id": Object {
+                                                        "type": "value",
+                                                        "value": "lateVarDisplay",
+                                                      },
+                                                      "value": Object {
+                                                        "type": "variable",
+                                                        "value": "lateVar",
+                                                      },
+                                                    },
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 111,
+                                                    "type": "textnode",
+                                                    "value": "
+                                Late Var Range:",
+                                                  },
+                                                ],
+                                                "id": 109,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                }
+>
                 <Display
                                 __vars__={
                                                 Object {
@@ -2998,6 +14858,24 @@ Late Var Range:",
                                                               }
                                 }
                                 id="lateVarDisplay"
+                                idyllASTNode={
+                                                Object {
+                                                                "children": Array [],
+                                                                "id": 110,
+                                                                "name": "Display",
+                                                                "properties": Object {
+                                                                  "id": Object {
+                                                                    "type": "value",
+                                                                    "value": "lateVarDisplay",
+                                                                  },
+                                                                  "value": Object {
+                                                                    "type": "variable",
+                                                                    "value": "lateVar",
+                                                                  },
+                                                                },
+                                                                "type": "component",
+                                                              }
+                                }
                                 value="lateVar"
                 />
                 
@@ -3009,27 +14887,1081 @@ Late Var Range:",
                                                 "value": "lateVar",
                                               }
                 }
+                idyllASTNode={
+                                Object {
+                                                "children": Array [],
+                                                "id": 112,
+                                                "name": "Range",
+                                                "properties": Object {
+                                                  "max": Object {
+                                                    "type": "value",
+                                                    "value": 100,
+                                                  },
+                                                  "min": Object {
+                                                    "type": "value",
+                                                    "value": 2,
+                                                  },
+                                                  "value": Object {
+                                                    "type": "variable",
+                                                    "value": "lateVar",
+                                                  },
+                                                },
+                                                "type": "component",
+                                              }
+                }
                 max={100}
                 min={2}
                 step={1}
                 value="lateVar"
 />,
-              <p>
+              <p
+                idyllASTNode={
+                                Object {
+                                                "children": Array [
+                                                  Object {
+                                                    "id": 114,
+                                                    "type": "textnode",
+                                                    "value": "Read more about Idyll at ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 116,
+                                                        "type": "textnode",
+                                                        "value": "https://idyll-lang.github.io/",
+                                                      },
+                                                    ],
+                                                    "id": 115,
+                                                    "name": "a",
+                                                    "properties": Object {
+                                                      "href": Object {
+                                                        "type": "value",
+                                                        "value": "https://idyll-lang.github.io/",
+                                                      },
+                                                    },
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 117,
+                                                    "type": "textnode",
+                                                    "value": ", and come say “Hi!” in our ",
+                                                  },
+                                                  Object {
+                                                    "children": Array [
+                                                      Object {
+                                                        "id": 119,
+                                                        "type": "textnode",
+                                                        "value": "chatroom on gitter",
+                                                      },
+                                                    ],
+                                                    "id": 118,
+                                                    "name": "a",
+                                                    "properties": Object {
+                                                      "href": Object {
+                                                        "type": "value",
+                                                        "value": "https://gitter.im/idyll-lang/Lobby",
+                                                      },
+                                                    },
+                                                    "type": "component",
+                                                  },
+                                                  Object {
+                                                    "id": 120,
+                                                    "type": "textnode",
+                                                    "value": ".",
+                                                  },
+                                                ],
+                                                "id": 113,
+                                                "name": "p",
+                                                "type": "component",
+                                              }
+                }
+>
                 Read more about Idyll at 
                 <a
                                 href="https://idyll-lang.github.io/"
+                                idyllASTNode={
+                                                Object {
+                                                                "children": Array [
+                                                                  Object {
+                                                                    "id": 116,
+                                                                    "type": "textnode",
+                                                                    "value": "https://idyll-lang.github.io/",
+                                                                  },
+                                                                ],
+                                                                "id": 115,
+                                                                "name": "a",
+                                                                "properties": Object {
+                                                                  "href": Object {
+                                                                    "type": "value",
+                                                                    "value": "https://idyll-lang.github.io/",
+                                                                  },
+                                                                },
+                                                                "type": "component",
+                                                              }
+                                }
                 >
                                 https://idyll-lang.github.io/
                 </a>
                 , and come say “Hi!” in our 
                 <a
                                 href="https://gitter.im/idyll-lang/Lobby"
+                                idyllASTNode={
+                                                Object {
+                                                                "children": Array [
+                                                                  Object {
+                                                                    "id": 119,
+                                                                    "type": "textnode",
+                                                                    "value": "chatroom on gitter",
+                                                                  },
+                                                                ],
+                                                                "id": 118,
+                                                                "name": "a",
+                                                                "properties": Object {
+                                                                  "href": Object {
+                                                                    "type": "value",
+                                                                    "value": "https://gitter.im/idyll-lang/Lobby",
+                                                                  },
+                                                                },
+                                                                "type": "component",
+                                                              }
+                                }
                 >
                                 chatroom on gitter
                 </a>
                 .
 </p>,
             ],
+            "idyllASTNode": Object {
+              "children": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": 12,
+                      "type": "textnode",
+                      "value": "Welcome to Idyll",
+                    },
+                  ],
+                  "id": 11,
+                  "name": "h1",
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": 14,
+                      "type": "textnode",
+                      "value": "Idyll is a language for creating interactive documents on the web.",
+                    },
+                  ],
+                  "id": 13,
+                  "name": "h3",
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": 16,
+                      "type": "textnode",
+                      "value": "This document is being rendered from ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 18,
+                          "type": "textnode",
+                          "value": "Idyll markup",
+                        },
+                      ],
+                      "id": 17,
+                      "name": "strong",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 19,
+                      "type": "textnode",
+                      "value": ". If you’ve used ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 21,
+                          "type": "textnode",
+                          "value": "markdown",
+                        },
+                      ],
+                      "id": 20,
+                      "name": "a",
+                      "properties": Object {
+                        "href": Object {
+                          "type": "value",
+                          "value": "https://daringfireball.net/projects/markdown/",
+                        },
+                      },
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 22,
+                      "type": "textnode",
+                      "value": ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.",
+                    },
+                  ],
+                  "id": 15,
+                  "name": "p",
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": 24,
+                      "type": "textnode",
+                      "value": "To make things a little more interesting you can add JavaScript components to your text.
+For example, a ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 26,
+                          "type": "textnode",
+                          "value": "[Chart /]",
+                        },
+                      ],
+                      "id": 25,
+                      "name": "code",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 27,
+                      "type": "textnode",
+                      "value": " component can be used to render a simple visualization:",
+                    },
+                  ],
+                  "id": 23,
+                  "name": "p",
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 28,
+                  "name": "Chart",
+                  "properties": Object {
+                    "type": Object {
+                      "type": "value",
+                      "value": "scatter",
+                    },
+                  },
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": 30,
+                      "type": "textnode",
+                      "value": "Try changing the chart’s type from ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 32,
+                          "type": "textnode",
+                          "value": "scatter",
+                        },
+                      ],
+                      "id": 31,
+                      "name": "code",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 33,
+                      "type": "textnode",
+                      "value": " to ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 35,
+                          "type": "textnode",
+                          "value": "line",
+                        },
+                      ],
+                      "id": 34,
+                      "name": "code",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 36,
+                      "type": "textnode",
+                      "value": ", ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 38,
+                          "type": "textnode",
+                          "value": "area",
+                        },
+                      ],
+                      "id": 37,
+                      "name": "code",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 39,
+                      "type": "textnode",
+                      "value": ", or ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 41,
+                          "type": "textnode",
+                          "value": "pie",
+                        },
+                      ],
+                      "id": 40,
+                      "name": "code",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 42,
+                      "type": "textnode",
+                      "value": ".",
+                    },
+                  ],
+                  "id": 29,
+                  "name": "p",
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": 44,
+                      "type": "textnode",
+                      "value": "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 46,
+                          "type": "textnode",
+                          "value": "\`2 * Math.PI\`",
+                        },
+                      ],
+                      "id": 45,
+                      "name": "code",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 47,
+                      "type": "textnode",
+                      "value": ").",
+                    },
+                  ],
+                  "id": 43,
+                  "name": "p",
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": 49,
+                      "type": "textnode",
+                      "value": "There are a number of components available — see ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 51,
+                          "type": "textnode",
+                          "value": "Idyll’s documentation",
+                        },
+                      ],
+                      "id": 50,
+                      "name": "a",
+                      "properties": Object {
+                        "href": Object {
+                          "type": "value",
+                          "value": "https://idyll-lang.github.io/components-built-in",
+                        },
+                      },
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 52,
+                      "type": "textnode",
+                      "value": " for a full list — Additional components can be installed via ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 54,
+                          "type": "textnode",
+                          "value": "npm",
+                        },
+                      ],
+                      "id": 53,
+                      "name": "code",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 55,
+                      "type": "textnode",
+                      "value": " (any React component should work), and if you are comfortable with JavaScript you can write ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 57,
+                          "type": "textnode",
+                          "value": "custom components",
+                        },
+                      ],
+                      "id": 56,
+                      "name": "a",
+                      "properties": Object {
+                        "href": Object {
+                          "type": "value",
+                          "value": "https://idyll-lang.github.io/components-custom",
+                        },
+                      },
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 58,
+                      "type": "textnode",
+                      "value": " as well.",
+                    },
+                  ],
+                  "id": 48,
+                  "name": "p",
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": 60,
+                      "type": "textnode",
+                      "value": "Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.",
+                    },
+                  ],
+                  "id": 59,
+                  "name": "p",
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": 62,
+                      "type": "textnode",
+                      "value": "Instantiating a variable is similar to instantiating a component:",
+                    },
+                  ],
+                  "id": 61,
+                  "name": "p",
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": 64,
+                      "type": "textnode",
+                      "value": "[var name:\\"x\\" value:1 /]",
+                    },
+                  ],
+                  "id": 63,
+                  "name": "code",
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": 66,
+                      "type": "textnode",
+                      "value": "Once you’ve created a variable, it can be displayed inline with text
+(x = ",
+                    },
+                    Object {
+                      "children": Array [],
+                      "id": 67,
+                      "name": "Display",
+                      "properties": Object {
+                        "var": Object {
+                          "type": "variable",
+                          "value": "x",
+                        },
+                      },
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 68,
+                      "type": "textnode",
+                      "value": "),
+or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:",
+                    },
+                  ],
+                  "id": 65,
+                  "name": "p",
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": 70,
+                      "type": "textnode",
+                      "value": "[derived name:\\"xSquared\\" value:\`x * x\` /]",
+                    },
+                  ],
+                  "id": 69,
+                  "name": "code",
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": 72,
+                      "type": "textnode",
+                      "value": "Here I bind the value of ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 74,
+                          "type": "textnode",
+                          "value": "x",
+                        },
+                      ],
+                      "id": 73,
+                      "name": "code",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 75,
+                      "type": "textnode",
+                      "value": " to a range slider. Move the slider and watch the variables update.",
+                    },
+                  ],
+                  "id": 71,
+                  "name": "p",
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 76,
+                  "name": "Range",
+                  "properties": Object {
+                    "max": Object {
+                      "type": "value",
+                      "value": 100,
+                    },
+                    "min": Object {
+                      "type": "value",
+                      "value": 0,
+                    },
+                    "value": Object {
+                      "type": "variable",
+                      "value": "x",
+                    },
+                  },
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 79,
+                          "type": "textnode",
+                          "value": "x",
+                        },
+                      ],
+                      "id": 78,
+                      "name": "equation",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 80,
+                      "type": "textnode",
+                      "value": ":
+ ",
+                    },
+                    Object {
+                      "children": Array [],
+                      "id": 81,
+                      "name": "Display",
+                      "properties": Object {
+                        "var": Object {
+                          "type": "expression",
+                          "value": "x",
+                        },
+                      },
+                      "type": "component",
+                    },
+                  ],
+                  "id": 77,
+                  "name": "p",
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 84,
+                          "type": "textnode",
+                          "value": "x^2",
+                        },
+                      ],
+                      "id": 83,
+                      "name": "equation",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 85,
+                      "type": "textnode",
+                      "value": ":",
+                    },
+                    Object {
+                      "children": Array [],
+                      "id": 86,
+                      "name": "Display",
+                      "properties": Object {
+                        "var": Object {
+                          "type": "expression",
+                          "value": "xSquared",
+                        },
+                      },
+                      "type": "component",
+                    },
+                  ],
+                  "id": 82,
+                  "name": "p",
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": 88,
+                      "type": "textnode",
+                      "value": "Test expression, displays:",
+                    },
+                  ],
+                  "id": 87,
+                  "name": "p",
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 89,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "varDisplay",
+                    },
+                    "value": Object {
+                      "type": "expression",
+                      "value": "x",
+                    },
+                  },
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 90,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "derivedVarDisplay",
+                    },
+                    "value": Object {
+                      "type": "expression",
+                      "value": "xSquared",
+                    },
+                  },
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 91,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "derivedVarDisplay2",
+                    },
+                    "value": Object {
+                      "type": "expression",
+                      "value": "xCubed",
+                    },
+                  },
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 92,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "strDisplay",
+                    },
+                    "value": Object {
+                      "type": "expression",
+                      "value": "\\"string\\"",
+                    },
+                  },
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 93,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "staticObjectDisplay",
+                    },
+                    "value": Object {
+                      "type": "expression",
+                      "value": "{ static: \\"object\\" }",
+                    },
+                  },
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 94,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "dynamicObjectDisplay",
+                    },
+                    "value": Object {
+                      "type": "expression",
+                      "value": "{ dynamic: x }",
+                    },
+                  },
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 95,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "dataDisplay",
+                    },
+                    "value": Object {
+                      "type": "expression",
+                      "value": "myData",
+                    },
+                  },
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 96,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "bareDataDisplay",
+                    },
+                    "value": Object {
+                      "type": "variable",
+                      "value": "myData",
+                    },
+                  },
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 97,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "bareVarDisplay",
+                    },
+                    "value": Object {
+                      "type": "variable",
+                      "value": "x",
+                    },
+                  },
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 98,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "bareDerivedDisplay",
+                    },
+                    "value": Object {
+                      "type": "variable",
+                      "value": "xSquared",
+                    },
+                  },
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 99,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "bareDerivedDisplay2",
+                    },
+                    "value": Object {
+                      "type": "variable",
+                      "value": "xCubed",
+                    },
+                  },
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 100,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "objectVarDisplay",
+                    },
+                    "value": Object {
+                      "type": "expression",
+                      "value": " objectVar ",
+                    },
+                  },
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 101,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "bareObjectVarDisplay",
+                    },
+                    "value": Object {
+                      "type": "variable",
+                      "value": "objectVar",
+                    },
+                  },
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 102,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "arrayVarDisplay",
+                    },
+                    "value": Object {
+                      "type": "expression",
+                      "value": " arrayVar ",
+                    },
+                  },
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 103,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "bareArrayVarDisplay",
+                    },
+                    "value": Object {
+                      "type": "variable",
+                      "value": "arrayVar",
+                    },
+                  },
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 104,
+                  "name": "br",
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": 106,
+                      "type": "textnode",
+                      "value": "Here is an example of how you could use a variable to control the frequency of a sine wave:",
+                    },
+                  ],
+                  "id": 105,
+                  "name": "p",
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 107,
+                  "name": "Chart",
+                  "properties": Object {
+                    "domain": Object {
+                      "type": "expression",
+                      "value": "[0, 2 * Math.PI]",
+                    },
+                    "equation": Object {
+                      "type": "expression",
+                      "value": "(t) => Math.sin(t * frequency)",
+                    },
+                    "samplePoints": Object {
+                      "type": "value",
+                      "value": 1000,
+                    },
+                  },
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 108,
+                  "name": "Range",
+                  "properties": Object {
+                    "max": Object {
+                      "type": "expression",
+                      "value": "2 * Math.PI",
+                    },
+                    "min": Object {
+                      "type": "value",
+                      "value": 0.5,
+                    },
+                    "step": Object {
+                      "type": "value",
+                      "value": 0.0001,
+                    },
+                    "value": Object {
+                      "type": "variable",
+                      "value": "frequency",
+                    },
+                  },
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [],
+                      "id": 110,
+                      "name": "Display",
+                      "properties": Object {
+                        "id": Object {
+                          "type": "value",
+                          "value": "lateVarDisplay",
+                        },
+                        "value": Object {
+                          "type": "variable",
+                          "value": "lateVar",
+                        },
+                      },
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 111,
+                      "type": "textnode",
+                      "value": "
+Late Var Range:",
+                    },
+                  ],
+                  "id": 109,
+                  "name": "p",
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [],
+                  "id": 112,
+                  "name": "Range",
+                  "properties": Object {
+                    "max": Object {
+                      "type": "value",
+                      "value": 100,
+                    },
+                    "min": Object {
+                      "type": "value",
+                      "value": 2,
+                    },
+                    "value": Object {
+                      "type": "variable",
+                      "value": "lateVar",
+                    },
+                  },
+                  "type": "component",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": 114,
+                      "type": "textnode",
+                      "value": "Read more about Idyll at ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 116,
+                          "type": "textnode",
+                          "value": "https://idyll-lang.github.io/",
+                        },
+                      ],
+                      "id": 115,
+                      "name": "a",
+                      "properties": Object {
+                        "href": Object {
+                          "type": "value",
+                          "value": "https://idyll-lang.github.io/",
+                        },
+                      },
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 117,
+                      "type": "textnode",
+                      "value": ", and come say “Hi!” in our ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 119,
+                          "type": "textnode",
+                          "value": "chatroom on gitter",
+                        },
+                      ],
+                      "id": 118,
+                      "name": "a",
+                      "properties": Object {
+                        "href": Object {
+                          "type": "value",
+                          "value": "https://gitter.im/idyll-lang/Lobby",
+                        },
+                      },
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 120,
+                      "type": "textnode",
+                      "value": ".",
+                    },
+                  ],
+                  "id": 113,
+                  "name": "p",
+                  "type": "component",
+                },
+              ],
+              "id": 10,
+              "name": "TextContainer",
+              "type": "component",
+            },
           },
           "ref": null,
           "rendered": Array [
@@ -3041,6 +15973,18 @@ Late Var Range:",
                 "children": Array [
                   "Welcome to Idyll",
                 ],
+                "idyllASTNode": Object {
+                  "children": Array [
+                    Object {
+                      "id": 12,
+                      "type": "textnode",
+                      "value": "Welcome to Idyll",
+                    },
+                  ],
+                  "id": 11,
+                  "name": "h1",
+                  "type": "component",
+                },
               },
               "ref": null,
               "rendered": Array [
@@ -3056,6 +16000,18 @@ Late Var Range:",
                 "children": Array [
                   "Idyll is a language for creating interactive documents on the web.",
                 ],
+                "idyllASTNode": Object {
+                  "children": Array [
+                    Object {
+                      "id": 14,
+                      "type": "textnode",
+                      "value": "Idyll is a language for creating interactive documents on the web.",
+                    },
+                  ],
+                  "id": 13,
+                  "name": "h3",
+                  "type": "component",
+                },
               },
               "ref": null,
               "rendered": Array [
@@ -3070,17 +16026,104 @@ Late Var Range:",
               "props": Object {
                 "children": Array [
                   "This document is being rendered from ",
-                  <strong>
+                  <strong
+                    idyllASTNode={
+                                        Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 18,
+                                                                "type": "textnode",
+                                                                "value": "Idyll markup",
+                                                              },
+                                                            ],
+                                                            "id": 17,
+                                                            "name": "strong",
+                                                            "type": "component",
+                                                          }
+                    }
+>
                     Idyll markup
 </strong>,
                   ". If you’ve used ",
                   <a
                     href="https://daringfireball.net/projects/markdown/"
+                    idyllASTNode={
+                                        Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 21,
+                                                                "type": "textnode",
+                                                                "value": "markdown",
+                                                              },
+                                                            ],
+                                                            "id": 20,
+                                                            "name": "a",
+                                                            "properties": Object {
+                                                              "href": Object {
+                                                                "type": "value",
+                                                                "value": "https://daringfireball.net/projects/markdown/",
+                                                              },
+                                                            },
+                                                            "type": "component",
+                                                          }
+                    }
 >
                     markdown
 </a>,
                   ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.",
                 ],
+                "idyllASTNode": Object {
+                  "children": Array [
+                    Object {
+                      "id": 16,
+                      "type": "textnode",
+                      "value": "This document is being rendered from ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 18,
+                          "type": "textnode",
+                          "value": "Idyll markup",
+                        },
+                      ],
+                      "id": 17,
+                      "name": "strong",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 19,
+                      "type": "textnode",
+                      "value": ". If you’ve used ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 21,
+                          "type": "textnode",
+                          "value": "markdown",
+                        },
+                      ],
+                      "id": 20,
+                      "name": "a",
+                      "properties": Object {
+                        "href": Object {
+                          "type": "value",
+                          "value": "https://daringfireball.net/projects/markdown/",
+                        },
+                      },
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 22,
+                      "type": "textnode",
+                      "value": ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.",
+                    },
+                  ],
+                  "id": 15,
+                  "name": "p",
+                  "type": "component",
+                },
               },
               "ref": null,
               "rendered": Array [
@@ -3093,6 +16136,18 @@ Late Var Range:",
                     "children": Array [
                       "Idyll markup",
                     ],
+                    "idyllASTNode": Object {
+                      "children": Array [
+                        Object {
+                          "id": 18,
+                          "type": "textnode",
+                          "value": "Idyll markup",
+                        },
+                      ],
+                      "id": 17,
+                      "name": "strong",
+                      "type": "component",
+                    },
                   },
                   "ref": null,
                   "rendered": Array [
@@ -3110,6 +16165,24 @@ Late Var Range:",
                       "markdown",
                     ],
                     "href": "https://daringfireball.net/projects/markdown/",
+                    "idyllASTNode": Object {
+                      "children": Array [
+                        Object {
+                          "id": 21,
+                          "type": "textnode",
+                          "value": "markdown",
+                        },
+                      ],
+                      "id": 20,
+                      "name": "a",
+                      "properties": Object {
+                        "href": Object {
+                          "type": "value",
+                          "value": "https://daringfireball.net/projects/markdown/",
+                        },
+                      },
+                      "type": "component",
+                    },
                   },
                   "ref": null,
                   "rendered": Array [
@@ -3129,11 +16202,56 @@ Late Var Range:",
                 "children": Array [
                   "To make things a little more interesting you can add JavaScript components to your text.
 For example, a ",
-                  <code>
+                  <code
+                    idyllASTNode={
+                                        Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 26,
+                                                                "type": "textnode",
+                                                                "value": "[Chart /]",
+                                                              },
+                                                            ],
+                                                            "id": 25,
+                                                            "name": "code",
+                                                            "type": "component",
+                                                          }
+                    }
+>
                     [Chart /]
 </code>,
                   " component can be used to render a simple visualization:",
                 ],
+                "idyllASTNode": Object {
+                  "children": Array [
+                    Object {
+                      "id": 24,
+                      "type": "textnode",
+                      "value": "To make things a little more interesting you can add JavaScript components to your text.
+For example, a ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 26,
+                          "type": "textnode",
+                          "value": "[Chart /]",
+                        },
+                      ],
+                      "id": 25,
+                      "name": "code",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 27,
+                      "type": "textnode",
+                      "value": " component can be used to render a simple visualization:",
+                    },
+                  ],
+                  "id": 23,
+                  "name": "p",
+                  "type": "component",
+                },
               },
               "ref": null,
               "rendered": Array [
@@ -3147,6 +16265,18 @@ For example, a ",
                     "children": Array [
                       "[Chart /]",
                     ],
+                    "idyllASTNode": Object {
+                      "children": Array [
+                        Object {
+                          "id": 26,
+                          "type": "textnode",
+                          "value": "[Chart /]",
+                        },
+                      ],
+                      "id": 25,
+                      "name": "code",
+                      "type": "component",
+                    },
                   },
                   "ref": null,
                   "rendered": Array [
@@ -3169,6 +16299,18 @@ For example, a ",
                   1,
                 ],
                 "domainPadding": 0,
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 28,
+                  "name": "Chart",
+                  "properties": Object {
+                    "type": Object {
+                      "type": "value",
+                      "value": "scatter",
+                    },
+                  },
+                  "type": "component",
+                },
                 "range": Array [
                   -1,
                   1,
@@ -3187,23 +16329,163 @@ For example, a ",
               "props": Object {
                 "children": Array [
                   "Try changing the chart’s type from ",
-                  <code>
+                  <code
+                    idyllASTNode={
+                                        Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 32,
+                                                                "type": "textnode",
+                                                                "value": "scatter",
+                                                              },
+                                                            ],
+                                                            "id": 31,
+                                                            "name": "code",
+                                                            "type": "component",
+                                                          }
+                    }
+>
                     scatter
 </code>,
                   " to ",
-                  <code>
+                  <code
+                    idyllASTNode={
+                                        Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 35,
+                                                                "type": "textnode",
+                                                                "value": "line",
+                                                              },
+                                                            ],
+                                                            "id": 34,
+                                                            "name": "code",
+                                                            "type": "component",
+                                                          }
+                    }
+>
                     line
 </code>,
                   ", ",
-                  <code>
+                  <code
+                    idyllASTNode={
+                                        Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 38,
+                                                                "type": "textnode",
+                                                                "value": "area",
+                                                              },
+                                                            ],
+                                                            "id": 37,
+                                                            "name": "code",
+                                                            "type": "component",
+                                                          }
+                    }
+>
                     area
 </code>,
                   ", or ",
-                  <code>
+                  <code
+                    idyllASTNode={
+                                        Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 41,
+                                                                "type": "textnode",
+                                                                "value": "pie",
+                                                              },
+                                                            ],
+                                                            "id": 40,
+                                                            "name": "code",
+                                                            "type": "component",
+                                                          }
+                    }
+>
                     pie
 </code>,
                   ".",
                 ],
+                "idyllASTNode": Object {
+                  "children": Array [
+                    Object {
+                      "id": 30,
+                      "type": "textnode",
+                      "value": "Try changing the chart’s type from ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 32,
+                          "type": "textnode",
+                          "value": "scatter",
+                        },
+                      ],
+                      "id": 31,
+                      "name": "code",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 33,
+                      "type": "textnode",
+                      "value": " to ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 35,
+                          "type": "textnode",
+                          "value": "line",
+                        },
+                      ],
+                      "id": 34,
+                      "name": "code",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 36,
+                      "type": "textnode",
+                      "value": ", ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 38,
+                          "type": "textnode",
+                          "value": "area",
+                        },
+                      ],
+                      "id": 37,
+                      "name": "code",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 39,
+                      "type": "textnode",
+                      "value": ", or ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 41,
+                          "type": "textnode",
+                          "value": "pie",
+                        },
+                      ],
+                      "id": 40,
+                      "name": "code",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 42,
+                      "type": "textnode",
+                      "value": ".",
+                    },
+                  ],
+                  "id": 29,
+                  "name": "p",
+                  "type": "component",
+                },
               },
               "ref": null,
               "rendered": Array [
@@ -3216,6 +16498,18 @@ For example, a ",
                     "children": Array [
                       "scatter",
                     ],
+                    "idyllASTNode": Object {
+                      "children": Array [
+                        Object {
+                          "id": 32,
+                          "type": "textnode",
+                          "value": "scatter",
+                        },
+                      ],
+                      "id": 31,
+                      "name": "code",
+                      "type": "component",
+                    },
                   },
                   "ref": null,
                   "rendered": Array [
@@ -3232,6 +16526,18 @@ For example, a ",
                     "children": Array [
                       "line",
                     ],
+                    "idyllASTNode": Object {
+                      "children": Array [
+                        Object {
+                          "id": 35,
+                          "type": "textnode",
+                          "value": "line",
+                        },
+                      ],
+                      "id": 34,
+                      "name": "code",
+                      "type": "component",
+                    },
                   },
                   "ref": null,
                   "rendered": Array [
@@ -3248,6 +16554,18 @@ For example, a ",
                     "children": Array [
                       "area",
                     ],
+                    "idyllASTNode": Object {
+                      "children": Array [
+                        Object {
+                          "id": 38,
+                          "type": "textnode",
+                          "value": "area",
+                        },
+                      ],
+                      "id": 37,
+                      "name": "code",
+                      "type": "component",
+                    },
                   },
                   "ref": null,
                   "rendered": Array [
@@ -3264,6 +16582,18 @@ For example, a ",
                     "children": Array [
                       "pie",
                     ],
+                    "idyllASTNode": Object {
+                      "children": Array [
+                        Object {
+                          "id": 41,
+                          "type": "textnode",
+                          "value": "pie",
+                        },
+                      ],
+                      "id": 40,
+                      "name": "code",
+                      "type": "component",
+                    },
                   },
                   "ref": null,
                   "rendered": Array [
@@ -3282,11 +16612,55 @@ For example, a ",
               "props": Object {
                 "children": Array [
                   "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (",
-                  <code>
+                  <code
+                    idyllASTNode={
+                                        Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 46,
+                                                                "type": "textnode",
+                                                                "value": "\`2 * Math.PI\`",
+                                                              },
+                                                            ],
+                                                            "id": 45,
+                                                            "name": "code",
+                                                            "type": "component",
+                                                          }
+                    }
+>
                     \`2 * Math.PI\`
 </code>,
                   ").",
                 ],
+                "idyllASTNode": Object {
+                  "children": Array [
+                    Object {
+                      "id": 44,
+                      "type": "textnode",
+                      "value": "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions (",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 46,
+                          "type": "textnode",
+                          "value": "\`2 * Math.PI\`",
+                        },
+                      ],
+                      "id": 45,
+                      "name": "code",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 47,
+                      "type": "textnode",
+                      "value": ").",
+                    },
+                  ],
+                  "id": 43,
+                  "name": "p",
+                  "type": "component",
+                },
               },
               "ref": null,
               "rendered": Array [
@@ -3299,6 +16673,18 @@ For example, a ",
                     "children": Array [
                       "\`2 * Math.PI\`",
                     ],
+                    "idyllASTNode": Object {
+                      "children": Array [
+                        Object {
+                          "id": 46,
+                          "type": "textnode",
+                          "value": "\`2 * Math.PI\`",
+                        },
+                      ],
+                      "id": 45,
+                      "name": "code",
+                      "type": "component",
+                    },
                   },
                   "ref": null,
                   "rendered": Array [
@@ -3319,21 +16705,151 @@ For example, a ",
                   "There are a number of components available — see ",
                   <a
                     href="https://idyll-lang.github.io/components-built-in"
+                    idyllASTNode={
+                                        Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 51,
+                                                                "type": "textnode",
+                                                                "value": "Idyll’s documentation",
+                                                              },
+                                                            ],
+                                                            "id": 50,
+                                                            "name": "a",
+                                                            "properties": Object {
+                                                              "href": Object {
+                                                                "type": "value",
+                                                                "value": "https://idyll-lang.github.io/components-built-in",
+                                                              },
+                                                            },
+                                                            "type": "component",
+                                                          }
+                    }
 >
                     Idyll’s documentation
 </a>,
                   " for a full list — Additional components can be installed via ",
-                  <code>
+                  <code
+                    idyllASTNode={
+                                        Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 54,
+                                                                "type": "textnode",
+                                                                "value": "npm",
+                                                              },
+                                                            ],
+                                                            "id": 53,
+                                                            "name": "code",
+                                                            "type": "component",
+                                                          }
+                    }
+>
                     npm
 </code>,
                   " (any React component should work), and if you are comfortable with JavaScript you can write ",
                   <a
                     href="https://idyll-lang.github.io/components-custom"
+                    idyllASTNode={
+                                        Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 57,
+                                                                "type": "textnode",
+                                                                "value": "custom components",
+                                                              },
+                                                            ],
+                                                            "id": 56,
+                                                            "name": "a",
+                                                            "properties": Object {
+                                                              "href": Object {
+                                                                "type": "value",
+                                                                "value": "https://idyll-lang.github.io/components-custom",
+                                                              },
+                                                            },
+                                                            "type": "component",
+                                                          }
+                    }
 >
                     custom components
 </a>,
                   " as well.",
                 ],
+                "idyllASTNode": Object {
+                  "children": Array [
+                    Object {
+                      "id": 49,
+                      "type": "textnode",
+                      "value": "There are a number of components available — see ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 51,
+                          "type": "textnode",
+                          "value": "Idyll’s documentation",
+                        },
+                      ],
+                      "id": 50,
+                      "name": "a",
+                      "properties": Object {
+                        "href": Object {
+                          "type": "value",
+                          "value": "https://idyll-lang.github.io/components-built-in",
+                        },
+                      },
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 52,
+                      "type": "textnode",
+                      "value": " for a full list — Additional components can be installed via ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 54,
+                          "type": "textnode",
+                          "value": "npm",
+                        },
+                      ],
+                      "id": 53,
+                      "name": "code",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 55,
+                      "type": "textnode",
+                      "value": " (any React component should work), and if you are comfortable with JavaScript you can write ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 57,
+                          "type": "textnode",
+                          "value": "custom components",
+                        },
+                      ],
+                      "id": 56,
+                      "name": "a",
+                      "properties": Object {
+                        "href": Object {
+                          "type": "value",
+                          "value": "https://idyll-lang.github.io/components-custom",
+                        },
+                      },
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 58,
+                      "type": "textnode",
+                      "value": " as well.",
+                    },
+                  ],
+                  "id": 48,
+                  "name": "p",
+                  "type": "component",
+                },
               },
               "ref": null,
               "rendered": Array [
@@ -3347,6 +16863,24 @@ For example, a ",
                       "Idyll’s documentation",
                     ],
                     "href": "https://idyll-lang.github.io/components-built-in",
+                    "idyllASTNode": Object {
+                      "children": Array [
+                        Object {
+                          "id": 51,
+                          "type": "textnode",
+                          "value": "Idyll’s documentation",
+                        },
+                      ],
+                      "id": 50,
+                      "name": "a",
+                      "properties": Object {
+                        "href": Object {
+                          "type": "value",
+                          "value": "https://idyll-lang.github.io/components-built-in",
+                        },
+                      },
+                      "type": "component",
+                    },
                   },
                   "ref": null,
                   "rendered": Array [
@@ -3363,6 +16897,18 @@ For example, a ",
                     "children": Array [
                       "npm",
                     ],
+                    "idyllASTNode": Object {
+                      "children": Array [
+                        Object {
+                          "id": 54,
+                          "type": "textnode",
+                          "value": "npm",
+                        },
+                      ],
+                      "id": 53,
+                      "name": "code",
+                      "type": "component",
+                    },
                   },
                   "ref": null,
                   "rendered": Array [
@@ -3380,6 +16926,24 @@ For example, a ",
                       "custom components",
                     ],
                     "href": "https://idyll-lang.github.io/components-custom",
+                    "idyllASTNode": Object {
+                      "children": Array [
+                        Object {
+                          "id": 57,
+                          "type": "textnode",
+                          "value": "custom components",
+                        },
+                      ],
+                      "id": 56,
+                      "name": "a",
+                      "properties": Object {
+                        "href": Object {
+                          "type": "value",
+                          "value": "https://idyll-lang.github.io/components-custom",
+                        },
+                      },
+                      "type": "component",
+                    },
                   },
                   "ref": null,
                   "rendered": Array [
@@ -3399,6 +16963,18 @@ For example, a ",
                 "children": Array [
                   "Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.",
                 ],
+                "idyllASTNode": Object {
+                  "children": Array [
+                    Object {
+                      "id": 60,
+                      "type": "textnode",
+                      "value": "Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader.",
+                    },
+                  ],
+                  "id": 59,
+                  "name": "p",
+                  "type": "component",
+                },
               },
               "ref": null,
               "rendered": Array [
@@ -3414,6 +16990,18 @@ For example, a ",
                 "children": Array [
                   "Instantiating a variable is similar to instantiating a component:",
                 ],
+                "idyllASTNode": Object {
+                  "children": Array [
+                    Object {
+                      "id": 62,
+                      "type": "textnode",
+                      "value": "Instantiating a variable is similar to instantiating a component:",
+                    },
+                  ],
+                  "id": 61,
+                  "name": "p",
+                  "type": "component",
+                },
               },
               "ref": null,
               "rendered": Array [
@@ -3429,6 +17017,18 @@ For example, a ",
                 "children": Array [
                   "[var name:\\"x\\" value:1 /]",
                 ],
+                "idyllASTNode": Object {
+                  "children": Array [
+                    Object {
+                      "id": 64,
+                      "type": "textnode",
+                      "value": "[var name:\\"x\\" value:1 /]",
+                    },
+                  ],
+                  "id": 63,
+                  "name": "code",
+                  "type": "component",
+                },
               },
               "ref": null,
               "rendered": Array [
@@ -3450,11 +17050,56 @@ For example, a ",
                                                             "var": "x",
                                                           }
                     }
+                    idyllASTNode={
+                                        Object {
+                                                            "children": Array [],
+                                                            "id": 67,
+                                                            "name": "Display",
+                                                            "properties": Object {
+                                                              "var": Object {
+                                                                "type": "variable",
+                                                                "value": "x",
+                                                              },
+                                                            },
+                                                            "type": "component",
+                                                          }
+                    }
                     var="x"
 />,
                   "),
 or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:",
                 ],
+                "idyllASTNode": Object {
+                  "children": Array [
+                    Object {
+                      "id": 66,
+                      "type": "textnode",
+                      "value": "Once you’ve created a variable, it can be displayed inline with text
+(x = ",
+                    },
+                    Object {
+                      "children": Array [],
+                      "id": 67,
+                      "name": "Display",
+                      "properties": Object {
+                        "var": Object {
+                          "type": "variable",
+                          "value": "x",
+                        },
+                      },
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 68,
+                      "type": "textnode",
+                      "value": "),
+or be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:",
+                    },
+                  ],
+                  "id": 65,
+                  "name": "p",
+                  "type": "component",
+                },
               },
               "ref": null,
               "rendered": Array [
@@ -3469,6 +17114,18 @@ or be used to parameterize components. Derived variables can be used to create v
                       "var": "x",
                     },
                     "children": undefined,
+                    "idyllASTNode": Object {
+                      "children": Array [],
+                      "id": 67,
+                      "name": "Display",
+                      "properties": Object {
+                        "var": Object {
+                          "type": "variable",
+                          "value": "x",
+                        },
+                      },
+                      "type": "component",
+                    },
                     "var": "x",
                   },
                   "ref": null,
@@ -3488,6 +17145,18 @@ or be used to parameterize components. Derived variables can be used to create v
                 "children": Array [
                   "[derived name:\\"xSquared\\" value:\`x * x\` /]",
                 ],
+                "idyllASTNode": Object {
+                  "children": Array [
+                    Object {
+                      "id": 70,
+                      "type": "textnode",
+                      "value": "[derived name:\\"xSquared\\" value:\`x * x\` /]",
+                    },
+                  ],
+                  "id": 69,
+                  "name": "code",
+                  "type": "component",
+                },
               },
               "ref": null,
               "rendered": Array [
@@ -3502,11 +17171,55 @@ or be used to parameterize components. Derived variables can be used to create v
               "props": Object {
                 "children": Array [
                   "Here I bind the value of ",
-                  <code>
+                  <code
+                    idyllASTNode={
+                                        Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 74,
+                                                                "type": "textnode",
+                                                                "value": "x",
+                                                              },
+                                                            ],
+                                                            "id": 73,
+                                                            "name": "code",
+                                                            "type": "component",
+                                                          }
+                    }
+>
                     x
 </code>,
                   " to a range slider. Move the slider and watch the variables update.",
                 ],
+                "idyllASTNode": Object {
+                  "children": Array [
+                    Object {
+                      "id": 72,
+                      "type": "textnode",
+                      "value": "Here I bind the value of ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 74,
+                          "type": "textnode",
+                          "value": "x",
+                        },
+                      ],
+                      "id": 73,
+                      "name": "code",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 75,
+                      "type": "textnode",
+                      "value": " to a range slider. Move the slider and watch the variables update.",
+                    },
+                  ],
+                  "id": 71,
+                  "name": "p",
+                  "type": "component",
+                },
               },
               "ref": null,
               "rendered": Array [
@@ -3519,6 +17232,18 @@ or be used to parameterize components. Derived variables can be used to create v
                     "children": Array [
                       "x",
                     ],
+                    "idyllASTNode": Object {
+                      "children": Array [
+                        Object {
+                          "id": 74,
+                          "type": "textnode",
+                          "value": "x",
+                        },
+                      ],
+                      "id": 73,
+                      "name": "code",
+                      "type": "component",
+                    },
                   },
                   "ref": null,
                   "rendered": Array [
@@ -3539,6 +17264,26 @@ or be used to parameterize components. Derived variables can be used to create v
                   "value": "x",
                 },
                 "children": undefined,
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 76,
+                  "name": "Range",
+                  "properties": Object {
+                    "max": Object {
+                      "type": "value",
+                      "value": 100,
+                    },
+                    "min": Object {
+                      "type": "value",
+                      "value": 0,
+                    },
+                    "value": Object {
+                      "type": "variable",
+                      "value": "x",
+                    },
+                  },
+                  "type": "component",
+                },
                 "max": 100,
                 "min": 0,
                 "step": 1,
@@ -3554,7 +17299,22 @@ or be used to parameterize components. Derived variables can be used to create v
               "nodeType": "host",
               "props": Object {
                 "children": Array [
-                  <Equation>
+                  <Equation
+                    idyllASTNode={
+                                        Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 79,
+                                                                "type": "textnode",
+                                                                "value": "x",
+                                                              },
+                                                            ],
+                                                            "id": 78,
+                                                            "name": "equation",
+                                                            "type": "component",
+                                                          }
+                    }
+>
                     x
 </Equation>,
                   ":
@@ -3565,9 +17325,60 @@ or be used to parameterize components. Derived variables can be used to create v
                                                             "var": "x",
                                                           }
                     }
+                    idyllASTNode={
+                                        Object {
+                                                            "children": Array [],
+                                                            "id": 81,
+                                                            "name": "Display",
+                                                            "properties": Object {
+                                                              "var": Object {
+                                                                "type": "expression",
+                                                                "value": "x",
+                                                              },
+                                                            },
+                                                            "type": "component",
+                                                          }
+                    }
                     var="x"
 />,
                 ],
+                "idyllASTNode": Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 79,
+                          "type": "textnode",
+                          "value": "x",
+                        },
+                      ],
+                      "id": 78,
+                      "name": "equation",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 80,
+                      "type": "textnode",
+                      "value": ":
+ ",
+                    },
+                    Object {
+                      "children": Array [],
+                      "id": 81,
+                      "name": "Display",
+                      "properties": Object {
+                        "var": Object {
+                          "type": "expression",
+                          "value": "x",
+                        },
+                      },
+                      "type": "component",
+                    },
+                  ],
+                  "id": 77,
+                  "name": "p",
+                  "type": "component",
+                },
               },
               "ref": null,
               "rendered": Array [
@@ -3579,6 +17390,18 @@ or be used to parameterize components. Derived variables can be used to create v
                     "children": Array [
                       "x",
                     ],
+                    "idyllASTNode": Object {
+                      "children": Array [
+                        Object {
+                          "id": 79,
+                          "type": "textnode",
+                          "value": "x",
+                        },
+                      ],
+                      "id": 78,
+                      "name": "equation",
+                      "type": "component",
+                    },
                   },
                   "ref": null,
                   "rendered": Array [
@@ -3597,6 +17420,18 @@ or be used to parameterize components. Derived variables can be used to create v
                       "var": "x",
                     },
                     "children": undefined,
+                    "idyllASTNode": Object {
+                      "children": Array [],
+                      "id": 81,
+                      "name": "Display",
+                      "properties": Object {
+                        "var": Object {
+                          "type": "expression",
+                          "value": "x",
+                        },
+                      },
+                      "type": "component",
+                    },
                     "var": "x",
                   },
                   "ref": null,
@@ -3612,7 +17447,22 @@ or be used to parameterize components. Derived variables can be used to create v
               "nodeType": "host",
               "props": Object {
                 "children": Array [
-                  <Equation>
+                  <Equation
+                    idyllASTNode={
+                                        Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 84,
+                                                                "type": "textnode",
+                                                                "value": "x^2",
+                                                              },
+                                                            ],
+                                                            "id": 83,
+                                                            "name": "equation",
+                                                            "type": "component",
+                                                          }
+                    }
+>
                     x^2
 </Equation>,
                   ":",
@@ -3622,9 +17472,59 @@ or be used to parameterize components. Derived variables can be used to create v
                                                             "var": "xSquared",
                                                           }
                     }
+                    idyllASTNode={
+                                        Object {
+                                                            "children": Array [],
+                                                            "id": 86,
+                                                            "name": "Display",
+                                                            "properties": Object {
+                                                              "var": Object {
+                                                                "type": "expression",
+                                                                "value": "xSquared",
+                                                              },
+                                                            },
+                                                            "type": "component",
+                                                          }
+                    }
                     var="xSquared"
 />,
                 ],
+                "idyllASTNode": Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 84,
+                          "type": "textnode",
+                          "value": "x^2",
+                        },
+                      ],
+                      "id": 83,
+                      "name": "equation",
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 85,
+                      "type": "textnode",
+                      "value": ":",
+                    },
+                    Object {
+                      "children": Array [],
+                      "id": 86,
+                      "name": "Display",
+                      "properties": Object {
+                        "var": Object {
+                          "type": "expression",
+                          "value": "xSquared",
+                        },
+                      },
+                      "type": "component",
+                    },
+                  ],
+                  "id": 82,
+                  "name": "p",
+                  "type": "component",
+                },
               },
               "ref": null,
               "rendered": Array [
@@ -3636,6 +17536,18 @@ or be used to parameterize components. Derived variables can be used to create v
                     "children": Array [
                       "x^2",
                     ],
+                    "idyllASTNode": Object {
+                      "children": Array [
+                        Object {
+                          "id": 84,
+                          "type": "textnode",
+                          "value": "x^2",
+                        },
+                      ],
+                      "id": 83,
+                      "name": "equation",
+                      "type": "component",
+                    },
                   },
                   "ref": null,
                   "rendered": Array [
@@ -3653,6 +17565,18 @@ or be used to parameterize components. Derived variables can be used to create v
                       "var": "xSquared",
                     },
                     "children": undefined,
+                    "idyllASTNode": Object {
+                      "children": Array [],
+                      "id": 86,
+                      "name": "Display",
+                      "properties": Object {
+                        "var": Object {
+                          "type": "expression",
+                          "value": "xSquared",
+                        },
+                      },
+                      "type": "component",
+                    },
                     "var": "xSquared",
                   },
                   "ref": null,
@@ -3670,6 +17594,18 @@ or be used to parameterize components. Derived variables can be used to create v
                 "children": Array [
                   "Test expression, displays:",
                 ],
+                "idyllASTNode": Object {
+                  "children": Array [
+                    Object {
+                      "id": 88,
+                      "type": "textnode",
+                      "value": "Test expression, displays:",
+                    },
+                  ],
+                  "id": 87,
+                  "name": "p",
+                  "type": "component",
+                },
               },
               "ref": null,
               "rendered": Array [
@@ -3687,6 +17623,22 @@ or be used to parameterize components. Derived variables can be used to create v
                 },
                 "children": undefined,
                 "id": "varDisplay",
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 89,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "varDisplay",
+                    },
+                    "value": Object {
+                      "type": "expression",
+                      "value": "x",
+                    },
+                  },
+                  "type": "component",
+                },
                 "value": "x",
               },
               "ref": null,
@@ -3703,6 +17655,22 @@ or be used to parameterize components. Derived variables can be used to create v
                 },
                 "children": undefined,
                 "id": "derivedVarDisplay",
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 90,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "derivedVarDisplay",
+                    },
+                    "value": Object {
+                      "type": "expression",
+                      "value": "xSquared",
+                    },
+                  },
+                  "type": "component",
+                },
                 "value": "xSquared",
               },
               "ref": null,
@@ -3719,6 +17687,22 @@ or be used to parameterize components. Derived variables can be used to create v
                 },
                 "children": undefined,
                 "id": "derivedVarDisplay2",
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 91,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "derivedVarDisplay2",
+                    },
+                    "value": Object {
+                      "type": "expression",
+                      "value": "xCubed",
+                    },
+                  },
+                  "type": "component",
+                },
                 "value": "xCubed",
               },
               "ref": null,
@@ -3735,6 +17719,22 @@ or be used to parameterize components. Derived variables can be used to create v
                 },
                 "children": undefined,
                 "id": "strDisplay",
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 92,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "strDisplay",
+                    },
+                    "value": Object {
+                      "type": "expression",
+                      "value": "\\"string\\"",
+                    },
+                  },
+                  "type": "component",
+                },
                 "value": "\\"string\\"",
               },
               "ref": null,
@@ -3751,6 +17751,22 @@ or be used to parameterize components. Derived variables can be used to create v
                 },
                 "children": undefined,
                 "id": "staticObjectDisplay",
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 93,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "staticObjectDisplay",
+                    },
+                    "value": Object {
+                      "type": "expression",
+                      "value": "{ static: \\"object\\" }",
+                    },
+                  },
+                  "type": "component",
+                },
                 "value": "{ static: \\"object\\" }",
               },
               "ref": null,
@@ -3767,6 +17783,22 @@ or be used to parameterize components. Derived variables can be used to create v
                 },
                 "children": undefined,
                 "id": "dynamicObjectDisplay",
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 94,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "dynamicObjectDisplay",
+                    },
+                    "value": Object {
+                      "type": "expression",
+                      "value": "{ dynamic: x }",
+                    },
+                  },
+                  "type": "component",
+                },
                 "value": "{ dynamic: x }",
               },
               "ref": null,
@@ -3783,6 +17815,22 @@ or be used to parameterize components. Derived variables can be used to create v
                 },
                 "children": undefined,
                 "id": "dataDisplay",
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 95,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "dataDisplay",
+                    },
+                    "value": Object {
+                      "type": "expression",
+                      "value": "myData",
+                    },
+                  },
+                  "type": "component",
+                },
                 "value": "myData",
               },
               "ref": null,
@@ -3799,6 +17847,22 @@ or be used to parameterize components. Derived variables can be used to create v
                 },
                 "children": undefined,
                 "id": "bareDataDisplay",
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 96,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "bareDataDisplay",
+                    },
+                    "value": Object {
+                      "type": "variable",
+                      "value": "myData",
+                    },
+                  },
+                  "type": "component",
+                },
                 "value": "myData",
               },
               "ref": null,
@@ -3815,6 +17879,22 @@ or be used to parameterize components. Derived variables can be used to create v
                 },
                 "children": undefined,
                 "id": "bareVarDisplay",
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 97,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "bareVarDisplay",
+                    },
+                    "value": Object {
+                      "type": "variable",
+                      "value": "x",
+                    },
+                  },
+                  "type": "component",
+                },
                 "value": "x",
               },
               "ref": null,
@@ -3831,6 +17911,22 @@ or be used to parameterize components. Derived variables can be used to create v
                 },
                 "children": undefined,
                 "id": "bareDerivedDisplay",
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 98,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "bareDerivedDisplay",
+                    },
+                    "value": Object {
+                      "type": "variable",
+                      "value": "xSquared",
+                    },
+                  },
+                  "type": "component",
+                },
                 "value": "xSquared",
               },
               "ref": null,
@@ -3847,6 +17943,22 @@ or be used to parameterize components. Derived variables can be used to create v
                 },
                 "children": undefined,
                 "id": "bareDerivedDisplay2",
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 99,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "bareDerivedDisplay2",
+                    },
+                    "value": Object {
+                      "type": "variable",
+                      "value": "xCubed",
+                    },
+                  },
+                  "type": "component",
+                },
                 "value": "xCubed",
               },
               "ref": null,
@@ -3863,6 +17975,22 @@ or be used to parameterize components. Derived variables can be used to create v
                 },
                 "children": undefined,
                 "id": "objectVarDisplay",
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 100,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "objectVarDisplay",
+                    },
+                    "value": Object {
+                      "type": "expression",
+                      "value": " objectVar ",
+                    },
+                  },
+                  "type": "component",
+                },
                 "value": " objectVar ",
               },
               "ref": null,
@@ -3879,6 +18007,22 @@ or be used to parameterize components. Derived variables can be used to create v
                 },
                 "children": undefined,
                 "id": "bareObjectVarDisplay",
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 101,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "bareObjectVarDisplay",
+                    },
+                    "value": Object {
+                      "type": "variable",
+                      "value": "objectVar",
+                    },
+                  },
+                  "type": "component",
+                },
                 "value": "objectVar",
               },
               "ref": null,
@@ -3895,6 +18039,22 @@ or be used to parameterize components. Derived variables can be used to create v
                 },
                 "children": undefined,
                 "id": "arrayVarDisplay",
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 102,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "arrayVarDisplay",
+                    },
+                    "value": Object {
+                      "type": "expression",
+                      "value": " arrayVar ",
+                    },
+                  },
+                  "type": "component",
+                },
                 "value": " arrayVar ",
               },
               "ref": null,
@@ -3911,6 +18071,22 @@ or be used to parameterize components. Derived variables can be used to create v
                 },
                 "children": undefined,
                 "id": "bareArrayVarDisplay",
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 103,
+                  "name": "Display",
+                  "properties": Object {
+                    "id": Object {
+                      "type": "value",
+                      "value": "bareArrayVarDisplay",
+                    },
+                    "value": Object {
+                      "type": "variable",
+                      "value": "arrayVar",
+                    },
+                  },
+                  "type": "component",
+                },
                 "value": "arrayVar",
               },
               "ref": null,
@@ -3923,6 +18099,12 @@ or be used to parameterize components. Derived variables can be used to create v
               "nodeType": "host",
               "props": Object {
                 "children": undefined,
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 104,
+                  "name": "br",
+                  "type": "component",
+                },
               },
               "ref": null,
               "rendered": null,
@@ -3936,6 +18118,18 @@ or be used to parameterize components. Derived variables can be used to create v
                 "children": Array [
                   "Here is an example of how you could use a variable to control the frequency of a sine wave:",
                 ],
+                "idyllASTNode": Object {
+                  "children": Array [
+                    Object {
+                      "id": 106,
+                      "type": "textnode",
+                      "value": "Here is an example of how you could use a variable to control the frequency of a sine wave:",
+                    },
+                  ],
+                  "id": 105,
+                  "name": "p",
+                  "type": "component",
+                },
               },
               "ref": null,
               "rendered": Array [
@@ -3956,6 +18150,26 @@ or be used to parameterize components. Derived variables can be used to create v
                 "domain": "[0, 2 * Math.PI]",
                 "domainPadding": 0,
                 "equation": "(t) => Math.sin(t * frequency)",
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 107,
+                  "name": "Chart",
+                  "properties": Object {
+                    "domain": Object {
+                      "type": "expression",
+                      "value": "[0, 2 * Math.PI]",
+                    },
+                    "equation": Object {
+                      "type": "expression",
+                      "value": "(t) => Math.sin(t * frequency)",
+                    },
+                    "samplePoints": Object {
+                      "type": "value",
+                      "value": 1000,
+                    },
+                  },
+                  "type": "component",
+                },
                 "range": Array [
                   -1,
                   1,
@@ -3979,6 +18193,30 @@ or be used to parameterize components. Derived variables can be used to create v
                   "value": "frequency",
                 },
                 "children": undefined,
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 108,
+                  "name": "Range",
+                  "properties": Object {
+                    "max": Object {
+                      "type": "expression",
+                      "value": "2 * Math.PI",
+                    },
+                    "min": Object {
+                      "type": "value",
+                      "value": 0.5,
+                    },
+                    "step": Object {
+                      "type": "value",
+                      "value": 0.0001,
+                    },
+                    "value": Object {
+                      "type": "variable",
+                      "value": "frequency",
+                    },
+                  },
+                  "type": "component",
+                },
                 "max": "2 * Math.PI",
                 "min": 0.5,
                 "step": 0.0001,
@@ -4001,11 +18239,58 @@ or be used to parameterize components. Derived variables can be used to create v
                                                           }
                     }
                     id="lateVarDisplay"
+                    idyllASTNode={
+                                        Object {
+                                                            "children": Array [],
+                                                            "id": 110,
+                                                            "name": "Display",
+                                                            "properties": Object {
+                                                              "id": Object {
+                                                                "type": "value",
+                                                                "value": "lateVarDisplay",
+                                                              },
+                                                              "value": Object {
+                                                                "type": "variable",
+                                                                "value": "lateVar",
+                                                              },
+                                                            },
+                                                            "type": "component",
+                                                          }
+                    }
                     value="lateVar"
 />,
                   "
 Late Var Range:",
                 ],
+                "idyllASTNode": Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [],
+                      "id": 110,
+                      "name": "Display",
+                      "properties": Object {
+                        "id": Object {
+                          "type": "value",
+                          "value": "lateVarDisplay",
+                        },
+                        "value": Object {
+                          "type": "variable",
+                          "value": "lateVar",
+                        },
+                      },
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 111,
+                      "type": "textnode",
+                      "value": "
+Late Var Range:",
+                    },
+                  ],
+                  "id": 109,
+                  "name": "p",
+                  "type": "component",
+                },
               },
               "ref": null,
               "rendered": Array [
@@ -4019,6 +18304,22 @@ Late Var Range:",
                     },
                     "children": undefined,
                     "id": "lateVarDisplay",
+                    "idyllASTNode": Object {
+                      "children": Array [],
+                      "id": 110,
+                      "name": "Display",
+                      "properties": Object {
+                        "id": Object {
+                          "type": "value",
+                          "value": "lateVarDisplay",
+                        },
+                        "value": Object {
+                          "type": "variable",
+                          "value": "lateVar",
+                        },
+                      },
+                      "type": "component",
+                    },
                     "value": "lateVar",
                   },
                   "ref": null,
@@ -4039,6 +18340,26 @@ Late Var Range:",
                   "value": "lateVar",
                 },
                 "children": undefined,
+                "idyllASTNode": Object {
+                  "children": Array [],
+                  "id": 112,
+                  "name": "Range",
+                  "properties": Object {
+                    "max": Object {
+                      "type": "value",
+                      "value": 100,
+                    },
+                    "min": Object {
+                      "type": "value",
+                      "value": 2,
+                    },
+                    "value": Object {
+                      "type": "variable",
+                      "value": "lateVar",
+                    },
+                  },
+                  "type": "component",
+                },
                 "max": 100,
                 "min": 2,
                 "step": 1,
@@ -4057,17 +18378,115 @@ Late Var Range:",
                   "Read more about Idyll at ",
                   <a
                     href="https://idyll-lang.github.io/"
+                    idyllASTNode={
+                                        Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 116,
+                                                                "type": "textnode",
+                                                                "value": "https://idyll-lang.github.io/",
+                                                              },
+                                                            ],
+                                                            "id": 115,
+                                                            "name": "a",
+                                                            "properties": Object {
+                                                              "href": Object {
+                                                                "type": "value",
+                                                                "value": "https://idyll-lang.github.io/",
+                                                              },
+                                                            },
+                                                            "type": "component",
+                                                          }
+                    }
 >
                     https://idyll-lang.github.io/
 </a>,
                   ", and come say “Hi!” in our ",
                   <a
                     href="https://gitter.im/idyll-lang/Lobby"
+                    idyllASTNode={
+                                        Object {
+                                                            "children": Array [
+                                                              Object {
+                                                                "id": 119,
+                                                                "type": "textnode",
+                                                                "value": "chatroom on gitter",
+                                                              },
+                                                            ],
+                                                            "id": 118,
+                                                            "name": "a",
+                                                            "properties": Object {
+                                                              "href": Object {
+                                                                "type": "value",
+                                                                "value": "https://gitter.im/idyll-lang/Lobby",
+                                                              },
+                                                            },
+                                                            "type": "component",
+                                                          }
+                    }
 >
                     chatroom on gitter
 </a>,
                   ".",
                 ],
+                "idyllASTNode": Object {
+                  "children": Array [
+                    Object {
+                      "id": 114,
+                      "type": "textnode",
+                      "value": "Read more about Idyll at ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 116,
+                          "type": "textnode",
+                          "value": "https://idyll-lang.github.io/",
+                        },
+                      ],
+                      "id": 115,
+                      "name": "a",
+                      "properties": Object {
+                        "href": Object {
+                          "type": "value",
+                          "value": "https://idyll-lang.github.io/",
+                        },
+                      },
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 117,
+                      "type": "textnode",
+                      "value": ", and come say “Hi!” in our ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": 119,
+                          "type": "textnode",
+                          "value": "chatroom on gitter",
+                        },
+                      ],
+                      "id": 118,
+                      "name": "a",
+                      "properties": Object {
+                        "href": Object {
+                          "type": "value",
+                          "value": "https://gitter.im/idyll-lang/Lobby",
+                        },
+                      },
+                      "type": "component",
+                    },
+                    Object {
+                      "id": 120,
+                      "type": "textnode",
+                      "value": ".",
+                    },
+                  ],
+                  "id": 113,
+                  "name": "p",
+                  "type": "component",
+                },
               },
               "ref": null,
               "rendered": Array [
@@ -4081,6 +18500,24 @@ Late Var Range:",
                       "https://idyll-lang.github.io/",
                     ],
                     "href": "https://idyll-lang.github.io/",
+                    "idyllASTNode": Object {
+                      "children": Array [
+                        Object {
+                          "id": 116,
+                          "type": "textnode",
+                          "value": "https://idyll-lang.github.io/",
+                        },
+                      ],
+                      "id": 115,
+                      "name": "a",
+                      "properties": Object {
+                        "href": Object {
+                          "type": "value",
+                          "value": "https://idyll-lang.github.io/",
+                        },
+                      },
+                      "type": "component",
+                    },
                   },
                   "ref": null,
                   "rendered": Array [
@@ -4098,6 +18535,24 @@ Late Var Range:",
                       "chatroom on gitter",
                     ],
                     "href": "https://gitter.im/idyll-lang/Lobby",
+                    "idyllASTNode": Object {
+                      "children": Array [
+                        Object {
+                          "id": 119,
+                          "type": "textnode",
+                          "value": "chatroom on gitter",
+                        },
+                      ],
+                      "id": 118,
+                      "name": "a",
+                      "properties": Object {
+                        "href": Object {
+                          "type": "value",
+                          "value": "https://gitter.im/idyll-lang/Lobby",
+                        },
+                      },
+                      "type": "component",
+                    },
                   },
                   "ref": null,
                   "rendered": Array [

--- a/packages/idyll-document/test/fixtures/schema.json
+++ b/packages/idyll-document/test/fixtures/schema.json
@@ -1,9 +1,947 @@
 [
   {
     "component": "TextContainer",
+    "idyllASTNode": {
+      "id": 10,
+      "type": "component",
+      "name": "TextContainer",
+      "children": [
+        {
+          "id": 11,
+          "type": "component",
+          "name": "h1",
+          "children": [
+            {
+              "id": 12,
+              "type": "textnode",
+              "value": "Welcome to Idyll"
+            }
+          ]
+        },
+        {
+          "id": 13,
+          "type": "component",
+          "name": "h3",
+          "children": [
+            {
+              "id": 14,
+              "type": "textnode",
+              "value": "Idyll is a language for creating interactive documents on the web."
+            }
+          ]
+        },
+        {
+          "id": 15,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 16,
+              "type": "textnode",
+              "value": "This document is being rendered from "
+            },
+            {
+              "id": 17,
+              "type": "component",
+              "name": "strong",
+              "children": [
+                {
+                  "id": 18,
+                  "type": "textnode",
+                  "value": "Idyll markup"
+                }
+              ]
+            },
+            {
+              "id": 19,
+              "type": "textnode",
+              "value": ". If you’ve used "
+            },
+            {
+              "id": 20,
+              "type": "component",
+              "name": "a",
+              "properties": {
+                "href": {
+                  "type": "value",
+                  "value": "https://daringfireball.net/projects/markdown/"
+                }
+              },
+              "children": [
+                {
+                  "id": 21,
+                  "type": "textnode",
+                  "value": "markdown"
+                }
+              ]
+            },
+            {
+              "id": 22,
+              "type": "textnode",
+              "value": ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update."
+            }
+          ]
+        },
+        {
+          "id": 23,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 24,
+              "type": "textnode",
+              "value": "To make things a little more interesting you can add JavaScript components to your text.\nFor example, a "
+            },
+            {
+              "id": 25,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 26,
+                  "type": "textnode",
+                  "value": "[Chart /]"
+                }
+              ]
+            },
+            {
+              "id": 27,
+              "type": "textnode",
+              "value": " component can be used to render a simple visualization:"
+            }
+          ]
+        },
+        {
+          "id": 28,
+          "type": "component",
+          "name": "Chart",
+          "properties": {
+            "type": {
+              "type": "value",
+              "value": "scatter"
+            }
+          },
+          "children": []
+        },
+        {
+          "id": 29,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 30,
+              "type": "textnode",
+              "value": "Try changing the chart’s type from "
+            },
+            {
+              "id": 31,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 32,
+                  "type": "textnode",
+                  "value": "scatter"
+                }
+              ]
+            },
+            {
+              "id": 33,
+              "type": "textnode",
+              "value": " to "
+            },
+            {
+              "id": 34,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 35,
+                  "type": "textnode",
+                  "value": "line"
+                }
+              ]
+            },
+            {
+              "id": 36,
+              "type": "textnode",
+              "value": ", "
+            },
+            {
+              "id": 37,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 38,
+                  "type": "textnode",
+                  "value": "area"
+                }
+              ]
+            },
+            {
+              "id": 39,
+              "type": "textnode",
+              "value": ", or "
+            },
+            {
+              "id": 40,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 41,
+                  "type": "textnode",
+                  "value": "pie"
+                }
+              ]
+            },
+            {
+              "id": 42,
+              "type": "textnode",
+              "value": "."
+            }
+          ]
+        },
+        {
+          "id": 43,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 44,
+              "type": "textnode",
+              "value": "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions ("
+            },
+            {
+              "id": 45,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 46,
+                  "type": "textnode",
+                  "value": "`2 * Math.PI`"
+                }
+              ]
+            },
+            {
+              "id": 47,
+              "type": "textnode",
+              "value": ")."
+            }
+          ]
+        },
+        {
+          "id": 48,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 49,
+              "type": "textnode",
+              "value": "There are a number of components available — see "
+            },
+            {
+              "id": 50,
+              "type": "component",
+              "name": "a",
+              "properties": {
+                "href": {
+                  "type": "value",
+                  "value": "https://idyll-lang.github.io/components-built-in"
+                }
+              },
+              "children": [
+                {
+                  "id": 51,
+                  "type": "textnode",
+                  "value": "Idyll’s documentation"
+                }
+              ]
+            },
+            {
+              "id": 52,
+              "type": "textnode",
+              "value": " for a full list — Additional components can be installed via "
+            },
+            {
+              "id": 53,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 54,
+                  "type": "textnode",
+                  "value": "npm"
+                }
+              ]
+            },
+            {
+              "id": 55,
+              "type": "textnode",
+              "value": " (any React component should work), and if you are comfortable with JavaScript you can write "
+            },
+            {
+              "id": 56,
+              "type": "component",
+              "name": "a",
+              "properties": {
+                "href": {
+                  "type": "value",
+                  "value": "https://idyll-lang.github.io/components-custom"
+                }
+              },
+              "children": [
+                {
+                  "id": 57,
+                  "type": "textnode",
+                  "value": "custom components"
+                }
+              ]
+            },
+            {
+              "id": 58,
+              "type": "textnode",
+              "value": " as well."
+            }
+          ]
+        },
+        {
+          "id": 59,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 60,
+              "type": "textnode",
+              "value": "Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader."
+            }
+          ]
+        },
+        {
+          "id": 61,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 62,
+              "type": "textnode",
+              "value": "Instantiating a variable is similar to instantiating a component:"
+            }
+          ]
+        },
+        {
+          "id": 63,
+          "type": "component",
+          "name": "code",
+          "children": [
+            {
+              "id": 64,
+              "type": "textnode",
+              "value": "[var name:\"x\" value:1 /]"
+            }
+          ]
+        },
+        {
+          "id": 65,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 66,
+              "type": "textnode",
+              "value": "Once you’ve created a variable, it can be displayed inline with text\n(x = "
+            },
+            {
+              "id": 67,
+              "type": "component",
+              "name": "Display",
+              "properties": {
+                "var": {
+                  "type": "variable",
+                  "value": "x"
+                }
+              },
+              "children": []
+            },
+            {
+              "id": 68,
+              "type": "textnode",
+              "value": "),\nor be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:"
+            }
+          ]
+        },
+        {
+          "id": 69,
+          "type": "component",
+          "name": "code",
+          "children": [
+            {
+              "id": 70,
+              "type": "textnode",
+              "value": "[derived name:\"xSquared\" value:`x * x` /]"
+            }
+          ]
+        },
+        {
+          "id": 71,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 72,
+              "type": "textnode",
+              "value": "Here I bind the value of "
+            },
+            {
+              "id": 73,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 74,
+                  "type": "textnode",
+                  "value": "x"
+                }
+              ]
+            },
+            {
+              "id": 75,
+              "type": "textnode",
+              "value": " to a range slider. Move the slider and watch the variables update."
+            }
+          ]
+        },
+        {
+          "id": 76,
+          "type": "component",
+          "name": "Range",
+          "properties": {
+            "value": {
+              "type": "variable",
+              "value": "x"
+            },
+            "min": {
+              "type": "value",
+              "value": 0
+            },
+            "max": {
+              "type": "value",
+              "value": 100
+            }
+          },
+          "children": []
+        },
+        {
+          "id": 77,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 78,
+              "type": "component",
+              "name": "equation",
+              "children": [
+                {
+                  "id": 79,
+                  "type": "textnode",
+                  "value": "x"
+                }
+              ]
+            },
+            {
+              "id": 80,
+              "type": "textnode",
+              "value": ":\n "
+            },
+            {
+              "id": 81,
+              "type": "component",
+              "name": "Display",
+              "properties": {
+                "var": {
+                  "type": "expression",
+                  "value": "x"
+                }
+              },
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": 82,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 83,
+              "type": "component",
+              "name": "equation",
+              "children": [
+                {
+                  "id": 84,
+                  "type": "textnode",
+                  "value": "x^2"
+                }
+              ]
+            },
+            {
+              "id": 85,
+              "type": "textnode",
+              "value": ":"
+            },
+            {
+              "id": 86,
+              "type": "component",
+              "name": "Display",
+              "properties": {
+                "var": {
+                  "type": "expression",
+                  "value": "xSquared"
+                }
+              },
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": 87,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 88,
+              "type": "textnode",
+              "value": "Test expression, displays:"
+            }
+          ]
+        },
+        {
+          "id": 89,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "varDisplay"
+            },
+            "value": {
+              "type": "expression",
+              "value": "x"
+            }
+          },
+          "children": []
+        },
+        {
+          "id": 90,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "derivedVarDisplay"
+            },
+            "value": {
+              "type": "expression",
+              "value": "xSquared"
+            }
+          },
+          "children": []
+        },
+        {
+          "id": 91,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "derivedVarDisplay2"
+            },
+            "value": {
+              "type": "expression",
+              "value": "xCubed"
+            }
+          },
+          "children": []
+        },
+        {
+          "id": 92,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "strDisplay"
+            },
+            "value": {
+              "type": "expression",
+              "value": "\"string\""
+            }
+          },
+          "children": []
+        },
+        {
+          "id": 93,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "staticObjectDisplay"
+            },
+            "value": {
+              "type": "expression",
+              "value": "{ static: \"object\" }"
+            }
+          },
+          "children": []
+        },
+        {
+          "id": 94,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "dynamicObjectDisplay"
+            },
+            "value": {
+              "type": "expression",
+              "value": "{ dynamic: x }"
+            }
+          },
+          "children": []
+        },
+        {
+          "id": 95,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "dataDisplay"
+            },
+            "value": {
+              "type": "expression",
+              "value": "myData"
+            }
+          },
+          "children": []
+        },
+        {
+          "id": 96,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "bareDataDisplay"
+            },
+            "value": {
+              "type": "variable",
+              "value": "myData"
+            }
+          },
+          "children": []
+        },
+        {
+          "id": 97,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "bareVarDisplay"
+            },
+            "value": {
+              "type": "variable",
+              "value": "x"
+            }
+          },
+          "children": []
+        },
+        {
+          "id": 98,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "bareDerivedDisplay"
+            },
+            "value": {
+              "type": "variable",
+              "value": "xSquared"
+            }
+          },
+          "children": []
+        },
+        {
+          "id": 99,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "bareDerivedDisplay2"
+            },
+            "value": {
+              "type": "variable",
+              "value": "xCubed"
+            }
+          },
+          "children": []
+        },
+        {
+          "id": 100,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "objectVarDisplay"
+            },
+            "value": {
+              "type": "expression",
+              "value": " objectVar "
+            }
+          },
+          "children": []
+        },
+        {
+          "id": 101,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "bareObjectVarDisplay"
+            },
+            "value": {
+              "type": "variable",
+              "value": "objectVar"
+            }
+          },
+          "children": []
+        },
+        {
+          "id": 102,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "arrayVarDisplay"
+            },
+            "value": {
+              "type": "expression",
+              "value": " arrayVar "
+            }
+          },
+          "children": []
+        },
+        {
+          "id": 103,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "bareArrayVarDisplay"
+            },
+            "value": {
+              "type": "variable",
+              "value": "arrayVar"
+            }
+          },
+          "children": []
+        },
+        {
+          "id": 104,
+          "type": "component",
+          "name": "br",
+          "children": []
+        },
+        {
+          "id": 105,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 106,
+              "type": "textnode",
+              "value": "Here is an example of how you could use a variable to control the frequency of a sine wave:"
+            }
+          ]
+        },
+        {
+          "id": 107,
+          "type": "component",
+          "name": "Chart",
+          "properties": {
+            "equation": {
+              "type": "expression",
+              "value": "(t) => Math.sin(t * frequency)"
+            },
+            "domain": {
+              "type": "expression",
+              "value": "[0, 2 * Math.PI]"
+            },
+            "samplePoints": {
+              "type": "value",
+              "value": 1000
+            }
+          },
+          "children": []
+        },
+        {
+          "id": 108,
+          "type": "component",
+          "name": "Range",
+          "properties": {
+            "value": {
+              "type": "variable",
+              "value": "frequency"
+            },
+            "min": {
+              "type": "value",
+              "value": 0.5
+            },
+            "max": {
+              "type": "expression",
+              "value": "2 * Math.PI"
+            },
+            "step": {
+              "type": "value",
+              "value": 0.0001
+            }
+          },
+          "children": []
+        },
+        {
+          "id": 109,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 110,
+              "type": "component",
+              "name": "Display",
+              "properties": {
+                "id": {
+                  "type": "value",
+                  "value": "lateVarDisplay"
+                },
+                "value": {
+                  "type": "variable",
+                  "value": "lateVar"
+                }
+              },
+              "children": []
+            },
+            {
+              "id": 111,
+              "type": "textnode",
+              "value": "\nLate Var Range:"
+            }
+          ]
+        },
+        {
+          "id": 112,
+          "type": "component",
+          "name": "Range",
+          "properties": {
+            "value": {
+              "type": "variable",
+              "value": "lateVar"
+            },
+            "min": {
+              "type": "value",
+              "value": 2
+            },
+            "max": {
+              "type": "value",
+              "value": 100
+            }
+          },
+          "children": []
+        },
+        {
+          "id": 113,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 114,
+              "type": "textnode",
+              "value": "Read more about Idyll at "
+            },
+            {
+              "id": 115,
+              "type": "component",
+              "name": "a",
+              "properties": {
+                "href": {
+                  "type": "value",
+                  "value": "https://idyll-lang.github.io/"
+                }
+              },
+              "children": [
+                {
+                  "id": 116,
+                  "type": "textnode",
+                  "value": "https://idyll-lang.github.io/"
+                }
+              ]
+            },
+            {
+              "id": 117,
+              "type": "textnode",
+              "value": ", and come say “Hi!” in our "
+            },
+            {
+              "id": 118,
+              "type": "component",
+              "name": "a",
+              "properties": {
+                "href": {
+                  "type": "value",
+                  "value": "https://gitter.im/idyll-lang/Lobby"
+                }
+              },
+              "children": [
+                {
+                  "id": 119,
+                  "type": "textnode",
+                  "value": "chatroom on gitter"
+                }
+              ]
+            },
+            {
+              "id": 120,
+              "type": "textnode",
+              "value": "."
+            }
+          ]
+        }
+      ]
+    },
     "children": [
       {
         "component": "h1",
+        "idyllASTNode": {
+          "id": 11,
+          "type": "component",
+          "name": "h1",
+          "children": [
+            {
+              "id": 12,
+              "type": "textnode",
+              "value": "Welcome to Idyll"
+            }
+          ]
+        },
         "children": [
           {
             "id": 12,
@@ -14,6 +952,18 @@
       },
       {
         "component": "h3",
+        "idyllASTNode": {
+          "id": 13,
+          "type": "component",
+          "name": "h3",
+          "children": [
+            {
+              "id": 14,
+              "type": "textnode",
+              "value": "Idyll is a language for creating interactive documents on the web."
+            }
+          ]
+        },
         "children": [
           {
             "id": 14,
@@ -24,6 +974,58 @@
       },
       {
         "component": "p",
+        "idyllASTNode": {
+          "id": 15,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 16,
+              "type": "textnode",
+              "value": "This document is being rendered from "
+            },
+            {
+              "id": 17,
+              "type": "component",
+              "name": "strong",
+              "children": [
+                {
+                  "id": 18,
+                  "type": "textnode",
+                  "value": "Idyll markup"
+                }
+              ]
+            },
+            {
+              "id": 19,
+              "type": "textnode",
+              "value": ". If you’ve used "
+            },
+            {
+              "id": 20,
+              "type": "component",
+              "name": "a",
+              "properties": {
+                "href": {
+                  "type": "value",
+                  "value": "https://daringfireball.net/projects/markdown/"
+                }
+              },
+              "children": [
+                {
+                  "id": 21,
+                  "type": "textnode",
+                  "value": "markdown"
+                }
+              ]
+            },
+            {
+              "id": 22,
+              "type": "textnode",
+              "value": ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update."
+            }
+          ]
+        },
         "children": [
           {
             "id": 16,
@@ -32,6 +1034,18 @@
           },
           {
             "component": "strong",
+            "idyllASTNode": {
+              "id": 17,
+              "type": "component",
+              "name": "strong",
+              "children": [
+                {
+                  "id": 18,
+                  "type": "textnode",
+                  "value": "Idyll markup"
+                }
+              ]
+            },
             "children": [
               {
                 "id": 18,
@@ -47,6 +1061,24 @@
           },
           {
             "component": "a",
+            "idyllASTNode": {
+              "id": 20,
+              "type": "component",
+              "name": "a",
+              "properties": {
+                "href": {
+                  "type": "value",
+                  "value": "https://daringfireball.net/projects/markdown/"
+                }
+              },
+              "children": [
+                {
+                  "id": 21,
+                  "type": "textnode",
+                  "value": "markdown"
+                }
+              ]
+            },
             "href": "https://daringfireball.net/projects/markdown/",
             "children": [
               {
@@ -65,6 +1097,35 @@
       },
       {
         "component": "p",
+        "idyllASTNode": {
+          "id": 23,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 24,
+              "type": "textnode",
+              "value": "To make things a little more interesting you can add JavaScript components to your text.\nFor example, a "
+            },
+            {
+              "id": 25,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 26,
+                  "type": "textnode",
+                  "value": "[Chart /]"
+                }
+              ]
+            },
+            {
+              "id": 27,
+              "type": "textnode",
+              "value": " component can be used to render a simple visualization:"
+            }
+          ]
+        },
         "children": [
           {
             "id": 24,
@@ -73,6 +1134,18 @@
           },
           {
             "component": "code",
+            "idyllASTNode": {
+              "id": 25,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 26,
+                  "type": "textnode",
+                  "value": "[Chart /]"
+                }
+              ]
+            },
             "children": [
               {
                 "id": 26,
@@ -90,11 +1163,103 @@
       },
       {
         "component": "Chart",
+        "idyllASTNode": {
+          "id": 28,
+          "type": "component",
+          "name": "Chart",
+          "properties": {
+            "type": {
+              "type": "value",
+              "value": "scatter"
+            }
+          },
+          "children": []
+        },
         "type": "scatter",
         "children": []
       },
       {
         "component": "p",
+        "idyllASTNode": {
+          "id": 29,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 30,
+              "type": "textnode",
+              "value": "Try changing the chart’s type from "
+            },
+            {
+              "id": 31,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 32,
+                  "type": "textnode",
+                  "value": "scatter"
+                }
+              ]
+            },
+            {
+              "id": 33,
+              "type": "textnode",
+              "value": " to "
+            },
+            {
+              "id": 34,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 35,
+                  "type": "textnode",
+                  "value": "line"
+                }
+              ]
+            },
+            {
+              "id": 36,
+              "type": "textnode",
+              "value": ", "
+            },
+            {
+              "id": 37,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 38,
+                  "type": "textnode",
+                  "value": "area"
+                }
+              ]
+            },
+            {
+              "id": 39,
+              "type": "textnode",
+              "value": ", or "
+            },
+            {
+              "id": 40,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 41,
+                  "type": "textnode",
+                  "value": "pie"
+                }
+              ]
+            },
+            {
+              "id": 42,
+              "type": "textnode",
+              "value": "."
+            }
+          ]
+        },
         "children": [
           {
             "id": 30,
@@ -103,6 +1268,18 @@
           },
           {
             "component": "code",
+            "idyllASTNode": {
+              "id": 31,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 32,
+                  "type": "textnode",
+                  "value": "scatter"
+                }
+              ]
+            },
             "children": [
               {
                 "id": 32,
@@ -118,6 +1295,18 @@
           },
           {
             "component": "code",
+            "idyllASTNode": {
+              "id": 34,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 35,
+                  "type": "textnode",
+                  "value": "line"
+                }
+              ]
+            },
             "children": [
               {
                 "id": 35,
@@ -133,6 +1322,18 @@
           },
           {
             "component": "code",
+            "idyllASTNode": {
+              "id": 37,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 38,
+                  "type": "textnode",
+                  "value": "area"
+                }
+              ]
+            },
             "children": [
               {
                 "id": 38,
@@ -148,6 +1349,18 @@
           },
           {
             "component": "code",
+            "idyllASTNode": {
+              "id": 40,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 41,
+                  "type": "textnode",
+                  "value": "pie"
+                }
+              ]
+            },
             "children": [
               {
                 "id": 41,
@@ -165,6 +1378,35 @@
       },
       {
         "component": "p",
+        "idyllASTNode": {
+          "id": 43,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 44,
+              "type": "textnode",
+              "value": "A component’s properties can be strings (“I’m a string!”), numbers (1.569), or evaluated JavaScript expressions ("
+            },
+            {
+              "id": 45,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 46,
+                  "type": "textnode",
+                  "value": "`2 * Math.PI`"
+                }
+              ]
+            },
+            {
+              "id": 47,
+              "type": "textnode",
+              "value": ")."
+            }
+          ]
+        },
         "children": [
           {
             "id": 44,
@@ -173,6 +1415,18 @@
           },
           {
             "component": "code",
+            "idyllASTNode": {
+              "id": 45,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 46,
+                  "type": "textnode",
+                  "value": "`2 * Math.PI`"
+                }
+              ]
+            },
             "children": [
               {
                 "id": 46,
@@ -190,6 +1444,81 @@
       },
       {
         "component": "p",
+        "idyllASTNode": {
+          "id": 48,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 49,
+              "type": "textnode",
+              "value": "There are a number of components available — see "
+            },
+            {
+              "id": 50,
+              "type": "component",
+              "name": "a",
+              "properties": {
+                "href": {
+                  "type": "value",
+                  "value": "https://idyll-lang.github.io/components-built-in"
+                }
+              },
+              "children": [
+                {
+                  "id": 51,
+                  "type": "textnode",
+                  "value": "Idyll’s documentation"
+                }
+              ]
+            },
+            {
+              "id": 52,
+              "type": "textnode",
+              "value": " for a full list — Additional components can be installed via "
+            },
+            {
+              "id": 53,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 54,
+                  "type": "textnode",
+                  "value": "npm"
+                }
+              ]
+            },
+            {
+              "id": 55,
+              "type": "textnode",
+              "value": " (any React component should work), and if you are comfortable with JavaScript you can write "
+            },
+            {
+              "id": 56,
+              "type": "component",
+              "name": "a",
+              "properties": {
+                "href": {
+                  "type": "value",
+                  "value": "https://idyll-lang.github.io/components-custom"
+                }
+              },
+              "children": [
+                {
+                  "id": 57,
+                  "type": "textnode",
+                  "value": "custom components"
+                }
+              ]
+            },
+            {
+              "id": 58,
+              "type": "textnode",
+              "value": " as well."
+            }
+          ]
+        },
         "children": [
           {
             "id": 49,
@@ -198,6 +1527,24 @@
           },
           {
             "component": "a",
+            "idyllASTNode": {
+              "id": 50,
+              "type": "component",
+              "name": "a",
+              "properties": {
+                "href": {
+                  "type": "value",
+                  "value": "https://idyll-lang.github.io/components-built-in"
+                }
+              },
+              "children": [
+                {
+                  "id": 51,
+                  "type": "textnode",
+                  "value": "Idyll’s documentation"
+                }
+              ]
+            },
             "href": "https://idyll-lang.github.io/components-built-in",
             "children": [
               {
@@ -214,6 +1561,18 @@
           },
           {
             "component": "code",
+            "idyllASTNode": {
+              "id": 53,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 54,
+                  "type": "textnode",
+                  "value": "npm"
+                }
+              ]
+            },
             "children": [
               {
                 "id": 54,
@@ -229,6 +1588,24 @@
           },
           {
             "component": "a",
+            "idyllASTNode": {
+              "id": 56,
+              "type": "component",
+              "name": "a",
+              "properties": {
+                "href": {
+                  "type": "value",
+                  "value": "https://idyll-lang.github.io/components-custom"
+                }
+              },
+              "children": [
+                {
+                  "id": 57,
+                  "type": "textnode",
+                  "value": "custom components"
+                }
+              ]
+            },
             "href": "https://idyll-lang.github.io/components-custom",
             "children": [
               {
@@ -247,6 +1624,18 @@
       },
       {
         "component": "p",
+        "idyllASTNode": {
+          "id": 59,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 60,
+              "type": "textnode",
+              "value": "Idyll also provides a reactive variable system that can be used to dynamically update the text based on input from a reader."
+            }
+          ]
+        },
         "children": [
           {
             "id": 60,
@@ -257,6 +1646,18 @@
       },
       {
         "component": "p",
+        "idyllASTNode": {
+          "id": 61,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 62,
+              "type": "textnode",
+              "value": "Instantiating a variable is similar to instantiating a component:"
+            }
+          ]
+        },
         "children": [
           {
             "id": 62,
@@ -267,6 +1668,18 @@
       },
       {
         "component": "code",
+        "idyllASTNode": {
+          "id": 63,
+          "type": "component",
+          "name": "code",
+          "children": [
+            {
+              "id": 64,
+              "type": "textnode",
+              "value": "[var name:\"x\" value:1 /]"
+            }
+          ]
+        },
         "children": [
           {
             "id": 64,
@@ -277,6 +1690,35 @@
       },
       {
         "component": "p",
+        "idyllASTNode": {
+          "id": 65,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 66,
+              "type": "textnode",
+              "value": "Once you’ve created a variable, it can be displayed inline with text\n(x = "
+            },
+            {
+              "id": 67,
+              "type": "component",
+              "name": "Display",
+              "properties": {
+                "var": {
+                  "type": "variable",
+                  "value": "x"
+                }
+              },
+              "children": []
+            },
+            {
+              "id": 68,
+              "type": "textnode",
+              "value": "),\nor be used to parameterize components. Derived variables can be used to create values that depend on other variables, similar to a formula in Excel:"
+            }
+          ]
+        },
         "children": [
           {
             "id": 66,
@@ -285,6 +1727,18 @@
           },
           {
             "component": "Display",
+            "idyllASTNode": {
+              "id": 67,
+              "type": "component",
+              "name": "Display",
+              "properties": {
+                "var": {
+                  "type": "variable",
+                  "value": "x"
+                }
+              },
+              "children": []
+            },
             "__vars__": {
               "var": "x"
             },
@@ -300,6 +1754,18 @@
       },
       {
         "component": "code",
+        "idyllASTNode": {
+          "id": 69,
+          "type": "component",
+          "name": "code",
+          "children": [
+            {
+              "id": 70,
+              "type": "textnode",
+              "value": "[derived name:\"xSquared\" value:`x * x` /]"
+            }
+          ]
+        },
         "children": [
           {
             "id": 70,
@@ -310,6 +1776,35 @@
       },
       {
         "component": "p",
+        "idyllASTNode": {
+          "id": 71,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 72,
+              "type": "textnode",
+              "value": "Here I bind the value of "
+            },
+            {
+              "id": 73,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 74,
+                  "type": "textnode",
+                  "value": "x"
+                }
+              ]
+            },
+            {
+              "id": 75,
+              "type": "textnode",
+              "value": " to a range slider. Move the slider and watch the variables update."
+            }
+          ]
+        },
         "children": [
           {
             "id": 72,
@@ -318,6 +1813,18 @@
           },
           {
             "component": "code",
+            "idyllASTNode": {
+              "id": 73,
+              "type": "component",
+              "name": "code",
+              "children": [
+                {
+                  "id": 74,
+                  "type": "textnode",
+                  "value": "x"
+                }
+              ]
+            },
             "children": [
               {
                 "id": 74,
@@ -335,6 +1842,26 @@
       },
       {
         "component": "Range",
+        "idyllASTNode": {
+          "id": 76,
+          "type": "component",
+          "name": "Range",
+          "properties": {
+            "value": {
+              "type": "variable",
+              "value": "x"
+            },
+            "min": {
+              "type": "value",
+              "value": 0
+            },
+            "max": {
+              "type": "value",
+              "value": 100
+            }
+          },
+          "children": []
+        },
         "__vars__": {
           "value": "x"
         },
@@ -345,9 +1872,57 @@
       },
       {
         "component": "p",
+        "idyllASTNode": {
+          "id": 77,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 78,
+              "type": "component",
+              "name": "equation",
+              "children": [
+                {
+                  "id": 79,
+                  "type": "textnode",
+                  "value": "x"
+                }
+              ]
+            },
+            {
+              "id": 80,
+              "type": "textnode",
+              "value": ":\n "
+            },
+            {
+              "id": 81,
+              "type": "component",
+              "name": "Display",
+              "properties": {
+                "var": {
+                  "type": "expression",
+                  "value": "x"
+                }
+              },
+              "children": []
+            }
+          ]
+        },
         "children": [
           {
             "component": "equation",
+            "idyllASTNode": {
+              "id": 78,
+              "type": "component",
+              "name": "equation",
+              "children": [
+                {
+                  "id": 79,
+                  "type": "textnode",
+                  "value": "x"
+                }
+              ]
+            },
             "children": [
               {
                 "id": 79,
@@ -363,6 +1938,18 @@
           },
           {
             "component": "Display",
+            "idyllASTNode": {
+              "id": 81,
+              "type": "component",
+              "name": "Display",
+              "properties": {
+                "var": {
+                  "type": "expression",
+                  "value": "x"
+                }
+              },
+              "children": []
+            },
             "__expr__": {
               "var": "x"
             },
@@ -373,9 +1960,57 @@
       },
       {
         "component": "p",
+        "idyllASTNode": {
+          "id": 82,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 83,
+              "type": "component",
+              "name": "equation",
+              "children": [
+                {
+                  "id": 84,
+                  "type": "textnode",
+                  "value": "x^2"
+                }
+              ]
+            },
+            {
+              "id": 85,
+              "type": "textnode",
+              "value": ":"
+            },
+            {
+              "id": 86,
+              "type": "component",
+              "name": "Display",
+              "properties": {
+                "var": {
+                  "type": "expression",
+                  "value": "xSquared"
+                }
+              },
+              "children": []
+            }
+          ]
+        },
         "children": [
           {
             "component": "equation",
+            "idyllASTNode": {
+              "id": 83,
+              "type": "component",
+              "name": "equation",
+              "children": [
+                {
+                  "id": 84,
+                  "type": "textnode",
+                  "value": "x^2"
+                }
+              ]
+            },
             "children": [
               {
                 "id": 84,
@@ -391,6 +2026,18 @@
           },
           {
             "component": "Display",
+            "idyllASTNode": {
+              "id": 86,
+              "type": "component",
+              "name": "Display",
+              "properties": {
+                "var": {
+                  "type": "expression",
+                  "value": "xSquared"
+                }
+              },
+              "children": []
+            },
             "__expr__": {
               "var": "xSquared"
             },
@@ -401,6 +2048,18 @@
       },
       {
         "component": "p",
+        "idyllASTNode": {
+          "id": 87,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 88,
+              "type": "textnode",
+              "value": "Test expression, displays:"
+            }
+          ]
+        },
         "children": [
           {
             "id": 88,
@@ -411,6 +2070,22 @@
       },
       {
         "component": "Display",
+        "idyllASTNode": {
+          "id": 89,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "varDisplay"
+            },
+            "value": {
+              "type": "expression",
+              "value": "x"
+            }
+          },
+          "children": []
+        },
         "id": "varDisplay",
         "__expr__": {
           "value": "x"
@@ -420,6 +2095,22 @@
       },
       {
         "component": "Display",
+        "idyllASTNode": {
+          "id": 90,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "derivedVarDisplay"
+            },
+            "value": {
+              "type": "expression",
+              "value": "xSquared"
+            }
+          },
+          "children": []
+        },
         "id": "derivedVarDisplay",
         "__expr__": {
           "value": "xSquared"
@@ -429,6 +2120,22 @@
       },
       {
         "component": "Display",
+        "idyllASTNode": {
+          "id": 91,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "derivedVarDisplay2"
+            },
+            "value": {
+              "type": "expression",
+              "value": "xCubed"
+            }
+          },
+          "children": []
+        },
         "id": "derivedVarDisplay2",
         "__expr__": {
           "value": "xCubed"
@@ -438,6 +2145,22 @@
       },
       {
         "component": "Display",
+        "idyllASTNode": {
+          "id": 92,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "strDisplay"
+            },
+            "value": {
+              "type": "expression",
+              "value": "\"string\""
+            }
+          },
+          "children": []
+        },
         "id": "strDisplay",
         "__expr__": {
           "value": "\"string\""
@@ -447,6 +2170,22 @@
       },
       {
         "component": "Display",
+        "idyllASTNode": {
+          "id": 93,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "staticObjectDisplay"
+            },
+            "value": {
+              "type": "expression",
+              "value": "{ static: \"object\" }"
+            }
+          },
+          "children": []
+        },
         "id": "staticObjectDisplay",
         "__expr__": {
           "value": "{ static: \"object\" }"
@@ -456,6 +2195,22 @@
       },
       {
         "component": "Display",
+        "idyllASTNode": {
+          "id": 94,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "dynamicObjectDisplay"
+            },
+            "value": {
+              "type": "expression",
+              "value": "{ dynamic: x }"
+            }
+          },
+          "children": []
+        },
         "id": "dynamicObjectDisplay",
         "__expr__": {
           "value": "{ dynamic: x }"
@@ -465,6 +2220,22 @@
       },
       {
         "component": "Display",
+        "idyllASTNode": {
+          "id": 95,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "dataDisplay"
+            },
+            "value": {
+              "type": "expression",
+              "value": "myData"
+            }
+          },
+          "children": []
+        },
         "id": "dataDisplay",
         "__expr__": {
           "value": "myData"
@@ -474,6 +2245,22 @@
       },
       {
         "component": "Display",
+        "idyllASTNode": {
+          "id": 96,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "bareDataDisplay"
+            },
+            "value": {
+              "type": "variable",
+              "value": "myData"
+            }
+          },
+          "children": []
+        },
         "id": "bareDataDisplay",
         "__vars__": {
           "value": "myData"
@@ -483,6 +2270,22 @@
       },
       {
         "component": "Display",
+        "idyllASTNode": {
+          "id": 97,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "bareVarDisplay"
+            },
+            "value": {
+              "type": "variable",
+              "value": "x"
+            }
+          },
+          "children": []
+        },
         "id": "bareVarDisplay",
         "__vars__": {
           "value": "x"
@@ -492,6 +2295,22 @@
       },
       {
         "component": "Display",
+        "idyllASTNode": {
+          "id": 98,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "bareDerivedDisplay"
+            },
+            "value": {
+              "type": "variable",
+              "value": "xSquared"
+            }
+          },
+          "children": []
+        },
         "id": "bareDerivedDisplay",
         "__vars__": {
           "value": "xSquared"
@@ -501,6 +2320,22 @@
       },
       {
         "component": "Display",
+        "idyllASTNode": {
+          "id": 99,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "bareDerivedDisplay2"
+            },
+            "value": {
+              "type": "variable",
+              "value": "xCubed"
+            }
+          },
+          "children": []
+        },
         "id": "bareDerivedDisplay2",
         "__vars__": {
           "value": "xCubed"
@@ -510,6 +2345,22 @@
       },
       {
         "component": "Display",
+        "idyllASTNode": {
+          "id": 100,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "objectVarDisplay"
+            },
+            "value": {
+              "type": "expression",
+              "value": " objectVar "
+            }
+          },
+          "children": []
+        },
         "id": "objectVarDisplay",
         "__expr__": {
           "value": " objectVar "
@@ -519,6 +2370,22 @@
       },
       {
         "component": "Display",
+        "idyllASTNode": {
+          "id": 101,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "bareObjectVarDisplay"
+            },
+            "value": {
+              "type": "variable",
+              "value": "objectVar"
+            }
+          },
+          "children": []
+        },
         "id": "bareObjectVarDisplay",
         "__vars__": {
           "value": "objectVar"
@@ -528,6 +2395,22 @@
       },
       {
         "component": "Display",
+        "idyllASTNode": {
+          "id": 102,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "arrayVarDisplay"
+            },
+            "value": {
+              "type": "expression",
+              "value": " arrayVar "
+            }
+          },
+          "children": []
+        },
         "id": "arrayVarDisplay",
         "__expr__": {
           "value": " arrayVar "
@@ -537,6 +2420,22 @@
       },
       {
         "component": "Display",
+        "idyllASTNode": {
+          "id": 103,
+          "type": "component",
+          "name": "Display",
+          "properties": {
+            "id": {
+              "type": "value",
+              "value": "bareArrayVarDisplay"
+            },
+            "value": {
+              "type": "variable",
+              "value": "arrayVar"
+            }
+          },
+          "children": []
+        },
         "id": "bareArrayVarDisplay",
         "__vars__": {
           "value": "arrayVar"
@@ -546,10 +2445,28 @@
       },
       {
         "component": "br",
+        "idyllASTNode": {
+          "id": 104,
+          "type": "component",
+          "name": "br",
+          "children": []
+        },
         "children": []
       },
       {
         "component": "p",
+        "idyllASTNode": {
+          "id": 105,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 106,
+              "type": "textnode",
+              "value": "Here is an example of how you could use a variable to control the frequency of a sine wave:"
+            }
+          ]
+        },
         "children": [
           {
             "id": 106,
@@ -560,6 +2477,26 @@
       },
       {
         "component": "Chart",
+        "idyllASTNode": {
+          "id": 107,
+          "type": "component",
+          "name": "Chart",
+          "properties": {
+            "equation": {
+              "type": "expression",
+              "value": "(t) => Math.sin(t * frequency)"
+            },
+            "domain": {
+              "type": "expression",
+              "value": "[0, 2 * Math.PI]"
+            },
+            "samplePoints": {
+              "type": "value",
+              "value": 1000
+            }
+          },
+          "children": []
+        },
         "__expr__": {
           "equation": "(t) => Math.sin(t * frequency)",
           "domain": "[0, 2 * Math.PI]"
@@ -571,6 +2508,30 @@
       },
       {
         "component": "Range",
+        "idyllASTNode": {
+          "id": 108,
+          "type": "component",
+          "name": "Range",
+          "properties": {
+            "value": {
+              "type": "variable",
+              "value": "frequency"
+            },
+            "min": {
+              "type": "value",
+              "value": 0.5
+            },
+            "max": {
+              "type": "expression",
+              "value": "2 * Math.PI"
+            },
+            "step": {
+              "type": "value",
+              "value": 0.0001
+            }
+          },
+          "children": []
+        },
         "__vars__": {
           "value": "frequency"
         },
@@ -585,9 +2546,53 @@
       },
       {
         "component": "p",
+        "idyllASTNode": {
+          "id": 109,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 110,
+              "type": "component",
+              "name": "Display",
+              "properties": {
+                "id": {
+                  "type": "value",
+                  "value": "lateVarDisplay"
+                },
+                "value": {
+                  "type": "variable",
+                  "value": "lateVar"
+                }
+              },
+              "children": []
+            },
+            {
+              "id": 111,
+              "type": "textnode",
+              "value": "\nLate Var Range:"
+            }
+          ]
+        },
         "children": [
           {
             "component": "Display",
+            "idyllASTNode": {
+              "id": 110,
+              "type": "component",
+              "name": "Display",
+              "properties": {
+                "id": {
+                  "type": "value",
+                  "value": "lateVarDisplay"
+                },
+                "value": {
+                  "type": "variable",
+                  "value": "lateVar"
+                }
+              },
+              "children": []
+            },
             "id": "lateVarDisplay",
             "__vars__": {
               "value": "lateVar"
@@ -604,6 +2609,26 @@
       },
       {
         "component": "Range",
+        "idyllASTNode": {
+          "id": 112,
+          "type": "component",
+          "name": "Range",
+          "properties": {
+            "value": {
+              "type": "variable",
+              "value": "lateVar"
+            },
+            "min": {
+              "type": "value",
+              "value": 2
+            },
+            "max": {
+              "type": "value",
+              "value": 100
+            }
+          },
+          "children": []
+        },
         "__vars__": {
           "value": "lateVar"
         },
@@ -614,6 +2639,64 @@
       },
       {
         "component": "p",
+        "idyllASTNode": {
+          "id": 113,
+          "type": "component",
+          "name": "p",
+          "children": [
+            {
+              "id": 114,
+              "type": "textnode",
+              "value": "Read more about Idyll at "
+            },
+            {
+              "id": 115,
+              "type": "component",
+              "name": "a",
+              "properties": {
+                "href": {
+                  "type": "value",
+                  "value": "https://idyll-lang.github.io/"
+                }
+              },
+              "children": [
+                {
+                  "id": 116,
+                  "type": "textnode",
+                  "value": "https://idyll-lang.github.io/"
+                }
+              ]
+            },
+            {
+              "id": 117,
+              "type": "textnode",
+              "value": ", and come say “Hi!” in our "
+            },
+            {
+              "id": 118,
+              "type": "component",
+              "name": "a",
+              "properties": {
+                "href": {
+                  "type": "value",
+                  "value": "https://gitter.im/idyll-lang/Lobby"
+                }
+              },
+              "children": [
+                {
+                  "id": 119,
+                  "type": "textnode",
+                  "value": "chatroom on gitter"
+                }
+              ]
+            },
+            {
+              "id": 120,
+              "type": "textnode",
+              "value": "."
+            }
+          ]
+        },
         "children": [
           {
             "id": 114,
@@ -622,6 +2705,24 @@
           },
           {
             "component": "a",
+            "idyllASTNode": {
+              "id": 115,
+              "type": "component",
+              "name": "a",
+              "properties": {
+                "href": {
+                  "type": "value",
+                  "value": "https://idyll-lang.github.io/"
+                }
+              },
+              "children": [
+                {
+                  "id": 116,
+                  "type": "textnode",
+                  "value": "https://idyll-lang.github.io/"
+                }
+              ]
+            },
             "href": "https://idyll-lang.github.io/",
             "children": [
               {
@@ -638,6 +2739,24 @@
           },
           {
             "component": "a",
+            "idyllASTNode": {
+              "id": 118,
+              "type": "component",
+              "name": "a",
+              "properties": {
+                "href": {
+                  "type": "value",
+                  "value": "https://gitter.im/idyll-lang/Lobby"
+                }
+              },
+              "children": [
+                {
+                  "id": 119,
+                  "type": "textnode",
+                  "value": "chatroom on gitter"
+                }
+              ]
+            },
             "href": "https://gitter.im/idyll-lang/Lobby",
             "children": [
               {

--- a/packages/idyll-document/test/nodes.js
+++ b/packages/idyll-document/test/nodes.js
@@ -3,71 +3,69 @@ import { shallow } from 'enzyme';
 import * as components from 'idyll-components';
 
 import IdyllDocument from '../src/';
-import { translate, mapTree } from '../src/utils'
+import { translate, mapTree } from '../src/utils';
 import ReactJsonSchema from '../src/utils/schema2element';
-import ast from './fixtures/ast.json'
-import schema from './fixtures/schema.json'
+import ast from './fixtures/ast.json';
+import schema from './fixtures/schema.json';
 
 describe('AST to Schema', () => {
   it('converts from AST to schema expected by ReactJsonSchema', () => {
-    expect(translate(ast)).toEqual(schema)
-  })
-})
+    expect(translate(ast)).toEqual(schema);
+  });
+});
 
 describe('Schema transformations', () => {
-  const source = [{
-    "component": "p",
-    "children": [
-      "This document is being rendered from ",
-      {
-        "component": "strong",
-        "children": [
-          "Idyll markup"
-        ]
-      },
-      ". If you’ve used ",
-      {
-        "component": "a",
-        "href": "https://daringfireball.net/projects/markdown/",
-        "children": [
-          "markdown"
-        ]
-      },
-      ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update."
-    ]
-  }];
+  const source = [
+    {
+      component: 'p',
+      children: [
+        'This document is being rendered from ',
+        {
+          component: 'strong',
+          children: ['Idyll markup']
+        },
+        '. If you’ve used ',
+        {
+          component: 'a',
+          href: 'https://daringfireball.net/projects/markdown/',
+          children: ['markdown']
+        },
+        ', Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.'
+      ]
+    }
+  ];
 
   it('can copy schema', () => {
-    const d = mapTree(source, x => x)
-    expect(d).toEqual(source)
-  })
+    const d = mapTree(source, x => x);
+    expect(d).toEqual(source);
+  });
 
   it('can modify schema', () => {
-    const modified = [{
-      "component": "p",
-      "children": [
-        "This document is being rendered from ",
-        {
-          "component": "wrapper",
-          "style": {color: 'red'},
-          "children": [
-            {
-              "component": "strong",
-              "children": ["Idyll markup"]
-            }
-          ]
-        },
-        ". If you’ve used ",
-        {
-          "component": "a",
-          "href": "https://daringfireball.net/projects/markdown/",
-          "children": [
-            "markdown"
-          ]
-        },
-        ", Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update."
-      ]
-    }];
+    const modified = [
+      {
+        component: 'p',
+        children: [
+          'This document is being rendered from ',
+          {
+            component: 'wrapper',
+            style: { color: 'red' },
+            children: [
+              {
+                component: 'strong',
+                children: ['Idyll markup']
+              }
+            ]
+          },
+          '. If you’ve used ',
+          {
+            component: 'a',
+            href: 'https://daringfireball.net/projects/markdown/',
+            children: ['markdown']
+          },
+          ', Idyll should look pretty familiar, but it has some additional features. Write text in the box on the left and the output on the right will automatically update.'
+        ]
+      }
+    ];
 
     const d = mapTree(source, x => {
       if (x.component === 'strong') {
@@ -75,19 +73,26 @@ describe('Schema transformations', () => {
           component: 'wrapper',
           style: { color: 'red' },
           children: [x]
-        }
+        };
       }
-      return x
-    })
+      return x;
+    });
 
-    expect(d).toEqual(modified)
-  })
+    expect(d).toEqual(modified);
+  });
 });
 
 describe('Schema to Elements', () => {
   it('creates the expected elements', () => {
     const rjs = new ReactJsonSchema(components);
-    const el = rjs.parseSchema({component: 'div', children: schema});
+
+    // Remove the idyllASTNodes from this check
+    const strippedSchema = mapTree(schema, c => {
+      const { idyllASTNode, ...rest } = c;
+      return rest;
+    });
+
+    const el = rjs.parseSchema({ component: 'div', children: strippedSchema });
     expect(shallow(el).contains(<h1>Welcome to Idyll</h1>)).toBe(true);
   });
 });


### PR DESCRIPTION
This change adds a new property to each of the `Wrapper` and `AuthorView` components that get created by the `IdyllDocument`.

In particular, all of these components will now have access to an `idyllASTNode` prop that contains the relevant subtree of the idyll AST that corresponds to that component This is useful for dynamically modifying the AST at runtime, and will allow us to make idyll documents that can be self modifying.

/cc @tanalan @megan-vo 