### PR TITLE
function to convert AST back to markup

### DIFF
--- a/packages/idyll-ast/README.md
+++ b/packages/idyll-ast/README.md
@@ -123,6 +123,7 @@ Only **component** nodes can have any children. **textnodes**, **var**, **derive
   - [~removeProperties](#module_idyll-ast..removeProperties) ⇒ <code>object</code>
   - [~setProperty](#module_idyll-ast..setProperty) ⇒ <code>object</code>
   - [~setProperties](#module_idyll-ast..setProperties) ⇒ <code>object</code>
+  - [~toString](#module_idyll-ast..toString) ⇒ <code>string</code>
   - [~walkNodes](#module_idyll-ast..walkNodes) : <code>function</code>
   - [~walkNodeBreadthFirst](#module_idyll-ast..walkNodeBreadthFirst)
 
@@ -501,6 +502,19 @@ Function to add multiple properties to a node
 | ---------- | ------------------- |
 | node       | <code>object</code> |
 | properties | <code>object</code> |
+
+<a name="module_idyll-ast..walkNodes"></a>
+
+### idyll-ast~toMarkup ⇒ <code>string</code>
+
+Function to convert an AST back into idyll markup
+
+**Kind**: inner property of [<code>idyll-ast</code>](#module_idyll-ast)
+**Returns**: <code>string</code> - markup string
+
+| Param | Type                |
+| ----- | ------------------- |
+| node  | <code>object</code> |
 
 <a name="module_idyll-ast..walkNodes"></a>
 

--- a/packages/idyll-ast/README.md
+++ b/packages/idyll-ast/README.md
@@ -123,7 +123,7 @@ Only **component** nodes can have any children. **textnodes**, **var**, **derive
   - [~removeProperties](#module_idyll-ast..removeProperties) ⇒ <code>object</code>
   - [~setProperty](#module_idyll-ast..setProperty) ⇒ <code>object</code>
   - [~setProperties](#module_idyll-ast..setProperties) ⇒ <code>object</code>
-  - [~toString](#module_idyll-ast..toString) ⇒ <code>string</code>
+  - [~toMarkup](#module_idyll-ast..toMarkup) ⇒ <code>string</code>
   - [~walkNodes](#module_idyll-ast..walkNodes) : <code>function</code>
   - [~walkNodeBreadthFirst](#module_idyll-ast..walkNodeBreadthFirst)
 

--- a/packages/idyll-ast/src/index.js
+++ b/packages/idyll-ast/src/index.js
@@ -942,27 +942,27 @@ function childrenToMarkup(node, depth) {
 function nodeToMarkup(node, depth) {
   switch (node.type) {
     case 'textnode':
-      return `${'\t'.repeat(depth)}${node.value}`;
+      return `${'  '.repeat(depth)}${node.value}`;
     case 'component':
       if (node.name.toLowerCase() === 'textcontainer') {
         return `\n${childrenToMarkup(node, depth)}\n`;
       }
       const propString = propertiesToString(node);
       if (hasChildren(node)) {
-        return `${'\t'.repeat(depth)}[${node.name}${
+        return `${'  '.repeat(depth)}[${node.name}${
           propString ? ` ${propString}` : ''
-        }]${childrenToMarkup(node, depth + 1)}\n${'\t'.repeat(depth)}[/${
+        }]${childrenToMarkup(node, depth + 1)}\n${'  '.repeat(depth)}[/${
           node.name
         }]`;
       }
-      return `${'\t'.repeat(depth)}[${node.name}${
+      return `${'  '.repeat(depth)}[${node.name}${
         propString ? ` ${propString}` : ''
       } /]`;
     case 'var':
     case 'derived':
     case 'data':
     case 'meta':
-      return `${'\t'.repeat(depth)}[${node.type} ${propertiesToString(
+      return `${'  '.repeat(depth)}[${node.type} ${propertiesToString(
         node
       )} /]`;
   }

--- a/packages/idyll-ast/src/index.js
+++ b/packages/idyll-ast/src/index.js
@@ -914,6 +914,71 @@ function runPropsValidator(props) {
   }
 }
 
+function propertyToString(property) {
+  switch (property.type) {
+    case 'value':
+      return JSON.stringify(property.value);
+    case 'expression':
+      return `\`${property.value}\``;
+    case 'variable':
+      return property.value;
+  }
+}
+
+function propertiesToString(node) {
+  return Object.keys(node.properties || {})
+    .reduce(function(memo, key) {
+      return memo + ` ${key}:${propertyToString(node.properties[key])}`;
+    }, '')
+    .trim();
+}
+
+function childrenToMarkup(node, depth) {
+  return (node.children || []).reduce(function(memo, child) {
+    return memo + `\n${nodeToMarkup(child, depth)}`;
+  }, '');
+}
+
+function nodeToMarkup(node, depth) {
+  switch (node.type) {
+    case 'textnode':
+      return `${'\t'.repeat(depth)}${node.value}`;
+    case 'component':
+      if (node.name.toLowerCase() === 'textcontainer') {
+        return `\n${childrenToMarkup(node, depth)}\n`;
+      }
+      const propString = propertiesToString(node);
+      if (hasChildren(node)) {
+        return `${'\t'.repeat(depth)}[${node.name}${
+          propString ? ` ${propString}` : ''
+        }]${childrenToMarkup(node, depth + 1)}\n${'\t'.repeat(depth)}[/${
+          node.name
+        }]`;
+      }
+      return `${'\t'.repeat(depth)}[${node.name}${
+        propString ? ` ${propString}` : ''
+      } /]`;
+    case 'var':
+    case 'derived':
+    case 'data':
+    case 'meta':
+      return `${'\t'.repeat(depth)}[${node.type} ${propertiesToString(
+        node
+      )} /]`;
+  }
+}
+
+/**
+ * @name toMarkup
+ * @description
+ * Function to convert AST back to idyll markup
+ * @param {object} ast  AST node
+ * @return {string} Markup string
+ */
+function toMarkup(ast) {
+  return childrenToMarkup(ast, 0).trim();
+}
+
 module.exports = {
   appendNode,
   appendNodes,
@@ -945,5 +1010,6 @@ module.exports = {
   setProperty,
   setProperties,
   walkNodes,
-  walkNodesBreadthFirst
+  walkNodesBreadthFirst,
+  toMarkup
 };

--- a/packages/idyll-ast/test/test.js
+++ b/packages/idyll-ast/test/test.js
@@ -287,3 +287,28 @@ describe('ast', function() {
     ).to.eql(false);
   });
 });
+
+describe('markup conversion', function() {
+  it('should convert a simple AST to markup', function() {
+    const markup = util.toMarkup(astTestVar);
+    expect(markup).to.eql(
+      `
+[p]
+	This is the first paragraph
+[/p]
+[div]
+	[h1]
+		This is a header
+	[/h1]
+	[var name:"testVar" value:\`3 * 3\` /]
+	[p]
+		[a href:"www.test.com"]
+			This is a link to a website
+		[/a]
+		[data name:"testData" source:"test.csv" /]
+	[/p]
+[/div]
+    `.trim()
+    );
+  });
+});

--- a/packages/idyll-ast/test/test.js
+++ b/packages/idyll-ast/test/test.js
@@ -294,19 +294,19 @@ describe('markup conversion', function() {
     expect(markup).to.eql(
       `
 [p]
-	This is the first paragraph
+  This is the first paragraph
 [/p]
 [div]
-	[h1]
-		This is a header
-	[/h1]
-	[var name:"testVar" value:\`3 * 3\` /]
-	[p]
-		[a href:"www.test.com"]
-			This is a link to a website
-		[/a]
-		[data name:"testData" source:"test.csv" /]
-	[/p]
+  [h1]
+    This is a header
+  [/h1]
+  [var name:"testVar" value:\`3 * 3\` /]
+  [p]
+    [a href:"www.test.com"]
+      This is a link to a website
+    [/a]
+    [data name:"testData" source:"test.csv" /]
+  [/p]
 [/div]
     `.trim()
     );


### PR DESCRIPTION
This adds a new `toMarkup()` function to the `idyll-ast` package that allows us to convert an Idyll AST back to a string of idyll markup.

This is useful for applications which operate on the AST but want to expose or otherwise utilize a string-based representation as well.

## Usage

```js
const { toMarkup } = require('idyll-ast');

toMarkup(idyllASTObject); // returns a string containing the markup
```

/cc @tanalan @megan-vo 