### PR TITLE
fix error when bold tag occurs at the end of a paragraph

### DIFF
--- a/packages/idyll-compiler/test/test.js
+++ b/packages/idyll-compiler/test/test.js
@@ -1439,5 +1439,50 @@ End text
         ])
       );
     });
+
+    it.only('should handle bold at the end of a paragraph', function() {
+      const input = `
+        This is **bold text.**
+
+        This is a new paragraph.
+      `;
+
+      expect(compile(input, { async: false })).to.eql({
+        id: 0,
+        type: 'component',
+        name: 'div',
+        children: [
+          {
+            id: 2,
+            type: 'component',
+            name: 'TextContainer',
+            children: [
+              {
+                id: 3,
+                type: 'component',
+                name: 'p',
+                children: [
+                  { id: 4, type: 'textnode', value: 'This is ' },
+                  {
+                    id: 5,
+                    type: 'component',
+                    name: 'strong',
+                    children: [{ id: 6, type: 'textnode', value: 'bold text.' }]
+                  }
+                ]
+              },
+              {
+                id: 7,
+                type: 'component',
+                name: 'p',
+                children: [
+                  { id: 8, type: 'textnode', value: 'This is a new paragraph.' }
+                ]
+              }
+            ]
+          }
+        ]
+      });
+    });
   });
 });


### PR DESCRIPTION
This is a bugfix for https://github.com/idyll-lang/idyll/issues/449. The current implementation swallows the expected paragraph break that occurs if a paragraph ends with a bold tag. This fix corrects the issue so that breaks are correctly maintained.

