### PR TITLE
Don't pass the `fullwidth` prop to components

### DIFF
--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -220,6 +220,7 @@ export const filterIdyllProps = (props, filterInjected) => {
     onEnterView,
     onExitViewFully,
     onExitView,
+    fullWidth,
     ...rest
   } = props;
   if (filterInjected) {


### PR DESCRIPTION
Another small tweak to the runtime to prevent warnings from being thrown. No behavioral change as none of the components themselves rely on this property. 