### PR TITLE
swallow annoying FS error

### DIFF
--- a/packages/idyll-cli/src/pipeline/index.js
+++ b/packages/idyll-cli/src/pipeline/index.js
@@ -5,6 +5,7 @@ const { copy, pathExists } = require('fs-extra');
 const compile = require('idyll-compiler');
 const UglifyJS = require('uglify-js');
 const { paramCase } = require('change-case');
+const debug = require('debug')('idyll:cli');
 
 const {
   getComponentNodes,
@@ -108,12 +109,16 @@ const build = (opts, paths, resolvers) => {
         writeFile(paths.JS_OUTPUT_FILE, output.js),
         writeFile(paths.CSS_OUTPUT_FILE, output.css),
         writeFile(paths.HTML_OUTPUT_FILE, output.html),
-        pathExists(paths.STATIC_DIR).then(exists => {
-          if (exists && paths.STATIC_DIR !== paths.STATIC_OUTPUT_DIR) {
-            return copy(paths.STATIC_DIR, paths.STATIC_OUTPUT_DIR);
-          }
-          return null;
-        })
+        pathExists(paths.STATIC_DIR)
+          .then(exists => {
+            if (exists && paths.STATIC_DIR !== paths.STATIC_OUTPUT_DIR) {
+              return copy(paths.STATIC_DIR, paths.STATIC_OUTPUT_DIR);
+            }
+            return null;
+          })
+          .catch(e => {
+            debug('Error copying static files', e);
+          })
       ]);
     })
     .then(() => {


### PR DESCRIPTION
This error (or similar) occasionally pops up during development on idyll : 

```
{ [Error: ENOENT: no such file or directory, unlink '<project-path>/build/static/images/logo.png']
  errno: -2,
  code: 'ENOENT',
  syscall: 'unlink',
  path:
   '<project-path>/build/static/images/logo.png' }
```

This is an occasional race condition that doesn't have adverse effects, so this PR is to hide the warning by default. 