### PR TITLE
remove frames from example gallery

### DIFF
--- a/packages/idyll-docs/components/example.js
+++ b/packages/idyll-docs/components/example.js
@@ -1,71 +1,72 @@
 import { Link } from '../routes';
 
-const imageUrl = (url) => /^http/.test(url) ? url : `/static/images/${url}`
+const imageUrl = url => (/^http/.test(url) ? url : `/static/images/${url}`);
 
-function slugify(text)
-{
-  return text.toString().split(/([A-Z][a-z]+)/).join('-').toLowerCase()
-    .replace(/\s+/g, '-')           // Replace spaces with -
-    .replace(/[^\w\-]+/g, '')       // Remove all non-word chars
-    .replace(/\-\-+/g, '-')         // Replace multiple - with single -
-    .replace(/^-+/, '')             // Trim - from start of text
-    .replace(/-+$/, '');            // Trim - from end of text
+function slugify(text) {
+  return text
+    .toString()
+    .split(/([A-Z][a-z]+)/)
+    .join('-')
+    .toLowerCase()
+    .replace(/\s+/g, '-') // Replace spaces with -
+    .replace(/[^\w\-]+/g, '') // Remove all non-word chars
+    .replace(/\-\-+/g, '-') // Replace multiple - with single -
+    .replace(/^-+/, '') // Trim - from start of text
+    .replace(/-+$/, ''); // Trim - from end of text
 }
-
 
 export default ({ href, label, subtitle, image, sourceUrl }) => (
   <div className="example">
-    <Link route='gallery-item' params={{slug: slugify(label)}}>
-      <a>
-        <div
-          className="example-image"
-          style={{ backgroundImage: `url(${imageUrl(image)})` }}
-        >
-          {
-            sourceUrl ? <div>
-              <div style={{
-                padding: 10,
-                background: '#fff',
-                width: 125,
-                margin: '0 auto',
-                textAlign: 'center',
-                border: 'solid 1px black',
-                color: 'black',
-                position: 'relative',
-                top: 5
-              }}>
-                Source Available
-              </div>
-            </div> : null
-          }
-        </div>
-        <div className="example-label">{ label }
-          {
-            subtitle ? (
-            <div className="subtitle">{subtitle}</div>
-            ) : null
-          }
-        </div>
-      </a>
-    </Link>
+    <div
+      className="example-image"
+      style={{ backgroundImage: `url(${imageUrl(image)})` }}
+    />
+    <div className="example-label">
+      {label}
+      {subtitle ? <div className="subtitle">{subtitle}</div> : null}
+    </div>
+    <div className="example-links">
+      <Link href={href}>
+        <a className="example-button">Open</a>
+      </Link>
+      {sourceUrl ? (
+        <Link href={sourceUrl}>
+          <a className="example-button">View Source</a>
+        </Link>
+      ) : null}
+    </div>
 
     <style jsx>{`
       .example {
         border: solid 2px #efefef;
         background: #efefef;
         transition: border 0.25s, background 0.25s, color 0.25s;
+      }
+
+      .example-links {
+        display: flex;
+        flex-direction: row;
+        margin-bottom: 1em;
+        justify-content: space-around;
+        width: 100%;
+      }
+
+      .example-button {
+        display: block;
+        padding: 10px
+        background: #fff;
+        width: 125px;
+        text-align: center;
+        border: solid 1px black;
+        color: black;
         cursor: pointer;
       }
 
-      .example:hover {
-        border: solid 2px #6122FB;
-        background: #6122FB;
-      }
-      .example:hover .example-label {
-        background: #6122FB;
+      .example-button:hover {
+        transition: border 0.25s, background 0.25s, color 0.25s;
         color: white;
+        background: #6122FB;
       }
-
 
       .example a {
         display: block;
@@ -79,6 +80,7 @@ export default ({ href, label, subtitle, image, sourceUrl }) => (
         background: #efefef;
         padding: 15px;
         transition: background 0.25s, color 0.25s;
+        min-height: 85px;
       }
       .example-label .subtitle {
         font-weight: normal;
@@ -93,4 +95,4 @@ export default ({ href, label, subtitle, image, sourceUrl }) => (
       }
     `}</style>
   </div>
-)
+);


### PR DESCRIPTION
This updates the gallery page to remove the "frames" around the articles when you click on an example. Now, instead there are direct links to the example and to the source code. 

