### PR TITLE
Use component metadata to create documentation

### DIFF
--- a/packages/idyll-components/src/chart.js
+++ b/packages/idyll-components/src/chart.js
@@ -1,4 +1,3 @@
-
 import React from 'react';
 const V = require('victory');
 const d3Arr = require('d3-array');
@@ -15,7 +14,6 @@ const types = {
 let chartCount = 0;
 
 class Chart extends React.PureComponent {
-
   constructor(props) {
     super(props);
     this.id = chartCount++;
@@ -33,7 +31,8 @@ class Chart extends React.PureComponent {
       domainPadding = 10,
       animate,
       theme = 'grayscale',
-      ...customProps } = props;
+      ...customProps
+    } = props;
 
     if (typeof theme === 'string') {
       theme = V.VictoryTheme[theme];
@@ -41,24 +40,26 @@ class Chart extends React.PureComponent {
 
     if (props.equation) {
       const d = domain;
-      data = d3Arr.range(d[0], d[1], (d[1] - d[0]) / props.samplePoints).map((x) => {
-        try {
-          return {
-            x: x,
-            y: props.equation(x)
-          };
-        } catch(err) {
-          return {
-            x: x,
-            y: 0
+      data = d3Arr
+        .range(d[0], d[1], (d[1] - d[0]) / props.samplePoints)
+        .map(x => {
+          try {
+            return {
+              x: x,
+              y: props.equation(x)
+            };
+          } catch (err) {
+            return {
+              x: x,
+              y: 0
+            };
           }
-        }
-      });
+        });
     }
 
     if (type === types.TIME) {
-      scale = {x: 'time', y: 'linear'};
-      data = data.map((d) => {
+      scale = { x: 'time', y: 'linear' };
+      data = data.map(d => {
         return Object.assign({}, d, {
           x: new Date(d.x)
         });
@@ -67,23 +68,23 @@ class Chart extends React.PureComponent {
 
     let formattedRange = { domain: { x: domain, y: range } };
 
-
     return (
       <div className={props.className}>
         {type !== 'PIE' ? (
-          <V.VictoryChart domainPadding={domainPadding} {...formattedRange} animate={animate} scale={scale} containerId={`container-${id}`} clipId={`clip-${id}`} theme={theme} >
-            <INNER_CHART
-              data={data}
-              x={props.x}
-              y={props.y}
-              {...customProps}>
-            </INNER_CHART>
+          <V.VictoryChart
+            domainPadding={domainPadding}
+            {...formattedRange}
+            animate={animate}
+            scale={scale}
+            containerId={`container-${id}`}
+            clipId={`clip-${id}`}
+            theme={theme}
+          >
+            <INNER_CHART data={data} x={props.x} y={props.y} {...customProps} />
           </V.VictoryChart>
         ) : (
-          <INNER_CHART data={data} colorScale={props.colorScale}>
-          </INNER_CHART>
-        )
-        }
+          <INNER_CHART data={data} colorScale={props.colorScale} />
+        )}
       </div>
     );
   }
@@ -97,19 +98,44 @@ Chart.defaultProps = {
   type: 'line'
 };
 
-
 Chart._idyll = {
-  name: "Chart",
-  tagType: "closed",
-  props: [{
-    name: "type",
-    type: "string",
-    example: '"scatter"'
-  },{
-    name: "data",
-    type: "array",
-    example: "`[{x: 1, y: 1}, { x: 2, y: 2 }]`"
-  }]
-}
+  name: 'Chart',
+  tagType: 'closed',
+  props: [
+    {
+      name: 'type',
+      type: 'string',
+      example: '"scatter"',
+      description:
+        'The type of the chart to display, can be `line`, `scatter`, `bar`, `pie`, or `time`. The time type is a line chart that expects the `x` values in the data to be in the temporal domain.'
+    },
+    {
+      name: 'data',
+      type: 'array',
+      example: '`[{x: 1, y: 1}, { x: 2, y: 2 }]`',
+      description:
+        'A JSON object containing the data for this chart. It uses the [victory](https://formidable.com/open-source/victory/docs) library to handle rendering, so see those docs for more information on what types of data can be passed in.'
+    },
+    {
+      name: 'domain',
+      type: 'array',
+      example: '`[0, 1]`',
+      description: 'The chart extent along the x dimension.'
+    },
+    {
+      name: 'range',
+      type: 'array',
+      example: '`[0, 1]`',
+      description: 'The chart extent along the y dimension.'
+    },
+    {
+      name: 'theme',
+      type: 'string',
+      example: "'grayscale'",
+      description:
+        'The theme to use, e.g. `grayscale` or `material` or a custom object (see [an example here](https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/victory-theme/grayscale.js))'
+    }
+  ]
+};
 
 export default Chart;

--- a/packages/idyll-components/src/conditional.js
+++ b/packages/idyll-components/src/conditional.js
@@ -5,7 +5,7 @@ class Conditional extends React.Component {
     const { idyll, hasError, updateProps, ...props } = this.props;
 
     if (!props.if) {
-      return <div style={{display: 'none'}}>{props.children}</div>;
+      return <div style={{ display: 'none' }}>{props.children}</div>;
     }
 
     return <div>{props.children}</div>;
@@ -13,13 +13,17 @@ class Conditional extends React.Component {
 }
 
 Conditional._idyll = {
-  name: "Conditional",
-  tagType: "open",
+  name: 'Conditional',
+  tagType: 'open',
   children: ['Some text'],
-  props: [{
-    name: "if",
-    type: "expression",
-    example: "`x < 10`"
-  }]
-}
+  props: [
+    {
+      name: 'if',
+      type: 'expression',
+      example: '`x < 10`',
+      description:
+        'An expression; if this evaluates to true, the children will be rendered, otherwise nothing will be drawn to the screen'
+    }
+  ]
+};
 module.exports = Conditional;

--- a/packages/idyll-components/src/dynamic.js
+++ b/packages/idyll-components/src/dynamic.js
@@ -5,19 +5,21 @@ const Drag = require('d3-drag');
 const Selection = require('d3-selection');
 
 class Dynamic extends React.PureComponent {
-
   componentDidMount() {
     let node;
     try {
       node = ReactDOM.findDOMNode(this);
-    } catch(e) {};
+    } catch (e) {}
     if (!node) {
       return;
     }
     this.drag = Drag.drag().on('drag', () => {
       const dx = Selection.event.dx;
       const { step, value, interval } = this.props;
-      const newValue = Math.max(Math.min(value + (step || interval) * dx, this.props.max), this.props.min);
+      const newValue = Math.max(
+        Math.min(value + (step || interval) * dx, this.props.max),
+        this.props.min
+      );
       this.props.updateProps({ value: newValue });
     });
     this.drag(Selection.select(node));
@@ -26,11 +28,7 @@ class Dynamic extends React.PureComponent {
   render() {
     const { format, value } = this.props;
     const formatter = Format.format(format);
-    return (
-      <span className="idyll-dynamic">
-        {formatter(value)}
-      </span>
-    );
+    return <span className="idyll-dynamic">{formatter(value)}</span>;
   }
 }
 
@@ -41,28 +39,36 @@ Dynamic.defaultProps = {
   step: 1
 };
 
-
 Dynamic._idyll = {
-  name: "Dynamic",
-  tagType: "closed",
-  displayType: "inline",
-  props: [{
-    name: "value",
-    type: "number",
-    example: "x"
-  }, {
-    name: "step",
-    type: "string",
-    example: '1'
-  }, {
-    name: "min",
-    type: "number",
-    example: '-100'
-  }, {
-    name: "max",
-    type: "number",
-    example: '100'
-  }]
-}
+  name: 'Dynamic',
+  tagType: 'closed',
+  displayType: 'inline',
+  props: [
+    {
+      name: 'value',
+      type: 'number',
+      example: 'x',
+      description: 'The value to display.'
+    },
+    {
+      name: 'step',
+      type: 'string',
+      example: '1',
+      description: 'The granularity of the changes.'
+    },
+    {
+      name: 'min',
+      type: 'number',
+      example: '-100',
+      description: 'The minimum value.'
+    },
+    {
+      name: 'max',
+      type: 'number',
+      example: '100',
+      description: 'The maximum value.'
+    }
+  ]
+};
 
 export default Dynamic;

--- a/packages/idyll-components/src/float.js
+++ b/packages/idyll-components/src/float.js
@@ -3,26 +3,34 @@ import React from 'react';
 class Float extends React.PureComponent {
   render() {
     return (
-      <div className={`float ${this.props.position}`} style={{float: this.props.position, width: this.props.width || '50%'}}>
+      <div
+        className={`float ${this.props.position}`}
+        style={{ float: this.props.position, width: this.props.width || '50%' }}
+      >
         {this.props.children}
       </div>
     );
   }
 }
 
-
 Float._idyll = {
-  name: "Float",
-  tagType: "open",
-  props: [{
-    name: "position",
-    type: "string",
-    example: '"left"'
-  }, {
-    name: 'width',
-    type: 'string',
-    example: '"50%"'
-  }]
-}
+  name: 'Float',
+  tagType: 'open',
+  props: [
+    {
+      name: 'position',
+      type: 'string',
+      example: '"left"',
+      description: 'the float position: left or right.'
+    },
+    {
+      name: 'width',
+      type: 'string',
+      example: '"50%"',
+      description:
+        'the width of the component, specified in pixels or percentage.'
+    }
+  ]
+};
 
 export default Float;

--- a/packages/idyll-components/src/preload.js
+++ b/packages/idyll-components/src/preload.js
@@ -28,6 +28,8 @@ Preloader._idyll = {
     {
       name: 'images',
       type: 'array',
+      description:
+        'the array of images: `["image-url-1.png", "image-url-2.jpg"]`.',
       example: '["image-url-1.png", "image-url-2.jpg"]'
     }
   ]

--- a/packages/idyll-components/src/radio.js
+++ b/packages/idyll-components/src/radio.js
@@ -14,15 +14,44 @@ class Radio extends React.PureComponent {
   }
 
   render() {
-    const { idyll, hasError, updateProps, options, value, ...props } = this.props;
+    const {
+      idyll,
+      hasError,
+      updateProps,
+      options,
+      value,
+      ...props
+    } = this.props;
 
     return (
       <div {...props}>
-        {options.map((d) => {
+        {options.map(d => {
           if (typeof d === 'string') {
-            return <label key={d}><input type="radio" checked={d === value} onChange={this.onChange} value={d} name={this.id} />{d}</label>;
+            return (
+              <label key={d}>
+                <input
+                  type="radio"
+                  checked={d === value}
+                  onChange={this.onChange}
+                  value={d}
+                  name={this.id}
+                />
+                {d}
+              </label>
+            );
           }
-          return <label key={d.value}><input type="radio" checked={d.value === value} onChange={this.onChange} value={d.value} name={this.id} />{d.label || d.value}</label>;
+          return (
+            <label key={d.value}>
+              <input
+                type="radio"
+                checked={d.value === value}
+                onChange={this.onChange}
+                value={d.value}
+                name={this.id}
+              />
+              {d.label || d.value}
+            </label>
+          );
         })}
       </div>
     );
@@ -33,19 +62,24 @@ Radio.defaultProps = {
   options: []
 };
 
-
 Radio._idyll = {
-  name: "Radio",
-  tagType: "closed",
-  props: [{
-    name: "value",
-    type: "string",
-    example: "x"
-  }, {
-    name: "options",
-    type: "array",
-    example: '`["option1", "option2"]`'
-  }]
-}
+  name: 'Radio',
+  tagType: 'closed',
+  props: [
+    {
+      name: 'value',
+      type: 'string',
+      example: 'x',
+      description: 'The value of the "checked" radio button'
+    },
+    {
+      name: 'options',
+      type: 'array',
+      example: '`["option1", "option2"]`',
+      description:
+        'an array representing the different buttons. Can be an array of strings like `["val1", "val2"]` or an array of objects `[{ value: "val1", label: "Value 1" }, { value: "val2", label: "Value 2" }]`.'
+    }
+  ]
+};
 
 export default Radio;

--- a/packages/idyll-components/src/range.js
+++ b/packages/idyll-components/src/range.js
@@ -14,7 +14,14 @@ class Range extends React.PureComponent {
   render() {
     const { value, min, max, step } = this.props;
     return (
-      <input type="range" onChange={this.handleChange.bind(this)} value={value} min={min} max={max} step={step} />
+      <input
+        type="range"
+        onChange={this.handleChange.bind(this)}
+        value={value}
+        min={min}
+        max={max}
+        step={step}
+      />
     );
   }
 }
@@ -27,25 +34,35 @@ Range.defaultProps = {
 };
 
 Range._idyll = {
-  name: "Range",
-  tagType: "closed",
-  props: [{
-    name: "value",
-    type: "number",
-    example: "x"
-  }, {
-    name: "min",
-    type: "number",
-    example: '0'
-  }, {
-    name: "max",
-    type: "number",
-    example: '100'
-  }, {
-    name: "step",
-    type: "number",
-    example: '1'
-  }]
-}
+  name: 'Range',
+  tagType: 'closed',
+  props: [
+    {
+      name: 'value',
+      type: 'number',
+      example: 'x',
+      description:
+        'The value to display; if this is a variable, the variable will automatically be updated when the slider is moved.'
+    },
+    {
+      name: 'min',
+      type: 'number',
+      example: '0',
+      description: 'The minimum value.'
+    },
+    {
+      name: 'max',
+      type: 'number',
+      example: '100',
+      description: 'The maximum value.'
+    },
+    {
+      name: 'step',
+      type: 'number',
+      example: '1',
+      description: 'The granularity of the slider.'
+    }
+  ]
+};
 
 export default Range;

--- a/packages/idyll-components/src/scroller.js
+++ b/packages/idyll-components/src/scroller.js
@@ -23,7 +23,7 @@ const styles = {
     top: '50%',
     transform: 'translateY(-50%)'
   }
-}
+};
 
 let id = 0;
 
@@ -56,9 +56,8 @@ class Scroller extends React.Component {
       })
       .onStepEnter(this.handleStepEnter.bind(this))
       // .onStepExit(handleStepExit)
-      .onContainerEnter(this.handleContainerEnter.bind(this))
-      //.onContainerExit(this.handleContainerExit.bind(this));
-
+      .onContainerEnter(this.handleContainerEnter.bind(this));
+    //.onContainerExit(this.handleContainerExit.bind(this));
 
     // setup resize event
     window.addEventListener('resize', this.handleResize.bind(this));
@@ -79,30 +78,48 @@ class Scroller extends React.Component {
   handleResize() {
     this.setState({
       graphicHeight: window.innerHeight + 'px',
-      graphicWidth: window.innerWidth + 'px',
+      graphicWidth: window.innerWidth + 'px'
     });
   }
 
   handleContainerEnter(response) {
-    if (this.props.disableScroll && (!this.props.currentStep || this.props.currentStep < Object.keys(this.SCROLL_STEP_MAP).length - 1)) {
+    if (
+      this.props.disableScroll &&
+      (!this.props.currentStep ||
+        this.props.currentStep < Object.keys(this.SCROLL_STEP_MAP).length - 1)
+    ) {
       d3.select('body').style('overflow', 'hidden');
     }
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.disableScroll && this.props.currentStep !== nextProps.currentStep) {
+    if (
+      nextProps.disableScroll &&
+      this.props.currentStep !== nextProps.currentStep
+    ) {
       d3.selectAll(`#idyll-scroll-${this.id} .idyll-step`)
-        .filter(function (d, i) { return i === nextProps.currentStep; })
+        .filter(function(d, i) {
+          return i === nextProps.currentStep;
+        })
         .node()
         .scrollIntoView({ behavior: 'smooth' });
     }
-    if (nextProps.disableScroll && this.props.currentState !== nextProps.currentState) {
+    if (
+      nextProps.disableScroll &&
+      this.props.currentState !== nextProps.currentState
+    ) {
       d3.selectAll(`#idyll-scroll-${this.id} .idyll-step`)
-        .filter((d, i) => { return nextProps.currentState === this.SCROLL_NAME_MAP[i] })
+        .filter((d, i) => {
+          return nextProps.currentState === this.SCROLL_NAME_MAP[i];
+        })
         .node()
         .scrollIntoView({ behavior: 'smooth' });
     }
-    if (nextProps.disableScroll && (!nextProps.currentStep || nextProps.currentStep < Object.keys(this.SCROLL_STEP_MAP).length - 1)) {
+    if (
+      nextProps.disableScroll &&
+      (!nextProps.currentStep ||
+        nextProps.currentStep < Object.keys(this.SCROLL_STEP_MAP).length - 1)
+    ) {
       d3.select('body').style('overflow', 'hidden');
     }
   }
@@ -116,37 +133,47 @@ class Scroller extends React.Component {
     const { hasError, updateProps, idyll, children, ...props } = this.props;
     const { graphicHeight, graphicWidth } = this.state;
 
-    const graphicChildren = filterChildren(
-      children,
-      (c) => {
-        return c.type.name && c.type.name.toLowerCase() === 'graphic';
-      }
-    );
+    const graphicChildren = filterChildren(children, c => {
+      return c.type.name && c.type.name.toLowerCase() === 'graphic';
+    });
 
     return (
-      <div ref={(ref) => this.ref = ref} className="idyll-scroll" id={`idyll-scroll-${this.id}`}
-        style={Object.assign({ position: 'relative' })}>
-        {
-          (graphicChildren && graphicChildren.length) ?
-            <div className="idyll-scroll-graphic"
-              style={Object.assign({ height: graphicHeight }, styles.SCROLL_GRAPHIC)} >
-              <div style={Object.assign({ width: graphicWidth }, styles.SCROLL_GRAPHIC_INNER)}>
-                {graphicChildren}
-              </div>
-            </div> : null
-        }
+      <div
+        ref={ref => (this.ref = ref)}
+        className="idyll-scroll"
+        id={`idyll-scroll-${this.id}`}
+        style={Object.assign({ position: 'relative' })}
+      >
+        {graphicChildren && graphicChildren.length ? (
+          <div
+            className="idyll-scroll-graphic"
+            style={Object.assign(
+              { height: graphicHeight },
+              styles.SCROLL_GRAPHIC
+            )}
+          >
+            <div
+              style={Object.assign(
+                { width: graphicWidth },
+                styles.SCROLL_GRAPHIC_INNER
+              )}
+            >
+              {graphicChildren}
+            </div>
+          </div>
+        ) : null}
         <TextContainer idyll={idyll}>
           <div className="idyll-scroll-text">
-            {mapChildren(filterChildren(
-              children,
-              (c) => {
+            {mapChildren(
+              filterChildren(children, c => {
                 return !c.type.name || c.type.name.toLowerCase() === 'step';
+              }),
+              c => {
+                return React.cloneElement(c, {
+                  registerStep: this.registerStep.bind(this)
+                });
               }
-            ), (c) => {
-              return React.cloneElement(c, {
-                registerStep: this.registerStep.bind(this)
-              });
-            })}
+            )}
           </div>
         </TextContainer>
       </div>
@@ -154,24 +181,31 @@ class Scroller extends React.Component {
   }
 }
 
-
 Scroller._idyll = {
-  name: "Scroller",
-  tagType: "open",
-  children: [`
+  name: 'Scroller',
+  tagType: 'open',
+  children: [
+    `
   [Graphic] This graphic stays fixed in the background.[/Graphic]
   [Step]This is the content for step 1[/Step]
   [Step]This is the content for step 2[/Step]
-  [Step]This is the content for step 3[/Step]`],
-  props: [{
-    name: "currentStep",
-    type: "integer",
-    example: "0"
-  }, {
-    name: "currentState",
-    type: "object",
-    example: "`{}`"
-  }]
-}
+  [Step]This is the content for step 3[/Step]`
+  ],
+  props: [
+    {
+      name: 'currentStep',
+      type: 'integer',
+      example: '0',
+      description: 'The index of the currently selected step.'
+    },
+    {
+      name: 'currentState',
+      type: 'object',
+      example: '`{}`',
+      description:
+        'The state value associated with the currently selected step. Note you must set the state property on the step components for this value to update.'
+    }
+  ]
+};
 
 export default Scroller;

--- a/packages/idyll-components/src/select.js
+++ b/packages/idyll-components/src/select.js
@@ -15,11 +15,19 @@ class Select extends React.PureComponent {
     const { idyll, hasError, updateProps, ...props } = this.props;
     return (
       <select onChange={this.onChange} {...props}>
-        {this.props.options.map((d) => {
+        {this.props.options.map(d => {
           if (typeof d === 'string') {
-            return <option key={d} value={d}>{d}</option>;
+            return (
+              <option key={d} value={d}>
+                {d}
+              </option>
+            );
           }
-          return <option key={d.label || d.value} value={d.value}>{d.label || d.value}</option>;
+          return (
+            <option key={d.label || d.value} value={d.value}>
+              {d.label || d.value}
+            </option>
+          );
         })}
       </select>
     );
@@ -28,19 +36,25 @@ class Select extends React.PureComponent {
 
 Select.defaultProps = {
   options: []
-}
+};
 
 Select._idyll = {
-  name: "Select",
-  tagType: "closed",
-  props: [{
-    name: "value",
-    type: "string",
-    example: "x"
-  }, {
-    name: "options",
-    type: "array",
-    example: '`["option1", "option2"]`'
-  }]
-}
+  name: 'Select',
+  tagType: 'closed',
+  props: [
+    {
+      name: 'value',
+      type: 'string',
+      example: 'x',
+      description: 'The currently selected value.'
+    },
+    {
+      name: 'options',
+      type: 'array',
+      example: '`["option1", "option2"]`',
+      description:
+        'An array representing the different options. Can be an array of strings like `["val1", "val2"]` or an array of objects `[{ value: "val1", label: "Value 1" }, { value: "val2", label: "Value 2" }]`.'
+    }
+  ]
+};
 export default Select;

--- a/packages/idyll-components/src/stepper.js
+++ b/packages/idyll-components/src/stepper.js
@@ -2,35 +2,34 @@ import React from 'react';
 const { filterChildren, mapChildren } = require('idyll-component-children');
 
 class Stepper extends React.PureComponent {
-
   constructor(props) {
     super(props);
     this.SCROLL_STEP_MAP = {};
     this.SCROLL_NAME_MAP = {};
   }
 
-
-  registerStep(elt, name, val)  {
+  registerStep(elt, name, val) {
     this.SCROLL_STEP_MAP[elt] = val;
     this.SCROLL_NAME_MAP[elt] = name;
   }
 
   getSteps() {
-    return filterChildren(
-        this.props.children || [],
-        (c) => {
-          return c.type.name && c.type.name.toLowerCase() === 'step';
-      }
-    ) || []
+    return (
+      filterChildren(this.props.children || [], c => {
+        return c.type.name && c.type.name.toLowerCase() === 'step';
+      }) || []
+    );
   }
 
   next() {
-    this.props.updateProps({ currentStep: (this.props.currentStep + 1) % (this.getSteps().length) });
+    this.props.updateProps({
+      currentStep: (this.props.currentStep + 1) % this.getSteps().length
+    });
   }
   previous() {
     let newStep = this.props.currentStep - 1;
     if (newStep < 0) {
-      newStep = (this.getSteps().length) + newStep;
+      newStep = this.getSteps().length + newStep;
     }
 
     this.props.updateProps({ currentStep: newStep });
@@ -40,12 +39,9 @@ class Stepper extends React.PureComponent {
     const { currentState, currentStep } = this.props;
     const steps = this.getSteps();
     if (currentState) {
-      return filterChildren(
-        steps,
-        (c) => {
-          return c.props.state === currentState
-        }
-      )[0];
+      return filterChildren(steps, c => {
+        return c.props.state === currentState;
+      })[0];
     }
     return steps[currentStep % steps.length];
   }
@@ -53,40 +49,39 @@ class Stepper extends React.PureComponent {
   render() {
     const { children, height, ...props } = this.props;
     return (
-      <div className="idyll-stepper" style={{position: 'relative', height: height}}>
+      <div
+        className="idyll-stepper"
+        style={{ position: 'relative', height: height }}
+      >
         <div className="idyll-step-graphic">
-          {filterChildren(
-            children,
-            (c) => {
-              return c.type.name && c.type.name.toLowerCase() === 'graphic';
-            }
-          )}
+          {filterChildren(children, c => {
+            return c.type.name && c.type.name.toLowerCase() === 'graphic';
+          })}
         </div>
         <div className="idyll-step-content">
-          {
-            mapChildren(this.getSelectedStep(), (c) => {
-              return React.cloneElement(c, {
-                registerStep: this.registerStep.bind(this)
-              })
-            })
-          }
+          {mapChildren(this.getSelectedStep(), c => {
+            return React.cloneElement(c, {
+              registerStep: this.registerStep.bind(this)
+            });
+          })}
         </div>
-        {mapChildren(filterChildren(
-          children,
-          (c) => {
-            return c.type.name && c.type.name.toLowerCase() === 'steppercontrol';
+        {mapChildren(
+          filterChildren(children, c => {
+            return (
+              c.type.name && c.type.name.toLowerCase() === 'steppercontrol'
+            );
+          }),
+          c => {
+            return React.cloneElement(c, {
+              next: this.next.bind(this),
+              previous: this.previous.bind(this)
+            });
           }
-        ), (c) => {
-          return React.cloneElement(c, {
-            next: this.next.bind(this),
-            previous: this.previous.bind(this)
-          })
-        })}
+        )}
       </div>
     );
   }
 }
-
 
 Stepper.defaultProps = {
   currentStep: 0,
@@ -94,16 +89,21 @@ Stepper.defaultProps = {
 };
 
 Stepper._idyll = {
-  name: "Stepper",
-  tagType: "open",
-  children: [`
+  name: 'Stepper',
+  tagType: 'open',
+  children: [
+    `
 [Step]This is the content for step 1[/Step]
 [Step]This is the content for step 2[/Step]
-[Step]This is the content for step 3[/Step]`],
-  props: [{
-    name: "currentStep",
-    type: "number",
-    example: '0'
-  }]
-}
+[Step]This is the content for step 3[/Step]`
+  ],
+  props: [
+    {
+      name: 'currentStep',
+      type: 'number',
+      example: '0',
+      description: 'The index of the currently selected step.'
+    }
+  ]
+};
 export default Stepper;

--- a/packages/idyll-components/src/text-input.js
+++ b/packages/idyll-components/src/text-input.js
@@ -13,20 +13,21 @@ class TextInput extends React.PureComponent {
 
   render() {
     const { idyll, hasError, updateProps, ...props } = this.props;
-    return (
-      <input type="text" onChange={this.onChange} {...props} />
-    );
+    return <input type="text" onChange={this.onChange} {...props} />;
   }
 }
 
 TextInput._idyll = {
-  name: "TextInput",
-  tagType: "closed",
-  props: [{
-    name: "value",
-    type: "string",
-    example: '"Hello"'
-  }]
-}
+  name: 'TextInput',
+  tagType: 'closed',
+  props: [
+    {
+      name: 'value',
+      type: 'string',
+      example: '"Hello"',
+      description: 'The current value of the text entry box.'
+    }
+  ]
+};
 
 export default TextInput;

--- a/packages/idyll-components/src/youtube.js
+++ b/packages/idyll-components/src/youtube.js
@@ -9,7 +9,7 @@ class YoutubeComponent extends React.Component {
     super(props);
     this.state = {
       mounted: false
-    }
+    };
   }
 
   componentDidMount() {
@@ -25,9 +25,14 @@ class YoutubeComponent extends React.Component {
     const opts = {
       height: this.props.height,
       width: this.props.width,
-      playerVars: Object.assign({}, { // https://developers.google.com/youtube/player_parameters
-        autoplay: this.props.play
-      }, this.props.options)
+      playerVars: Object.assign(
+        {},
+        {
+          // https://developers.google.com/youtube/player_parameters
+          autoplay: this.props.play
+        },
+        this.props.options
+      )
     };
 
     return (
@@ -66,48 +71,64 @@ class YoutubeComponent extends React.Component {
     if (!this.props.audio) {
       this._player.mute();
     }
-    this._player.addEventListener('onStateChange', (event) => {
+    this._player.addEventListener('onStateChange', event => {
       if (event.data === YT_PLAYING && !this.props.play) {
-        this.props.updateProps({ play: true })
+        this.props.updateProps({ play: true });
       } else if (event.data === YT_PAUSED && this.props.play) {
-        this.props.updateProps({ play: false })
+        this.props.updateProps({ play: false });
       }
-    })
+    });
     this.props.onReady && this.props.onReady();
   }
 }
 
 YoutubeComponent._idyll = {
-  name: "Youtube",
-  tagType: "closed",
-  props: [{
-    name: "onReady",
-    type: "expression",
-    example: '`initialized = true`'
-  }, {
-    name: "width",
-    type: "integer",
-    example: '600'
-  }, {
-    name: "height",
-    type: "integer",
-    example: '400'
-  }, {
-    name: "audio",
-    type: "boolean",
-    example: 'true'
-  }, {
-    name: "play",
-    type: "boolean",
-    example: 'true'
-  }, {
-    name: "id",
-    type: "string",
-    example: '<youtube-video-id>'
-  }, {
-    name: "options",
-    type: "object",
-    example: '`{}`'
-  }, ]
-}
+  name: 'Youtube',
+  tagType: 'closed',
+  props: [
+    {
+      name: 'onReady',
+      type: 'expression',
+      example: '`initialized = true`',
+      description: 'Callback triggered when the video is ready to play.'
+    },
+    {
+      name: 'width',
+      type: 'integer',
+      example: '600',
+      description: 'Width of the video.'
+    },
+    {
+      name: 'height',
+      type: 'integer',
+      example: '400',
+      description: 'Height of the video.'
+    },
+    {
+      name: 'audio',
+      type: 'boolean',
+      example: 'true',
+      description: 'Is the audio turned on? Default: true'
+    },
+    {
+      name: 'play',
+      type: 'boolean',
+      example: 'true',
+      description: 'Is the video playing? Default: false'
+    },
+    {
+      name: 'id',
+      type: 'string',
+      example: '<youtube-video-id>',
+      description: 'YouTube video id. Required.'
+    },
+    {
+      name: 'options',
+      type: 'object',
+      example: '`{}`',
+      description:
+        'Dictionary of extra options. See YouTube docs for all options.'
+    }
+  ]
+};
 export default YoutubeComponent;

--- a/packages/idyll-docs/idyll-components/contents.js
+++ b/packages/idyll-docs/idyll-components/contents.js
@@ -252,27 +252,41 @@ const components = [
               'The meta component adds context to the page template when building your app for publication. The following variables are available and will be inserted as `<meta>` properties into the head of your HTML page if you define them:',
             idyllProps: [
               {
-                title: 'the page title.'
+                name: 'title',
+                type: 'string',
+                description: 'the page title.'
               },
               {
-                description: 'a short description of your project.'
+                name: 'description',
+                type: 'string',
+                description: 'A short description of your project.'
               },
               {
-                url: 'the canonical URL from this project.'
+                name: 'url',
+                type: 'string',
+                description: 'The canonical URL from this project.'
               },
               {
-                twitterHandle:
-                  "the author's twitter handle, it will create a link in the twitter card."
+                name: 'twitterHandle',
+                type: 'string',
+                description:
+                  "The author's twitter handle, it will create a link in the twitter card."
               },
               {
-                shareImageUrl:
-                  'the URL of an image to be shared on social media (twitter cards, etc.). This must be a fully qualified URL, e.g. https://idyll-lang.github.io/images/logo.png.'
+                name: 'shareImageUrl',
+                type: 'string',
+                description:
+                  'The URL of an image to be shared on social media (twitter cards, etc.). This must be a fully qualified URL, e.g. https://idyll-lang.github.io/images/logo.png.'
               },
               {
-                shareImageWidth: 'the width of the share image in pixels.'
+                name: 'shareImageWidth',
+                type: 'string',
+                description: 'The width of the share image in pixels.'
               },
               {
-                shareImageHeight: 'the height of the share image in pixels.'
+                name: 'shareImageHeight',
+                type: 'string',
+                description: 'The height of the share image in pixels.'
               }
             ]
           }

--- a/packages/idyll-docs/idyll-components/contents.js
+++ b/packages/idyll-docs/idyll-components/contents.js
@@ -1,203 +1,92 @@
+import * as COMPONENTS from 'idyll-components';
+
 const components = [
   {
-    "Layout": {
-      "description": "These components help manage page layout, for example putting text in the `Aside` component will render it in the article margin instead of inline with the rest of your text.",
-      "components": [
+    Layout: {
+      description:
+        'These components help manage page layout, for example putting text in the `Aside` component will render it in the article margin instead of inline with the rest of your text.',
+      components: [
         {
-          "Aside": {
-            "description": "Content inside of an aside component will be displayed in the margin of your document. For example, the [consumer complaints](https://mathisonian.github.io/consumer-complaints/) article uses the `Aside` component to display a small chart and caption:",
-            "image": "aside.png",
-            "thumbnail": "aside.png"
+          Aside: {
+            description:
+              'Content inside of an aside component will be displayed in the margin of your document. For example, the [consumer complaints](https://mathisonian.github.io/consumer-complaints/) article uses the `Aside` component to display a small chart and caption:',
+            image: 'aside.png',
+            thumbnail: 'aside.png',
+            component: COMPONENTS.Aside
           }
         },
         {
-          "FullWidth": {
-            "description": "A `FullWidth` component will break out of the text container and expand to fill the full width of the reader's browser.",
-            "image": "feature.png",
-            "thumbnail": "feature.png",
-            "idyllProps": [
-            ]
+          FullWidth: {
+            description:
+              "A `FullWidth` component will break out of the text container and expand to fill the full width of the reader's browser.",
+            image: 'feature.png',
+            thumbnail: 'feature.png',
+            component: COMPONENTS.FullWidth,
+            idyllProps: []
           }
         },
         {
-          "Fixed": {
-            "description": "Content inside of a `fixed` component will be locked in place, even when the rest of the document scrolls. The [scroll](https://idyll-lang.github.io/idyll/scroll) example uses the `fixed` component to keep the dynamic chart in place:",
-            "thumbnail": "fixed.gif",
-            "image": "fixed.gif"
+          Fixed: {
+            description:
+              'Content inside of a `fixed` component will be locked in place, even when the rest of the document scrolls. The [scroll](https://idyll-lang.github.io/idyll/scroll) example uses the `fixed` component to keep the dynamic chart in place:',
+            thumbnail: 'fixed.gif',
+            image: 'fixed.gif',
+            component: COMPONENTS.Fixed
           }
         },
         {
-          "Float": {
-            "description": "Content inside of a float will use the CSS `float` attribute to float to the left or right of its parent container.",
-            "thumbnail": "float.png",
-            "idyllProps": [
+          Float: {
+            description:
+              'Content inside of a float will use the CSS `float` attribute to float to the left or right of its parent container.',
+            thumbnail: 'float.png',
+            component: COMPONENTS.Float,
+            idyllProps: [
               {
-                "position": "the float position: left or right."
+                position: 'the float position: left or right.'
               },
               {
-                "width": "the width of the component, specified in pixels or percentage."
+                width:
+                  'the width of the component, specified in pixels or percentage.'
               }
             ]
           }
         },
         {
-          "Inline": {
-            "thumbnail": "inline.png",
-            "description": "The `inline` component adds the `display: inline-block` style property, so that items inside of `inline` component will be displayed next to each other. For example, this code will display three images side by side:"
+          Inline: {
+            thumbnail: 'inline.png',
+            description:
+              'The `inline` component adds the `display: inline-block` style property, so that items inside of `inline` component will be displayed next to each other. For example, this code will display three images side by side:',
+            component: COMPONENTS.Inline
           }
         },
         {
-          "Scroller": {
-            "description": "The `Scroller` component is used to create scroll-based presentations. See [this example](https://mathisonian.github.io/idyll/scaffolding-interactives/) for more details.",
-            "thumbnail": "scroller.gif",
-            "image": "scroller.gif",
-            "idyllProps": [
+          Scroller: {
+            description:
+              'The `Scroller` component is used to create scroll-based presentations. See [this example](https://mathisonian.github.io/idyll/scaffolding-interactives/) for more details.',
+            thumbnail: 'scroller.gif',
+            image: 'scroller.gif',
+            component: COMPONENTS.Scroller,
+            idyllProps: [
               {
-                "currentStep": "the index of the currently selected step."
+                currentStep: 'the index of the currently selected step.'
               },
               {
-                "currentState": "the state value associated with the currently selected step. Note you must set the state property on the step components for this value to update."
+                currentState:
+                  'the state value associated with the currently selected step. Note you must set the state property on the step components for this value to update.'
               }
             ]
           }
         },
         {
-          "Stepper": {
-            "description": "The `Step` component is used to create step-based presentations, like slideshows.  See [this example](https://mathisonian.github.io/idyll/scaffolding-interactives/) for more details.",
-            "thumbnail": "stepper.gif",
-            "image": "stepper.gif",
-            "idyllProps": [
+          Stepper: {
+            description:
+              'The `Step` component is used to create step-based presentations, like slideshows.  See [this example](https://mathisonian.github.io/idyll/scaffolding-interactives/) for more details.',
+            thumbnail: 'stepper.gif',
+            image: 'stepper.gif',
+            component: COMPONENTS.Stepper,
+            idyllProps: [
               {
-                "currentStep": "the index of the currently selected step."
-              }
-            ]
-          }
-        },
-      ]
-    }
-  },
-  {
-    "Input": {
-      "description": "The components are used to accept reader input and update variables in response.",
-      "components": [
-        {
-          "Action": {
-            "thumbnail": "action.png",
-            "description": "The `action` component allows you to add event handlers to text. For example:",
-            "idyllProps": [
-              {
-                "onClick": null
-              },
-              {
-                "onMouseEnter": null
-              },
-              {
-                "onMouseLeave": null
-              }
-            ]
-          }
-        },
-        {
-          "Boolean": {
-            "thumbnail": "boolean.png",
-            "image": "boolean.gif",
-            "description": "This will display a checkbox.",
-            "idyllProps": [
-              {
-                "value": "A value for the checkbox. If this value is truthy, the checkbox will be shown."
-              }
-            ]
-          }
-        },
-        {
-          "Button": {
-            "thumbnail": "button.png",
-            "description": "This will display a button. To control what happens when the button is clicked, add an `onClick` property:",
-            "image": "button.gif",
-            "idyllProps": [
-              {
-                "onClick": null
-              }
-            ]
-          }
-        },
-        {
-          "Dynamic": {
-            "thumbnail": "dynamic.png",
-            "description": "This will render a dynamic variable to the screen.",
-            "image": "dynamic.gif",
-            "idyllProps": [
-              {
-                "value": "The value to display."
-              },
-              {
-                "max": "The maximum value."
-              },
-              {
-                "min": "The minimum value."
-              },
-              {
-                "step": "The granularity of the changes."
-              }
-            ]
-          }
-        },
-        {
-          "Radio": {
-            "thumbnail": "radio.png",
-            "description": "This component displays a set of radio buttons.",
-            "idyllProps": [
-              {
-                "value": "the value of the \"checked\" radio button"
-              },
-              {
-                "options": "an array representing the different buttons. Can be an array of strings like `[\"val1\", \"val2\"]` or an array of objects `[{ value: \"val1\", label: \"Value 1\" }, { value: \"val2\", label: \"Value 2\" }]`."
-              }
-            ]
-          }
-        },
-        {
-          "Range": {
-            "thumbnail": "range.png",
-            "description": "This component displays a range slider.",
-            "image": "displayvar.gif",
-            "idyllProps": [
-              {
-                "value": "The value to display; if this is a variable, the variable will automatically be updated when the slider is moved."
-              },
-              {
-                "max": "The maximum value."
-              },
-              {
-                "min": "The minimum value."
-              },
-              {
-                "step": "The granularity of the slider."
-              }
-            ]
-          }
-        },
-        {
-          "Select": {
-            "thumbnail": "select.png",
-            "description": "This component displays a selection dropdown.",
-            "idyllProps": [
-              {
-                "value": "the currently selected value."
-              },
-              {
-                "options": "an array representing the different options. Can be an array of strings like `[\"val1\", \"val2\"]` or an array of objects `[{ value: \"val1\", label: \"Value 1\" }, { value: \"val2\", label: \"Value 2\" }]`."
-              }
-            ]
-          }
-        },
-        {
-          "TextInput": {
-            "thumbnail": "text-input.png",
-            "description": "A user-editable text input field.",
-            "idyllProps": [
-              {
-                "value": "the current value of the text entry box."
+                currentStep: 'the index of the currently selected step.'
               }
             ]
           }
@@ -206,113 +95,142 @@ const components = [
     }
   },
   {
-    "Presentation": {
-      "description": "These components render something to the screen, for example the `Chart` component takes data as input and can display several types of charts.",
-      "components": [
+    Input: {
+      description:
+        'The components are used to accept reader input and update variables in response.',
+      components: [
         {
-          "Chart": {
-            "thumbnail": "chart.png",
-            "description": "This will display a chart.",
-            "image": "chart.png",
-            "idyllProps": [
+          Action: {
+            thumbnail: 'action.png',
+            component: COMPONENTS.Action,
+            description:
+              'The `action` component allows you to add event handlers to text. For example:',
+            idyllProps: [
               {
-                "data": "A JSON object containing the data for this chart. It uses the [victory](https://formidable.com/open-source/victory/docs) library to handle rendering, so see those docs for more information on what types of data can be passed in."
+                onClick: null
               },
               {
-                "type": "The type of the chart to display, can be `line`, `scatter`, `bar`, `pie`, or `time`. The time type is a line chart that expects the `x` values in the data to be in the temporal domain."
+                onMouseEnter: null
               },
               {
-                "domain": "The chart extent along the x dimension. *Default is [0, 1]*"
-              },
-              {
-                "range": "The chart extent along the y dimension. *Default is [0, 1]*"
-              },
-              {
-                "theme": "The theme to use, e.g. `grayscale` or `material` or a custom object (see [an example here](https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/victory-theme/grayscale.js))"
+                onMouseLeave: null
               }
             ]
           }
         },
         {
-          "Conditional": {
-            "thumbnail": "conditional.png",
-            "description": "This component will conditionally display its children.",
-            "idyllProps": [
+          Boolean: {
+            thumbnail: 'boolean.png',
+            image: 'boolean.gif',
+            component: COMPONENTS.Boolean,
+            description: 'This will display a checkbox.',
+            idyllProps: [
               {
-                "if": "An expression; if this evaluates to true, the children will be rendered, otherwise nothing will be drawn to the screen"
+                value:
+                  'A value for the checkbox. If this value is truthy, the checkbox will be shown.'
               }
             ]
           }
         },
         {
-          "Display": {
-            "thumbnail": "display.png",
-            "description": "This will render the value of a variable to the screen. It is mostly useful for debugging:",
-            "image": "displayvar.gif"
-          }
-        },
-        {
-          "Equation": {
-            "thumbnail": "equation.png",
-            "description": "This uses [KaTeX](https://github.com/Khan/KaTeX) to typeset mathematical equations. Example:",
-            "image": "equation.png"
-          }
-        },
-        {
-          "Gist": {
-            "thumbnail": "gist.png",
-            "description": "Embed a github gist",
-            "image": "gist.png"
-          }
-        },
-        {
-          "Header": {
-            "thumbnail": "header.png",
-            "description": "This component makes it easy to add a title, subtitle, and byline to your article:",
-            "image": "header.png"
-          }
-        },
-        {
-          "Link": {
-            "thumbnail": "link.png",
-            "description": "This component just acts as syntactic sugar for displaying links inline in your text."
-          }
-        },
-        {
-          "SVG": {
-            "thumbnail": "svg.png",
-            "description": "This component will display an SVG file inline using https://github.com/matthewwithanm/react-inlinesvg. This makes it easy to style the SVG with css, as opposed to displaying the svg inside of an image tag."
-          }
-        },
-        {
-          "Table": {
-            "thumbnail": "table.png",
-            "description": "Display tabular data. Uses https://github.com/react-tools/react-table under the hood to render the table.",
-            "image": "table.png"
-          }
-        },
-        {
-          "Youtube": {
-            "thumbnail": "youtube.png",
-            "description": "Plays a video from YouTube. All of the parameters are optional except for id, which must be provided. See all available options at https://developers.google.com/youtube/player_parameters",
-            "idyllProps": [
+          Button: {
+            thumbnail: 'button.png',
+            description:
+              'This will display a button. To control what happens when the button is clicked, add an `onClick` property:',
+            image: 'button.gif',
+            component: COMPONENTS.Button,
+            idyllProps: [
               {
-                "id": "YouTube video id. Required."
+                onClick: null
+              }
+            ]
+          }
+        },
+        {
+          Dynamic: {
+            thumbnail: 'dynamic.png',
+            description: 'This will render a dynamic variable to the screen.',
+            image: 'dynamic.gif',
+            component: COMPONENTS.Dynamic,
+            idyllProps: [
+              {
+                value: 'The value to display.'
               },
               {
-                "width": "width of the video"
+                max: 'The maximum value.'
               },
               {
-                "height": "height of the video"
+                min: 'The minimum value.'
               },
               {
-                "play": "Is the video playing? Default: false"
+                step: 'The granularity of the changes.'
+              }
+            ]
+          }
+        },
+        {
+          Radio: {
+            thumbnail: 'radio.png',
+            component: COMPONENTS.Radio,
+            description: 'This component displays a set of radio buttons.',
+            idyllProps: [
+              {
+                value: 'the value of the "checked" radio button'
               },
               {
-                "audio": "Is the audio turned on? Default: true"
+                options:
+                  'an array representing the different buttons. Can be an array of strings like `["val1", "val2"]` or an array of objects `[{ value: "val1", label: "Value 1" }, { value: "val2", label: "Value 2" }]`.'
+              }
+            ]
+          }
+        },
+        {
+          Range: {
+            thumbnail: 'range.png',
+            component: COMPONENTS.Range,
+            description: 'This component displays a range slider.',
+            image: 'displayvar.gif',
+            idyllProps: [
+              {
+                value:
+                  'The value to display; if this is a variable, the variable will automatically be updated when the slider is moved.'
               },
               {
-                "options": "Dictionary of extra options. See YouTube docs for all options."
+                max: 'The maximum value.'
+              },
+              {
+                min: 'The minimum value.'
+              },
+              {
+                step: 'The granularity of the slider.'
+              }
+            ]
+          }
+        },
+        {
+          Select: {
+            thumbnail: 'select.png',
+            component: COMPONENTS.Select,
+            description: 'This component displays a selection dropdown.',
+            idyllProps: [
+              {
+                value: 'the currently selected value.'
+              },
+              {
+                options:
+                  'an array representing the different options. Can be an array of strings like `["val1", "val2"]` or an array of objects `[{ value: "val1", label: "Value 1" }, { value: "val2", label: "Value 2" }]`.'
+              }
+            ]
+          }
+        },
+        {
+          TextInput: {
+            thumbnail: 'text-input.png',
+            component: COMPONENTS.TextInput,
+            description: 'A user-editable text input field.',
+            idyllProps: [
+              {
+                value: 'the current value of the text entry box.'
               }
             ]
           }
@@ -321,51 +239,202 @@ const components = [
     }
   },
   {
-    "Helpers": {
-      "description": "These components don't affect the page content, but help with common tasks. The `Analytics` component makes it easy to add Google Analytics to your page.",
-      "components": [
+    Presentation: {
+      description:
+        'These components render something to the screen, for example the `Chart` component takes data as input and can display several types of charts.',
+      components: [
         {
-          "Analytics": {
-            "thumbnail": "analytics.png",
-            "description": "This component makes it easy to insert a Google Analytics code on your page."
-          }
-        },
-        {
-          "Meta": {
-            "thumbnail": "meta.png",
-            "description": "The meta component adds context to the page template when building your app for publication. The following variables are available and will be inserted as `<meta>` properties into the head of your HTML page if you define them:",
-            "idyllProps": [
+          Chart: {
+            thumbnail: 'chart.png',
+            component: COMPONENTS.Chart,
+            description: 'This will display a chart.',
+            image: 'chart.png',
+            idyllProps: [
               {
-                "title": "the page title."
+                data:
+                  'A JSON object containing the data for this chart. It uses the [victory](https://formidable.com/open-source/victory/docs) library to handle rendering, so see those docs for more information on what types of data can be passed in.'
               },
               {
-                "description": "a short description of your project."
+                type:
+                  'The type of the chart to display, can be `line`, `scatter`, `bar`, `pie`, or `time`. The time type is a line chart that expects the `x` values in the data to be in the temporal domain.'
               },
               {
-                "url": "the canonical URL from this project."
+                domain:
+                  'The chart extent along the x dimension. *Default is [0, 1]*'
               },
               {
-                "twitterHandle": "the author's twitter handle, it will create a link in the twitter card."
+                range:
+                  'The chart extent along the y dimension. *Default is [0, 1]*'
               },
               {
-                "shareImageUrl": "the URL of an image to be shared on social media (twitter cards, etc.). This must be a fully qualified URL, e.g. https://idyll-lang.github.io/images/logo.png."
-              },
-              {
-                "shareImageWidth": "the width of the share image in pixels."
-              },
-              {
-                "shareImageHeight": "the height of the share image in pixels."
+                theme:
+                  'The theme to use, e.g. `grayscale` or `material` or a custom object (see [an example here](https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/victory-theme/grayscale.js))'
               }
             ]
           }
         },
         {
-          "Preload": {
-            "thumbnail": "preload.png",
-            "description": "This will preload an array of images, useful if you want to show them later on in the article and not have a loading flash.",
-            "idyllProps": [
+          Conditional: {
+            thumbnail: 'conditional.png',
+            description:
+              'This component will conditionally display its children.',
+            component: COMPONENTS.Conditional,
+            idyllProps: [
               {
-                "images": "the array of images: `[\"image-url-1.png\", \"image-url-2.jpg\"]`."
+                if:
+                  'An expression; if this evaluates to true, the children will be rendered, otherwise nothing will be drawn to the screen'
+              }
+            ]
+          }
+        },
+        {
+          Display: {
+            thumbnail: 'display.png',
+            component: COMPONENTS.Display,
+            description:
+              'This will render the value of a variable to the screen. It is mostly useful for debugging:',
+            image: 'displayvar.gif'
+          }
+        },
+        {
+          Equation: {
+            thumbnail: 'equation.png',
+            component: COMPONENTS.Equation,
+            description:
+              'This uses [KaTeX](https://github.com/Khan/KaTeX) to typeset mathematical equations. Example:',
+            image: 'equation.png'
+          }
+        },
+        {
+          Gist: {
+            thumbnail: 'gist.png',
+            component: COMPONENTS.Gist,
+            description: 'Embed a github gist',
+            image: 'gist.png'
+          }
+        },
+        {
+          Header: {
+            thumbnail: 'header.png',
+            component: COMPONENTS.Header,
+            description:
+              'This component makes it easy to add a title, subtitle, and byline to your article:',
+            image: 'header.png'
+          }
+        },
+        {
+          Link: {
+            thumbnail: 'link.png',
+            component: COMPONENTS.Link,
+            description:
+              'This component just acts as syntactic sugar for displaying links inline in your text.'
+          }
+        },
+        {
+          SVG: {
+            thumbnail: 'svg.png',
+            component: COMPONENTS.SVG,
+            description:
+              'This component will display an SVG file inline using https://github.com/matthewwithanm/react-inlinesvg. This makes it easy to style the SVG with css, as opposed to displaying the svg inside of an image tag.'
+          }
+        },
+        {
+          Table: {
+            thumbnail: 'table.png',
+            component: COMPONENTS.Table,
+            description:
+              'Display tabular data. Uses https://github.com/react-tools/react-table under the hood to render the table.',
+            image: 'table.png'
+          }
+        },
+        {
+          Youtube: {
+            thumbnail: 'youtube.png',
+            component: COMPONENTS.Youtube,
+            description:
+              'Plays a video from YouTube. All of the parameters are optional except for id, which must be provided. See all available options at https://developers.google.com/youtube/player_parameters',
+            idyllProps: [
+              {
+                id: 'YouTube video id. Required.'
+              },
+              {
+                width: 'width of the video'
+              },
+              {
+                height: 'height of the video'
+              },
+              {
+                play: 'Is the video playing? Default: false'
+              },
+              {
+                audio: 'Is the audio turned on? Default: true'
+              },
+              {
+                options:
+                  'Dictionary of extra options. See YouTube docs for all options.'
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    Helpers: {
+      description:
+        "These components don't affect the page content, but help with common tasks. The `Analytics` component makes it easy to add Google Analytics to your page.",
+      components: [
+        {
+          Analytics: {
+            thumbnail: 'analytics.png',
+            component: COMPONENTS.Analytics,
+            description:
+              'This component makes it easy to insert a Google Analytics code on your page.'
+          }
+        },
+        {
+          Meta: {
+            thumbnail: 'meta.png',
+            component: COMPONENTS.Meta,
+            description:
+              'The meta component adds context to the page template when building your app for publication. The following variables are available and will be inserted as `<meta>` properties into the head of your HTML page if you define them:',
+            idyllProps: [
+              {
+                title: 'the page title.'
+              },
+              {
+                description: 'a short description of your project.'
+              },
+              {
+                url: 'the canonical URL from this project.'
+              },
+              {
+                twitterHandle:
+                  "the author's twitter handle, it will create a link in the twitter card."
+              },
+              {
+                shareImageUrl:
+                  'the URL of an image to be shared on social media (twitter cards, etc.). This must be a fully qualified URL, e.g. https://idyll-lang.github.io/images/logo.png.'
+              },
+              {
+                shareImageWidth: 'the width of the share image in pixels.'
+              },
+              {
+                shareImageHeight: 'the height of the share image in pixels.'
+              }
+            ]
+          }
+        },
+        {
+          Preload: {
+            thumbnail: 'preload.png',
+            component: COMPONENTS.Preload,
+            description:
+              'This will preload an array of images, useful if you want to show them later on in the article and not have a loading flash.',
+            idyllProps: [
+              {
+                images:
+                  'the array of images: `["image-url-1.png", "image-url-2.jpg"]`.'
               }
             ]
           }
@@ -375,28 +444,36 @@ const components = [
   }
 ];
 
-function slugify(text)
-{
-  return text.toString().split(/([A-Z][a-z]+)/).join('-').toLowerCase()
-    .replace(/\s+/g, '-')           // Replace spaces with -
-    .replace(/[^\w\-]+/g, '')       // Remove all non-word chars
-    .replace(/\-\-+/g, '-')         // Replace multiple - with single -
-    .replace(/^-+/, '')             // Trim - from start of text
-    .replace(/-+$/, '');            // Trim - from end of text
+function slugify(text) {
+  return text
+    .toString()
+    .split(/([A-Z][a-z]+)/)
+    .join('-')
+    .toLowerCase()
+    .replace(/\s+/g, '-') // Replace spaces with -
+    .replace(/[^\w\-]+/g, '') // Remove all non-word chars
+    .replace(/\-\-+/g, '-') // Replace multiple - with single -
+    .replace(/^-+/, '') // Trim - from start of text
+    .replace(/-+$/, ''); // Trim - from end of text
 }
 
 const indexedComponents = {};
-components.forEach((g) => {
-  Object.keys(g).map(key => g[key].components).forEach((comps) => {
-
-    comps.forEach((comp) => {
-      Object.keys(comp).forEach((key) => {
-        const slug = slugify(key);
-        indexedComponents[slug] = Object.assign({}, comp[key], { slug: slug, title: key, name: key });
-      })
-    })
-  })
-})
+components.forEach(g => {
+  Object.keys(g)
+    .map(key => g[key].components)
+    .forEach(comps => {
+      comps.forEach(comp => {
+        Object.keys(comp).forEach(key => {
+          const slug = slugify(key);
+          indexedComponents[slug] = Object.assign({}, comp[key], {
+            slug: slug,
+            title: key,
+            name: key
+          });
+        });
+      });
+    });
+});
 
 export { indexedComponents };
 export default components;

--- a/packages/idyll-docs/idyll-components/contents.js
+++ b/packages/idyll-docs/idyll-components/contents.js
@@ -20,9 +20,7 @@ const components = [
             description:
               "A `FullWidth` component will break out of the text container and expand to fill the full width of the reader's browser.",
             image: 'feature.png',
-            thumbnail: 'feature.png',
-            component: COMPONENTS.FullWidth,
-            idyllProps: []
+            thumbnail: 'feature.png'
           }
         },
         {
@@ -39,16 +37,7 @@ const components = [
             description:
               'Content inside of a float will use the CSS `float` attribute to float to the left or right of its parent container.',
             thumbnail: 'float.png',
-            component: COMPONENTS.Float,
-            idyllProps: [
-              {
-                position: 'the float position: left or right.'
-              },
-              {
-                width:
-                  'the width of the component, specified in pixels or percentage.'
-              }
-            ]
+            component: COMPONENTS.Float
           }
         },
         {
@@ -65,16 +54,7 @@ const components = [
               'The `Scroller` component is used to create scroll-based presentations. See [this example](https://mathisonian.github.io/idyll/scaffolding-interactives/) for more details.',
             thumbnail: 'scroller.gif',
             image: 'scroller.gif',
-            component: COMPONENTS.Scroller,
-            idyllProps: [
-              {
-                currentStep: 'the index of the currently selected step.'
-              },
-              {
-                currentState:
-                  'the state value associated with the currently selected step. Note you must set the state property on the step components for this value to update.'
-              }
-            ]
+            component: COMPONENTS.Scroller
           }
         },
         {
@@ -83,12 +63,7 @@ const components = [
               'The `Step` component is used to create step-based presentations, like slideshows.  See [this example](https://mathisonian.github.io/idyll/scaffolding-interactives/) for more details.',
             thumbnail: 'stepper.gif',
             image: 'stepper.gif',
-            component: COMPONENTS.Stepper,
-            idyllProps: [
-              {
-                currentStep: 'the index of the currently selected step.'
-              }
-            ]
+            component: COMPONENTS.Stepper
           }
         }
       ]
@@ -104,18 +79,7 @@ const components = [
             thumbnail: 'action.png',
             component: COMPONENTS.Action,
             description:
-              'The `action` component allows you to add event handlers to text. For example:',
-            idyllProps: [
-              {
-                onClick: null
-              },
-              {
-                onMouseEnter: null
-              },
-              {
-                onMouseLeave: null
-              }
-            ]
+              'The `action` component allows you to add event handlers to text. For example:'
           }
         },
         {
@@ -123,13 +87,7 @@ const components = [
             thumbnail: 'boolean.png',
             image: 'boolean.gif',
             component: COMPONENTS.Boolean,
-            description: 'This will display a checkbox.',
-            idyllProps: [
-              {
-                value:
-                  'A value for the checkbox. If this value is truthy, the checkbox will be shown.'
-              }
-            ]
+            description: 'This will display a checkbox.'
           }
         },
         {
@@ -138,12 +96,7 @@ const components = [
             description:
               'This will display a button. To control what happens when the button is clicked, add an `onClick` property:',
             image: 'button.gif',
-            component: COMPONENTS.Button,
-            idyllProps: [
-              {
-                onClick: null
-              }
-            ]
+            component: COMPONENTS.Button
           }
         },
         {
@@ -151,37 +104,14 @@ const components = [
             thumbnail: 'dynamic.png',
             description: 'This will render a dynamic variable to the screen.',
             image: 'dynamic.gif',
-            component: COMPONENTS.Dynamic,
-            idyllProps: [
-              {
-                value: 'The value to display.'
-              },
-              {
-                max: 'The maximum value.'
-              },
-              {
-                min: 'The minimum value.'
-              },
-              {
-                step: 'The granularity of the changes.'
-              }
-            ]
+            component: COMPONENTS.Dynamic
           }
         },
         {
           Radio: {
             thumbnail: 'radio.png',
             component: COMPONENTS.Radio,
-            description: 'This component displays a set of radio buttons.',
-            idyllProps: [
-              {
-                value: 'the value of the "checked" radio button'
-              },
-              {
-                options:
-                  'an array representing the different buttons. Can be an array of strings like `["val1", "val2"]` or an array of objects `[{ value: "val1", label: "Value 1" }, { value: "val2", label: "Value 2" }]`.'
-              }
-            ]
+            description: 'This component displays a set of radio buttons.'
           }
         },
         {
@@ -189,50 +119,21 @@ const components = [
             thumbnail: 'range.png',
             component: COMPONENTS.Range,
             description: 'This component displays a range slider.',
-            image: 'displayvar.gif',
-            idyllProps: [
-              {
-                value:
-                  'The value to display; if this is a variable, the variable will automatically be updated when the slider is moved.'
-              },
-              {
-                max: 'The maximum value.'
-              },
-              {
-                min: 'The minimum value.'
-              },
-              {
-                step: 'The granularity of the slider.'
-              }
-            ]
+            image: 'displayvar.gif'
           }
         },
         {
           Select: {
             thumbnail: 'select.png',
             component: COMPONENTS.Select,
-            description: 'This component displays a selection dropdown.',
-            idyllProps: [
-              {
-                value: 'the currently selected value.'
-              },
-              {
-                options:
-                  'an array representing the different options. Can be an array of strings like `["val1", "val2"]` or an array of objects `[{ value: "val1", label: "Value 1" }, { value: "val2", label: "Value 2" }]`.'
-              }
-            ]
+            description: 'This component displays a selection dropdown.'
           }
         },
         {
           TextInput: {
             thumbnail: 'text-input.png',
             component: COMPONENTS.TextInput,
-            description: 'A user-editable text input field.',
-            idyllProps: [
-              {
-                value: 'the current value of the text entry box.'
-              }
-            ]
+            description: 'A user-editable text input field.'
           }
         }
       ]
@@ -248,29 +149,7 @@ const components = [
             thumbnail: 'chart.png',
             component: COMPONENTS.Chart,
             description: 'This will display a chart.',
-            image: 'chart.png',
-            idyllProps: [
-              {
-                data:
-                  'A JSON object containing the data for this chart. It uses the [victory](https://formidable.com/open-source/victory/docs) library to handle rendering, so see those docs for more information on what types of data can be passed in.'
-              },
-              {
-                type:
-                  'The type of the chart to display, can be `line`, `scatter`, `bar`, `pie`, or `time`. The time type is a line chart that expects the `x` values in the data to be in the temporal domain.'
-              },
-              {
-                domain:
-                  'The chart extent along the x dimension. *Default is [0, 1]*'
-              },
-              {
-                range:
-                  'The chart extent along the y dimension. *Default is [0, 1]*'
-              },
-              {
-                theme:
-                  'The theme to use, e.g. `grayscale` or `material` or a custom object (see [an example here](https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/victory-theme/grayscale.js))'
-              }
-            ]
+            image: 'chart.png'
           }
         },
         {
@@ -278,13 +157,7 @@ const components = [
             thumbnail: 'conditional.png',
             description:
               'This component will conditionally display its children.',
-            component: COMPONENTS.Conditional,
-            idyllProps: [
-              {
-                if:
-                  'An expression; if this evaluates to true, the children will be rendered, otherwise nothing will be drawn to the screen'
-              }
-            ]
+            component: COMPONENTS.Conditional
           }
         },
         {
@@ -352,28 +225,7 @@ const components = [
             thumbnail: 'youtube.png',
             component: COMPONENTS.Youtube,
             description:
-              'Plays a video from YouTube. All of the parameters are optional except for id, which must be provided. See all available options at https://developers.google.com/youtube/player_parameters',
-            idyllProps: [
-              {
-                id: 'YouTube video id. Required.'
-              },
-              {
-                width: 'width of the video'
-              },
-              {
-                height: 'height of the video'
-              },
-              {
-                play: 'Is the video playing? Default: false'
-              },
-              {
-                audio: 'Is the audio turned on? Default: true'
-              },
-              {
-                options:
-                  'Dictionary of extra options. See YouTube docs for all options.'
-              }
-            ]
+              'Plays a video from YouTube. All of the parameters are optional except for id, which must be provided. See all available options at https://developers.google.com/youtube/player_parameters'
           }
         }
       ]
@@ -430,13 +282,7 @@ const components = [
             thumbnail: 'preload.png',
             component: COMPONENTS.Preload,
             description:
-              'This will preload an array of images, useful if you want to show them later on in the article and not have a loading flash.',
-            idyllProps: [
-              {
-                images:
-                  'the array of images: `["image-url-1.png", "image-url-2.jpg"]`.'
-              }
-            ]
+              'This will preload an array of images, useful if you want to show them later on in the article and not have a loading flash.'
           }
         }
       ]

--- a/packages/idyll-docs/pages/docs/component.js
+++ b/packages/idyll-docs/pages/docs/component.js
@@ -1,25 +1,24 @@
-import Link from 'next/link'
-import markdown from 'markdown-in-js'
-import Layout from '../../components/layout'
+import Link from 'next/link';
+import markdown from 'markdown-in-js';
+import Layout from '../../components/layout';
 import { indexedComponents } from '../../idyll-components/contents';
-import showdown from 'showdown'
+import showdown from 'showdown';
 import Parser from 'html-react-parser';
-import * as Examples from '../../idyll-components/examples'
+import * as Examples from '../../idyll-components/examples';
 
-showdown.setFlavor('github')
-const mdConverter = new showdown.Converter()
+showdown.setFlavor('github');
+const mdConverter = new showdown.Converter();
 
 function md2html(md, naked = false) {
-  if (!md) return md
-  let html = mdConverter.makeHtml(md)
-  if (naked) html = html.replace(/^<p>/, '').replace(/<\/p>$/, '')
-  return Parser(html)
+  if (!md) return md;
+  let html = mdConverter.makeHtml(md);
+  if (naked) html = html.replace(/^<p>/, '').replace(/<\/p>$/, '');
+  return Parser(html);
 }
 
 function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
-
 
 class IdyllComponentDoc extends React.Component {
   render() {
@@ -29,51 +28,52 @@ class IdyllComponentDoc extends React.Component {
       description,
       image,
       idyllProps,
-    } = this.props.component
+      component
+    } = this.props.component;
 
     const exampleCode = Examples[title];
 
+    console.log(component);
+    console.log(component._idyll);
+
     return (
-      <div id={ hrefId }>
-        <h1>{ title }</h1>
-        { md2html(description) }
-        { image &&
+      <div id={hrefId}>
+        <h1>{title}</h1>
+        {md2html(description)}
+        {image && (
           <figure>
-            <img src={ `/static/images/components/${image}` } alt={ title } />
+            <img src={`/static/images/components/${image}`} alt={title} />
           </figure>
-        }
-        { exampleCode &&
+        )}
+        {exampleCode && (
           <pre>
-            <code>{ exampleCode }</code>
+            <code>{exampleCode}</code>
           </pre>
-        }
-        { idyllProps && idyllProps.length > 0 &&
+        )}
+        {component._idyll.props && component._idyll.props.length > 0 && (
           <div>
             <h4>Props</h4>
-            <ul>
-              { idyllProps.map(p => this.renderPropBullet(p)) }
-            </ul>
+            <ul>{component._idyll.props.map(p => this.renderPropBullet(p))}</ul>
           </div>
-        }
+        )}
       </div>
-    )
+    );
   }
 
   renderPropBullet(prop) {
-    const [ name ] = Object.keys(prop)
-    const description = prop[name]
+    const { name, type, example } = prop;
+    const description = prop[name];
     return (
-      <li key={ name } className="idyll-prop">
-        <code>{ name }</code>
-        {' '}&mdash;{' '}
-        <span>{ md2html(description) }</span>
+      <li key={name} className="idyll-prop">
+        <b>{name}</b>
+        <code>{type}</code> &mdash;{' '}
+        {/* <span>{ md2html(description) }</span> */}
       </li>
-    )
+    );
   }
 }
 
 export default class IdyllComponentPage extends React.PureComponent {
-
   // getInitialProps({query}) {
   //   return {
   //     slug: query.slug
@@ -81,20 +81,25 @@ export default class IdyllComponentPage extends React.PureComponent {
   // }
 
   constructor(props) {
-    super(props)
-    this.state = {}
+    super(props);
+    this.state = {};
   }
 
   render() {
     const { url } = this.props;
     const comp = indexedComponents[url.query.slug];
     return (
-      <Layout url={ url } title={`Idyll Documentation | Component - ${comp.name}`}>
+      <Layout
+        url={url}
+        title={`Idyll Documentation | Component - ${comp.name}`}
+      >
         <div>
-          <Link href={'/docs/components'}><a>← Back</a></Link>
-          <IdyllComponentDoc component={ comp } />
+          <Link href={'/docs/components'}>
+            <a>← Back</a>
+          </Link>
+          <IdyllComponentDoc component={comp} />
         </div>
       </Layout>
-    )
+    );
   }
 }

--- a/packages/idyll-docs/pages/docs/component.js
+++ b/packages/idyll-docs/pages/docs/component.js
@@ -33,9 +33,6 @@ class IdyllComponentDoc extends React.Component {
 
     const exampleCode = Examples[title];
 
-    console.log(component);
-    console.log(component._idyll);
-
     return (
       <div id={hrefId}>
         <h1>{title}</h1>
@@ -50,10 +47,14 @@ class IdyllComponentDoc extends React.Component {
             <code>{exampleCode}</code>
           </pre>
         )}
-        {component._idyll.props && component._idyll.props.length > 0 && (
+        {((component && component._idyll.props) || idyllProps) && (
           <div>
             <h4>Props</h4>
-            <ul>{component._idyll.props.map(p => this.renderPropBullet(p))}</ul>
+            <ul>
+              {(component ? component._idyll.props : idyllProps).map(p =>
+                this.renderPropBullet(p)
+              )}
+            </ul>
           </div>
         )}
       </div>
@@ -61,13 +62,11 @@ class IdyllComponentDoc extends React.Component {
   }
 
   renderPropBullet(prop) {
-    const { name, type, example } = prop;
-    const description = prop[name];
+    const { name, type, example, description } = prop;
     return (
       <li key={name} className="idyll-prop">
-        <b>{name}</b>
-        <code>{type}</code> &mdash;{' '}
-        {/* <span>{ md2html(description) }</span> */}
+        <b>{name}</b> <code>{type}</code> &mdash;{' '}
+        <span>{md2html(description)}</span>
       </li>
     );
   }

--- a/packages/idyll-docs/pages/docs/components.js
+++ b/packages/idyll-docs/pages/docs/components.js
@@ -1,88 +1,95 @@
-import React from 'react'
+import React from 'react';
 import { Link } from '../../routes';
-import showdown from 'showdown'
+import showdown from 'showdown';
 import Parser from 'html-react-parser';
-import Layout from '../../components/layout'
+import Layout from '../../components/layout';
 
-import Contents from '../../idyll-components/contents'
+import Contents from '../../idyll-components/contents';
 // import * as Descriptions from '../idyll-components/descriptions'
-import * as Examples from '../../idyll-components/examples'
+import * as Examples from '../../idyll-components/examples';
 
-showdown.setFlavor('github')
+showdown.setFlavor('github');
 
-
-function slugify(text)
-{
-  return text.toString().toLowerCase()
-    .replace(/\s+/g, '-')           // Replace spaces with -
-    .replace(/[^\w\-]+/g, '')       // Remove all non-word chars
-    .replace(/\-\-+/g, '-')         // Replace multiple - with single -
-    .replace(/^-+/, '')             // Trim - from start of text
-    .replace(/-+$/, '');            // Trim - from end of text
+function slugify(text) {
+  return text
+    .toString()
+    .toLowerCase()
+    .replace(/\s+/g, '-') // Replace spaces with -
+    .replace(/[^\w\-]+/g, '') // Remove all non-word chars
+    .replace(/\-\-+/g, '-') // Replace multiple - with single -
+    .replace(/^-+/, '') // Trim - from start of text
+    .replace(/-+$/, ''); // Trim - from end of text
 }
 
-const mdConverter = new showdown.Converter()
+const mdConverter = new showdown.Converter();
 
 function md2html(md, naked = false) {
-  if (!md) return md
-  let html = mdConverter.makeHtml(md)
-  if (naked) html = html.replace(/^<p>/, '').replace(/<\/p>$/, '')
-  return Parser(html)
+  if (!md) return md;
+  let html = mdConverter.makeHtml(md);
+  if (naked) html = html.replace(/^<p>/, '').replace(/<\/p>$/, '');
+  return Parser(html);
 }
 
 function md2htmlNaked(md) {
-  return md2html(md, true)
+  return md2html(md, true);
 }
 
-const titleFromName = name => name.split(/([A-Z][a-z]+)/).join(' ').trim()
-const titleHrefFromTitle = title => title.replace(' ', '-')
-
+const titleFromName = name =>
+  name
+    .split(/([A-Z][a-z]+)/)
+    .join(' ')
+    .trim();
+const titleHrefFromTitle = title => title.replace(' ', '-');
 
 class BaseSection {
   constructor(obj) {
-    this.name = Object.keys(obj)[0]
-    this.title = titleFromName(this.name)
+    this.name = Object.keys(obj)[0];
+    this.title = titleFromName(this.name);
   }
 
   get hrefId() {
-    return this.name
+    return this.name;
   }
 }
 
 class IdyllComponentGroup extends BaseSection {
   constructor(obj) {
-    super(obj)
-    const { description, components } = obj[this.name]
-    this.description = description
-    this.components = components.map(sub => new IdyllComponentInfo(sub, this))
+    super(obj);
+    const { description, components } = obj[this.name];
+    this.description = description;
+    this.components = components.map(sub => new IdyllComponentInfo(sub, this));
   }
 
   renderContents() {
     return (
-      <div key={ this.name }>
-
-        <h3>{ this.title }</h3>
-        { md2html(this.description) }
-        <div style={{display: 'flex', flexWrap: 'wrap', width: 'calc(100vw - 2em - 20% - 175px)'}}>
-          { this.components.map(comp => comp.renderContents()) }
+      <div key={this.name}>
+        <h3>{this.title}</h3>
+        {md2html(this.description)}
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            width: 'calc(100vw - 2em - 20% - 250px)'
+          }}
+        >
+          {this.components.map(comp => comp.renderContents())}
         </div>
       </div>
-    )
+    );
   }
 }
 
 class IdyllComponentInfo extends BaseSection {
   constructor(obj, parent) {
-    super(obj)
-    this.parent = parent
-    Object.assign(this, obj[this.name])
+    super(obj);
+    this.parent = parent;
+    Object.assign(this, obj[this.name]);
     // this.Description = this.description
     //   ? (() => md2html(this.description))
     //   : (Descriptions[this.name] || (() => null))
-    this.Description = () => md2html(this.description) || null
-    this.exampleCode = Examples[this.name]
+    this.Description = () => md2html(this.description) || null;
+    this.exampleCode = Examples[this.name];
   }
-
 
   get slug() {
     return slugify(this.title);
@@ -90,13 +97,18 @@ class IdyllComponentInfo extends BaseSection {
 
   renderContents() {
     return (
-      <Link route='component' params={{slug: this.slug}}  >
-        <a style={{display: 'block', width: 140, margin: 20}} >
-          <img style={{display: 'block' , width: '100%'}} src={`/static/images/components/thumbnails/${this.thumbnail}`} />
-          <div style={{textAlign: 'center', margin: '10px 0'}} >{ this.title }</div>
+      <Link route="component" params={{ slug: this.slug }}>
+        <a style={{ display: 'block', width: 140, margin: 20 }}>
+          <img
+            style={{ display: 'block', width: '100%' }}
+            src={`/static/images/components/thumbnails/${this.thumbnail}`}
+          />
+          <div style={{ textAlign: 'center', margin: '10px 0' }}>
+            {this.title}
+          </div>
         </a>
       </Link>
-    )
+    );
   }
 }
 
@@ -109,81 +121,72 @@ class IdyllComponentDoc extends React.Component {
       Description,
       image,
       exampleCode,
-      idyllProps,
-    } = this.props.component
+      idyllProps
+    } = this.props.component;
 
     return (
-      <div id={ hrefId } key={ name }>
-        <h3>{ title }</h3>
+      <div id={hrefId} key={name}>
+        <h3>{title}</h3>
         {/*{ md2html(this.description) }*/}
         <Description />
-        { image &&
+        {image && (
           <figure>
-            <img src={ `static/images/${image}` } alt={ title } />
+            <img src={`static/images/${image}`} alt={title} />
           </figure>
-        }
-        { exampleCode &&
+        )}
+        {exampleCode && (
           <pre>
-            <code>{ exampleCode }</code>
+            <code>{exampleCode}</code>
           </pre>
-        }
-        { idyllProps && idyllProps.length > 0 &&
+        )}
+        {idyllProps && idyllProps.length > 0 && (
           <div>
             <h4>Props</h4>
-            <div>
-              { idyllProps.map(p => this.renderPropBullet(p)) }
-            </div>
+            <div>{idyllProps.map(p => this.renderPropBullet(p))}</div>
           </div>
-        }
+        )}
       </div>
-    )
+    );
   }
 
   renderPropBullet(prop) {
-    const [ name ] = Object.keys(prop)
-    const description = prop[name]
+    const [name] = Object.keys(prop);
+    const description = prop[name];
     return (
-      <li key={ name } className="idyll-prop">
-        <code>{ name }</code>
-        {' '}&mdash;{' '}
-        <span>{ md2html(description) }</span>
+      <li key={name} className="idyll-prop">
+        <code>{name}</code> &mdash; <span>{md2html(description)}</span>
       </li>
-    )
+    );
   }
 }
 
 class IdyllComponentSection extends React.Component {
   render() {
-    const {
-      name,
-      title,
-      hrefId,
-      components,
-    } = this.props.group
+    const { name, title, hrefId, components } = this.props.group;
 
     return (
-      <section id={ hrefId } key={ name }>
-        <h2>{ title }</h2>
-        { components.map(comp => <IdyllComponentDoc component={ comp } key={ comp.name } />) }
+      <section id={hrefId} key={name}>
+        <h2>{title}</h2>
+        {components.map(comp => (
+          <IdyllComponentDoc component={comp} key={comp.name} />
+        ))}
       </section>
-    )
+    );
   }
 }
 
-
-const groups = Contents.map(groupObj => new IdyllComponentGroup(groupObj))
+const groups = Contents.map(groupObj => new IdyllComponentGroup(groupObj));
 
 export default ({ url }) => (
-  <Layout url={ url } title={'Idyll Documentation | Standard Component Library'}>
+  <Layout url={url} title={'Idyll Documentation | Standard Component Library'}>
     <h1>Built-In Components</h1>
     <p>
-      Idyll ships with a handful of components that handle common tasks. They are broken into four categories:{' '}
-      <em>layout</em>, <em>input</em>, <em>presentation</em>, and <em>helpers</em>.
+      Idyll ships with a handful of components that handle common tasks. They
+      are broken into four categories: <em>layout</em>, <em>input</em>,{' '}
+      <em>presentation</em>, and <em>helpers</em>.
     </p>
     <div className="page-contents">
-      <div>
-        { groups.map(g => g.renderContents()) }
-      </div>
+      <div>{groups.map(g => g.renderContents())}</div>
     </div>
 
     {/* <p>
@@ -197,7 +200,10 @@ export default ({ url }) => (
     </p> */}
     <p>
       Continue to{' '}
-      <Link href="/docs/components/npm"><a>npm components</a></Link>.
+      <Link href="/docs/components/npm">
+        <a>npm components</a>
+      </Link>
+      .
     </p>
   </Layout>
-)
+);


### PR DESCRIPTION
This PR updates the documentation so that component pages (e.g. https://idyll-lang.org/docs/components/default/range) are generated directly from component metadata. This should help us keep the docs up-to-date as components are updated.