### PR TITLE
Embed components live in the docs pages

### DIFF
--- a/packages/idyll-components/src/analytics.js
+++ b/packages/idyll-components/src/analytics.js
@@ -46,6 +46,7 @@ Analytics._idyll = {
       name: 'google',
       type: 'string',
       example: '"UA-XXXXXXX"',
+      defaultValue: 'none',
       description: 'The google analytics Identifier.'
     }
   ]

--- a/packages/idyll-components/src/boolean.js
+++ b/packages/idyll-components/src/boolean.js
@@ -14,7 +14,11 @@ class Boolean extends React.PureComponent {
   render() {
     const { value } = this.props;
     return (
-      <input type="checkbox" onChange={this.toggleCheckbox.bind(this)} value={value} />
+      <input
+        type="checkbox"
+        onChange={this.toggleCheckbox.bind(this)}
+        value={value}
+      />
     );
   }
 }
@@ -23,15 +27,18 @@ Boolean.defaultProps = {
   value: false
 };
 
-
 Boolean._idyll = {
-  name: "Boolean",
-  tagType: "closed",
-  props: [{
-    name: "value",
-    type: "boolean",
-    example: "x"
-  }]
-}
+  name: 'Boolean',
+  tagType: 'closed',
+  props: [
+    {
+      name: 'value',
+      type: 'boolean',
+      example: 'x',
+      description:
+        'A value for the checkbox. If this value is truthy, the checkbox will be shown.'
+    }
+  ]
+};
 
 export default Boolean;

--- a/packages/idyll-components/src/chart.js
+++ b/packages/idyll-components/src/chart.js
@@ -106,6 +106,7 @@ Chart._idyll = {
       name: 'type',
       type: 'string',
       example: '"scatter"',
+      defaultValue: "'line'",
       description:
         'The type of the chart to display, can be `line`, `scatter`, `bar`, `pie`, or `time`. The time type is a line chart that expects the `x` values in the data to be in the temporal domain.'
     },
@@ -120,18 +121,21 @@ Chart._idyll = {
       name: 'domain',
       type: 'array',
       example: '`[0, 1]`',
+      defaultValue: '`[0, 1]`',
       description: 'The chart extent along the x dimension.'
     },
     {
       name: 'range',
       type: 'array',
       example: '`[0, 1]`',
+      defaultValue: '`[0, 1]`',
       description: 'The chart extent along the y dimension.'
     },
     {
       name: 'theme',
       type: 'string',
-      example: "'grayscale'",
+      example: "'material'",
+      defaultValue: "'grayscale'",
       description:
         'The theme to use, e.g. `grayscale` or `material` or a custom object (see [an example here](https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/victory-theme/grayscale.js))'
     }

--- a/packages/idyll-components/src/dynamic.js
+++ b/packages/idyll-components/src/dynamic.js
@@ -54,18 +54,21 @@ Dynamic._idyll = {
       name: 'step',
       type: 'string',
       example: '1',
+      defaultValue: '1',
       description: 'The granularity of the changes.'
     },
     {
       name: 'min',
       type: 'number',
       example: '-100',
+      defaultValue: 'none',
       description: 'The minimum value.'
     },
     {
       name: 'max',
       type: 'number',
       example: '100',
+      defaultValue: 'none',
       description: 'The maximum value.'
     }
   ]

--- a/packages/idyll-components/src/equation.js
+++ b/packages/idyll-components/src/equation.js
@@ -174,6 +174,7 @@ Equation._idyll = {
       name: 'display',
       type: 'boolean',
       example: 'true',
+      defaultValue: 'false',
       description:
         'Set to `true` for a centered, standalone equation, set to `false` for an inline equation.'
     }

--- a/packages/idyll-components/src/float.js
+++ b/packages/idyll-components/src/float.js
@@ -27,6 +27,7 @@ Float._idyll = {
       name: 'width',
       type: 'string',
       example: '"50%"',
+      defaultValue: '"50%"',
       description:
         'the width of the component, specified in pixels or percentage.'
     }

--- a/packages/idyll-components/src/header.js
+++ b/packages/idyll-components/src/header.js
@@ -85,13 +85,15 @@ Header._idyll = {
     {
       name: 'background',
       type: 'string',
-      example: '"#222"',
+      example: '"blue"',
+      defaultValue: '"#222"',
       description: 'The background of the header. Can pass a color or a url().'
     },
     {
       name: 'color',
       type: 'string',
-      example: '"#fff"',
+      example: '"#000"',
+      defaultValue: '"#fff"',
       description: 'The text color of the header.'
     }
   ]

--- a/packages/idyll-components/src/range.js
+++ b/packages/idyll-components/src/range.js
@@ -60,6 +60,7 @@ Range._idyll = {
       name: 'step',
       type: 'number',
       example: '1',
+      defaultValue: '1',
       description: 'The granularity of the slider.'
     }
   ]

--- a/packages/idyll-components/src/table.js
+++ b/packages/idyll-components/src/table.js
@@ -4,24 +4,27 @@ const Table = require('react-table').default;
 class TableComponent extends React.PureComponent {
   getColumns() {
     if (this.props.columns) {
-      if (this.props.columns.length && typeof this.props.columns[0] === 'string') {
-        return this.props.columns.map((d) => {
+      if (
+        this.props.columns.length &&
+        typeof this.props.columns[0] === 'string'
+      ) {
+        return this.props.columns.map(d => {
           return {
             Header: d,
             accessor: d
           };
-        })
+        });
       }
 
       return this.props.columns;
     }
     if ((this.props.data || []).length) {
-      return Object.keys(this.props.data[0]).map((d) => {
+      return Object.keys(this.props.data[0]).map(d => {
         return {
           Header: d,
           accessor: d
-        }
-      })
+        };
+      });
     }
 
     return [];
@@ -31,11 +34,15 @@ class TableComponent extends React.PureComponent {
       <Table
         className={`table ${this.props.className || ''}`}
         showPagination={this.props.data.length > this.props.defaultPageSize}
-        minRows={this.props.data.length <= this.props.defaultPageSize ? this.props.data.length : undefined}
+        minRows={
+          this.props.data.length <= this.props.defaultPageSize
+            ? this.props.data.length
+            : undefined
+        }
         {...this.props}
         children={undefined}
         columns={this.getColumns()}
-         />
+      />
     );
   }
 }
@@ -45,28 +52,48 @@ TableComponent.defaultProps = {
   showPageSizeOptions: false,
   showPageJump: false,
   defaultPageSize: 20
-}
+};
 
 TableComponent._idyll = {
-  name: "Table",
-  tagType: "closed",
-  props: [{
-    name: "data",
-    type: "array",
-    example: 'x'
-  }, {
-    name: "showPagination",
-    type: "boolean",
-    example: 'false'
-  }, {
-    name: "showPageSizeOptions",
-    type: "boolean",
-    example: 'false'
-  }, {
-    name: "showPageJump",
-    type: "boolean",
-    example: 'false'
-  }]
-}
+  name: 'Table',
+  tagType: 'closed',
+  props: [
+    {
+      name: 'data',
+      type: 'array',
+      description:
+        'The data to be shown in a table. Should be an array of object.',
+      example: '`[{name: "A", value: 0}, {name: "B", value: 5}]`'
+    },
+    {
+      name: 'defaultPageSize',
+      type: 'number',
+      example: '10',
+      description: 'The number of datapoints to be shown on a page.',
+      defaultValue: '20'
+    },
+    {
+      name: 'showPagination',
+      type: 'boolean',
+      example: 'false',
+      description: 'Show next and previous page buttons.',
+      defaultValue: 'true'
+    },
+    {
+      name: 'showPageSizeOptions',
+      type: 'boolean',
+      example: 'false',
+      description: 'Show options to configure page size.',
+      defaultValue: 'false'
+    },
+    {
+      name: 'showPageJump',
+      type: 'boolean',
+      example: 'false',
+      description: 'Show page jump option.',
+      defaultValue: 'false'
+    }
+  ]
+};
 
 export default TableComponent;

--- a/packages/idyll-components/src/youtube.js
+++ b/packages/idyll-components/src/youtube.js
@@ -107,14 +107,16 @@ YoutubeComponent._idyll = {
     {
       name: 'audio',
       type: 'boolean',
-      example: 'true',
-      description: 'Is the audio turned on? Default: true'
+      example: 'false',
+      defaultValue: 'true',
+      description: 'Is the audio turned on?'
     },
     {
       name: 'play',
       type: 'boolean',
       example: 'true',
-      description: 'Is the video playing? Default: false'
+      defaultValue: 'false',
+      description: 'Is the video playing?'
     },
     {
       name: 'id',
@@ -125,7 +127,8 @@ YoutubeComponent._idyll = {
     {
       name: 'options',
       type: 'object',
-      example: '`{}`',
+      example: '`{ modestbranding: 1 }`',
+      defaultValue: '`{}`',
       description:
         'Dictionary of extra options. See YouTube docs for all options.'
     }

--- a/packages/idyll-docs/components/global-styles.js
+++ b/packages/idyll-docs/components/global-styles.js
@@ -1,96 +1,103 @@
+export default () => (
+  <style jsx global>{`
+    @import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,300i,400,400i,600,600i,700,700i');
 
-export default () => <style jsx global>{`
-@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,300i,400,400i,600,600i,700,700i');
+    html,
+    body {
+      margin: 0;
+      padding: 0;
+    }
 
-html, body {
-  margin: 0;
-  padding: 0;
-}
+    html {
+      opacity: 0;
+      transition: opacity 0.25s ease-in;
+    }
+    html.loaded {
+      opacity: 1;
+    }
 
-html {
-  opacity: 0;
-  transition: opacity 0.25s ease-in;
-}
-html.loaded {
-  opacity: 1;
-}
+    body {
+      font-family: 'Source Sans Pro', sans-serif;
+      // color: rgb(80, 80, 80);
+      color: black;
+    }
 
-body {
-  font-family: 'Source Sans Pro', sans-serif;
-  // color: rgb(80, 80, 80);
-  color: black;
-}
+    a,
+    a:visited {
+      color: black;
+    }
 
-a, a:visited {
-  color: black;
-}
+    a:hover,
+    a:visited:hover {
+      color: #6122fb;
+    }
 
-a:hover, a:visited:hover {
-  color: #6122FB;
-}
+    figure {
+      margin: 0;
+    }
 
+    ._markdown_ img,
+    figure img {
+      max-width: 75%;
+      margin: 60px auto;
+      display: block;
+    }
 
+    code {
+      padding: 0;
+      padding-top: 0.2em;
+      padding-bottom: 0.2em;
+      margin: 0;
+      // font-size: 85%;
+      background-color: rgba(0, 0, 0, 0.04);
+      border-radius: 3px;
+    }
 
+    code:before,
+    code:after {
+      letter-spacing: -0.2em;
+      content: '\00a0';
+    }
 
-figure {
-  margin: 0;
-}
+    Highlight,
+    pre {
+      padding: 15px 10px;
+      overflow: auto;
+      line-height: 1.45;
+      background-color: #f7f7f7;
+      // border-radius: 3px;
+      word-wrap: normal;
+      background: #4c4b63;
+      font-family: 'Fira Mono', monospace;
+      color: white;
+    }
 
-._markdown_ img,
-figure img {
-  max-width: 75%;
-  margin: 60px auto;
-  display: block;
-}
+    pre code {
+      display: inline;
+      max-width: initial;
+      padding: 0;
+      margin: 0;
+      overflow: initial;
+      line-height: inherit;
+      word-wrap: normal;
+      background-color: transparent;
+      border: 0;
+      font-size: 100%;
+      white-space: pre;
+    }
 
-code {
-  padding: 0;
-  padding-top: 0.2em;
-  padding-bottom: 0.2em;
-  margin: 0;
-  // font-size: 85%;
-  background-color: rgba(0,0,0,0.04);
-  border-radius: 3px;
-}
+    pre code:before,
+    pre code:after {
+      content: normal;
+    }
 
-code:before,
-code:after {
-  letter-spacing: -0.2em;
-  content: "\00a0";
-}
+    li p {
+      display: inline;
+    }
 
-Highlight, pre {
-  padding: 15px 10px;
-  overflow: auto;
-  line-height: 1.45;
-  background-color: #f7f7f7;
-  // border-radius: 3px;
-  word-wrap: normal;
-  background: #4C4B63;
-  font-family: 'Fira Mono', monospace;
-  color: white;
-}
-
-pre code {
-  display: inline;
-  max-width: initial;
-  padding: 0;
-  margin: 0;
-  overflow: initial;
-  line-height: inherit;
-  word-wrap: normal;
-  background-color: transparent;
-  border: 0;
-  font-size: 100%;
-  white-space: pre;
-}
-
-pre code:before,
-pre code:after {
-  content: normal;
-}
-
-li p {
-  display: inline;
-}
-`}</style>
+    .idyll-action {
+      text-decoration: underline;
+      cursor: pointer;
+    }
+  `}</style>
+);

--- a/packages/idyll-docs/idyll-components/contents.js
+++ b/packages/idyll-docs/idyll-components/contents.js
@@ -12,7 +12,8 @@ const components = [
               'Content inside of an aside component will be displayed in the margin of your document. For example, the [consumer complaints](https://mathisonian.github.io/consumer-complaints/) article uses the `Aside` component to display a small chart and caption:',
             image: 'aside.png',
             thumbnail: 'aside.png',
-            component: COMPONENTS.Aside
+            component: COMPONENTS.Aside,
+            liveExample: false
           }
         },
         {
@@ -20,7 +21,8 @@ const components = [
             description:
               "A `FullWidth` component will break out of the text container and expand to fill the full width of the reader's browser.",
             image: 'feature.png',
-            thumbnail: 'feature.png'
+            thumbnail: 'feature.png',
+            liveExample: false
           }
         },
         {
@@ -29,7 +31,8 @@ const components = [
               'Content inside of a `fixed` component will be locked in place, even when the rest of the document scrolls. The [scroll](https://idyll-lang.github.io/idyll/scroll) example uses the `fixed` component to keep the dynamic chart in place:',
             thumbnail: 'fixed.gif',
             image: 'fixed.gif',
-            component: COMPONENTS.Fixed
+            component: COMPONENTS.Fixed,
+            liveExample: false
           }
         },
         {
@@ -37,7 +40,8 @@ const components = [
             description:
               'Content inside of a float will use the CSS `float` attribute to float to the left or right of its parent container.',
             thumbnail: 'float.png',
-            component: COMPONENTS.Float
+            component: COMPONENTS.Float,
+            liveExample: false
           }
         },
         {
@@ -45,7 +49,8 @@ const components = [
             thumbnail: 'inline.png',
             description:
               'The `inline` component adds the `display: inline-block` style property, so that items inside of `inline` component will be displayed next to each other. For example, this code will display three images side by side:',
-            component: COMPONENTS.Inline
+            component: COMPONENTS.Inline,
+            liveExample: false
           }
         },
         {
@@ -54,7 +59,8 @@ const components = [
               'The `Scroller` component is used to create scroll-based presentations. See [this example](https://mathisonian.github.io/idyll/scaffolding-interactives/) for more details.',
             thumbnail: 'scroller.gif',
             image: 'scroller.gif',
-            component: COMPONENTS.Scroller
+            component: COMPONENTS.Scroller,
+            liveExample: false
           }
         },
         {
@@ -63,7 +69,8 @@ const components = [
               'The `Step` component is used to create step-based presentations, like slideshows.  See [this example](https://mathisonian.github.io/idyll/scaffolding-interactives/) for more details.',
             thumbnail: 'stepper.gif',
             image: 'stepper.gif',
-            component: COMPONENTS.Stepper
+            component: COMPONENTS.Stepper,
+            liveExample: false
           }
         }
       ]
@@ -79,7 +86,8 @@ const components = [
             thumbnail: 'action.png',
             component: COMPONENTS.Action,
             description:
-              'The `action` component allows you to add event handlers to text. For example:'
+              'The `action` component allows you to add event handlers to text. For example:',
+            liveExample: true
           }
         },
         {
@@ -87,7 +95,8 @@ const components = [
             thumbnail: 'boolean.png',
             image: 'boolean.gif',
             component: COMPONENTS.Boolean,
-            description: 'This will display a checkbox.'
+            description: 'This will display a checkbox.',
+            liveExample: true
           }
         },
         {
@@ -96,7 +105,8 @@ const components = [
             description:
               'This will display a button. To control what happens when the button is clicked, add an `onClick` property:',
             image: 'button.gif',
-            component: COMPONENTS.Button
+            component: COMPONENTS.Button,
+            liveExample: true
           }
         },
         {
@@ -104,14 +114,16 @@ const components = [
             thumbnail: 'dynamic.png',
             description: 'This will render a dynamic variable to the screen.',
             image: 'dynamic.gif',
-            component: COMPONENTS.Dynamic
+            component: COMPONENTS.Dynamic,
+            liveExample: true
           }
         },
         {
           Radio: {
             thumbnail: 'radio.png',
             component: COMPONENTS.Radio,
-            description: 'This component displays a set of radio buttons.'
+            description: 'This component displays a set of radio buttons.',
+            liveExample: true
           }
         },
         {
@@ -119,21 +131,24 @@ const components = [
             thumbnail: 'range.png',
             component: COMPONENTS.Range,
             description: 'This component displays a range slider.',
-            image: 'displayvar.gif'
+            image: 'displayvar.gif',
+            liveExample: true
           }
         },
         {
           Select: {
             thumbnail: 'select.png',
             component: COMPONENTS.Select,
-            description: 'This component displays a selection dropdown.'
+            description: 'This component displays a selection dropdown.',
+            liveExample: true
           }
         },
         {
           TextInput: {
             thumbnail: 'text-input.png',
             component: COMPONENTS.TextInput,
-            description: 'A user-editable text input field.'
+            description: 'A user-editable text input field.',
+            liveExample: true
           }
         }
       ]
@@ -149,7 +164,8 @@ const components = [
             thumbnail: 'chart.png',
             component: COMPONENTS.Chart,
             description: 'This will display a chart.',
-            image: 'chart.png'
+            image: 'chart.png',
+            liveExample: true
           }
         },
         {
@@ -157,7 +173,8 @@ const components = [
             thumbnail: 'conditional.png',
             description:
               'This component will conditionally display its children.',
-            component: COMPONENTS.Conditional
+            component: COMPONENTS.Conditional,
+            liveExample: true
           }
         },
         {
@@ -166,7 +183,8 @@ const components = [
             component: COMPONENTS.Display,
             description:
               'This will render the value of a variable to the screen. It is mostly useful for debugging:',
-            image: 'displayvar.gif'
+            image: 'displayvar.gif',
+            liveExample: true
           }
         },
         {
@@ -175,7 +193,8 @@ const components = [
             component: COMPONENTS.Equation,
             description:
               'This uses [KaTeX](https://github.com/Khan/KaTeX) to typeset mathematical equations. Example:',
-            image: 'equation.png'
+            image: 'equation.png',
+            liveExample: true
           }
         },
         {
@@ -183,7 +202,8 @@ const components = [
             thumbnail: 'gist.png',
             component: COMPONENTS.Gist,
             description: 'Embed a github gist',
-            image: 'gist.png'
+            image: 'gist.png',
+            liveExample: true
           }
         },
         {
@@ -192,7 +212,8 @@ const components = [
             component: COMPONENTS.Header,
             description:
               'This component makes it easy to add a title, subtitle, and byline to your article:',
-            image: 'header.png'
+            image: 'header.png',
+            liveExample: true
           }
         },
         {
@@ -200,7 +221,8 @@ const components = [
             thumbnail: 'link.png',
             component: COMPONENTS.Link,
             description:
-              'This component just acts as syntactic sugar for displaying links inline in your text.'
+              'This component just acts as syntactic sugar for displaying links inline in your text.',
+            liveExample: true
           }
         },
         {
@@ -208,7 +230,8 @@ const components = [
             thumbnail: 'svg.png',
             component: COMPONENTS.SVG,
             description:
-              'This component will display an SVG file inline using https://github.com/matthewwithanm/react-inlinesvg. This makes it easy to style the SVG with css, as opposed to displaying the svg inside of an image tag.'
+              'This component will display an SVG file inline using https://github.com/matthewwithanm/react-inlinesvg. This makes it easy to style the SVG with css, as opposed to displaying the svg inside of an image tag.',
+            liveExample: true
           }
         },
         {
@@ -217,7 +240,8 @@ const components = [
             component: COMPONENTS.Table,
             description:
               'Display tabular data. Uses https://github.com/react-tools/react-table under the hood to render the table.',
-            image: 'table.png'
+            image: 'table.png',
+            liveExample: true
           }
         },
         {
@@ -225,7 +249,8 @@ const components = [
             thumbnail: 'youtube.png',
             component: COMPONENTS.Youtube,
             description:
-              'Plays a video from YouTube. All of the parameters are optional except for id, which must be provided. See all available options at https://developers.google.com/youtube/player_parameters'
+              'Plays a video from YouTube. All of the parameters are optional except for id, which must be provided. See all available options at https://developers.google.com/youtube/player_parameters',
+            liveExample: true
           }
         }
       ]
@@ -241,7 +266,8 @@ const components = [
             thumbnail: 'analytics.png',
             component: COMPONENTS.Analytics,
             description:
-              'This component makes it easy to insert a Google Analytics code on your page.'
+              'This component makes it easy to insert a Google Analytics code on your page.',
+            liveExample: false
           }
         },
         {
@@ -250,6 +276,7 @@ const components = [
             component: COMPONENTS.Meta,
             description:
               'The meta component adds context to the page template when building your app for publication. The following variables are available and will be inserted as `<meta>` properties into the head of your HTML page if you define them:',
+            liveExample: false,
             idyllProps: [
               {
                 name: 'title',
@@ -296,7 +323,8 @@ const components = [
             thumbnail: 'preload.png',
             component: COMPONENTS.Preload,
             description:
-              'This will preload an array of images, useful if you want to show them later on in the article and not have a loading flash.'
+              'This will preload an array of images, useful if you want to show them later on in the article and not have a loading flash.',
+            liveExample: false
           }
         }
       ]

--- a/packages/idyll-docs/idyll-components/examples/Action.idl
+++ b/packages/idyll-docs/idyll-components/examples/Action.idl
@@ -1,1 +1,3 @@
-This is regular text, but when you [action onClick:`alert('clicked the text')`]click me[/action], an alert will appear.
+This is regular text, but when you
+[action onClick:`alert('clicked the text')`]click me[/action],
+an alert will appear.

--- a/packages/idyll-docs/idyll-components/examples/Button.idl
+++ b/packages/idyll-docs/idyll-components/examples/Button.idl
@@ -1,1 +1,6 @@
+[var name:"myVar" value:0 /]
+
 [button onClick:`myVar += 1`]Click Me![/button]
+
+Variable value: [Display value:myVar /]
+

--- a/packages/idyll-docs/idyll-components/examples/Conditional.idl
+++ b/packages/idyll-docs/idyll-components/examples/Conditional.idl
@@ -1,6 +1,8 @@
 [var name:"showChart" value:false /]
 
-[Button onClick:` showChart = true `]Show Chart[/Button]
+[Button onClick:` showChart = !showChart `]
+  [Display value:`showChart ? 'Hide Chart' : 'Show Chart' `]
+[/Button]
 
 [Conditional if:` showChart `]
   [Chart /]

--- a/packages/idyll-docs/pages/docs/component.js
+++ b/packages/idyll-docs/pages/docs/component.js
@@ -5,6 +5,8 @@ import { indexedComponents } from '../../idyll-components/contents';
 import showdown from 'showdown';
 import Parser from 'html-react-parser';
 import * as Examples from '../../idyll-components/examples';
+import * as IdyllComponents from 'idyll-components';
+import IdyllDocument from 'idyll-document';
 
 showdown.setFlavor('github');
 const mdConverter = new showdown.Converter();
@@ -28,7 +30,8 @@ class IdyllComponentDoc extends React.Component {
       description,
       image,
       idyllProps,
-      component
+      component,
+      liveExample
     } = this.props.component;
 
     const exampleCode = Examples[title];
@@ -37,19 +40,23 @@ class IdyllComponentDoc extends React.Component {
       <div id={hrefId}>
         <h1>{title}</h1>
         {md2html(description)}
-        {image && (
+        {!liveExample && image && (
           <figure>
             <img src={`/static/images/components/${image}`} alt={title} />
           </figure>
         )}
-        {exampleCode && (
-          <pre>
-            <code>{exampleCode}</code>
-          </pre>
+        {liveExample && exampleCode && (
+          <div>
+            <h3>Live Example</h3>
+            <IdyllDocument markup={exampleCode} components={IdyllComponents} />
+            <pre>
+              <code>{exampleCode}</code>
+            </pre>
+          </div>
         )}
         {((component && component._idyll.props) || idyllProps) && (
           <div>
-            <h4>Props</h4>
+            <h3>Props</h3>
             <ul>
               {(component ? component._idyll.props : idyllProps).map(p =>
                 this.renderPropBullet(p)
@@ -57,16 +64,37 @@ class IdyllComponentDoc extends React.Component {
             </ul>
           </div>
         )}
+        {!liveExample && exampleCode && (
+          <div>
+            <h3>Example Code</h3>
+            <pre>
+              <code>{exampleCode}</code>
+            </pre>
+          </div>
+        )}
       </div>
     );
   }
 
   renderPropBullet(prop) {
-    const { name, type, example, description } = prop;
+    const { name, type, example, defaultValue, description } = prop;
     return (
       <li key={name} className="idyll-prop">
-        <b>{name}</b> <code>{type}</code> &mdash;{' '}
+        <b>{name}</b> <code>{type}</code> <br />
+        <br />
         <span>{md2html(description)}</span>
+        <ul>
+          {example ? (
+            <li>
+              <em>Example</em>: <code>{example}</code>
+            </li>
+          ) : null}
+          {defaultValue ? (
+            <li>
+              <em>Default value</em>: <code>{defaultValue}</code>
+            </li>
+          ) : null}
+        </ul>
       </li>
     );
   }
@@ -98,6 +126,28 @@ export default class IdyllComponentPage extends React.PureComponent {
           </Link>
           <IdyllComponentDoc component={comp} />
         </div>
+        <style jsx global>{`
+          ul {
+            list-style-type: none;
+          }
+          .idyll-prop {
+            margin-bottom: 1em;
+            padding: 1em;
+            overflow-x: auto;
+            background: #efefef;
+          }
+          .idyll-prop ul li {
+            margin-top: 1em;
+          }
+
+          .idyll-prop code {
+            border: solid 1px #222;
+            border-radius: 5px;
+            margin: 0 5px;
+            background: #fff;
+            white-space: nowrap;
+          }
+        `}</style>
       </Layout>
     );
   }


### PR DESCRIPTION
This PR updates the docs to embed live versions of the components on the appropriate pages. This is a per-component option that can be turned off where it doesn't make sense (e.g. layout components) and an image is shown instead in these cases.

It also improves the overall styling of the component pages, and adds additional metadata to some of the components. 

![new-component-docs](https://user-images.githubusercontent.com/1074773/54392980-387f8300-4666-11e9-9d7f-1a953a367d54.gif)
