### PR TITLE
Print both local and global idyll versions when running the `--version` command

### DIFF
--- a/packages/idyll-cli/bin/cli.js
+++ b/packages/idyll-cli/bin/cli.js
@@ -19,7 +19,7 @@ require('yargs')
       } catch (e) {
         console.log(
           'Local idyll version:',
-          require(p.join(localIdyllPath, 'package.json')).version
+          require(p.join(localIdyllPath, '..', '..', 'package.json')).version
         );
       }
     }

--- a/packages/idyll-cli/bin/cli.js
+++ b/packages/idyll-cli/bin/cli.js
@@ -1,8 +1,16 @@
 #!/usr/bin/env node
+const { getLocalIdyll } = require('./util');
 
 require('yargs')
   .usage('Usage: idyll <command> [options]')
   .commandDir('cmds')
   .demandCommand()
   .help()
-  .version().argv;
+  .version(function() {
+    console.log('Global idyll version:', require('../package').version);
+    const localIdyllPath = getLocalIdyll();
+    if (localIdyllPath) {
+      console.log('Local idyll version:', require(localIdyllPath).getVersion());
+    }
+    return process.exit();
+  }).argv;

--- a/packages/idyll-cli/bin/cli.js
+++ b/packages/idyll-cli/bin/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 const { getLocalIdyll } = require('./util');
+const p = require('path');
 
 require('yargs')
   .usage('Usage: idyll <command> [options]')
@@ -10,7 +11,17 @@ require('yargs')
     console.log('Global idyll version:', require('../package').version);
     const localIdyllPath = getLocalIdyll();
     if (localIdyllPath) {
-      console.log('Local idyll version:', require(localIdyllPath).getVersion());
+      try {
+        console.log(
+          'Local idyll version:',
+          require(localIdyllPath).getVersion()
+        );
+      } catch (e) {
+        console.log(
+          'Local idyll version:',
+          require(p.join(localIdyllPath, 'package.json')).version
+        );
+      }
     }
     return process.exit();
   }).argv;

--- a/packages/idyll-cli/src/index.js
+++ b/packages/idyll-cli/src/index.js
@@ -301,4 +301,8 @@ const idyll = (options = {}, cb) => {
   return inst;
 };
 
+idyll.getVersion = () => {
+  return require('../package.json').version;
+};
+
 module.exports = idyll;


### PR DESCRIPTION
Current behavior:

```
$ idyll --version
4.0.4-alpha.0
```

New behavior:

```
$ idyll --version
Global idyll version: 4.0.4-alpha.0
Local idyll version: 4.0.4-alpha.0
```

Fixes #399 