### PR TITLE
[bugfix] Fix starter project typo (command)

### DIFF
--- a/packages/idyll-template-projects/templates/basic/index.idyll
+++ b/packages/idyll-template-projects/templates/basic/index.idyll
@@ -15,7 +15,7 @@
 
 This is an Idyll post. It is generated via
 the file `index.idyll`. To compile this post using
-idyll, run the commnad `idyll` inside of this directory.
+idyll, run the command `idyll` inside of this directory.
 
 
 Idyll posts are designed to support interaction and


### PR DESCRIPTION
Fixes a typo in the starter project. 

- `commnad` -> `command`
