### PR TITLE
update how keys are defined

### DIFF
--- a/packages/idyll-docs/idyll-components/examples/Action.idl
+++ b/packages/idyll-docs/idyll-components/examples/Action.idl
@@ -1,3 +1,3 @@
 This is regular text, but when you
- [action onClick:`alert('clicked the text')`]Click me[/action],
+ [action onClick:`alert('clicked the text')`]click me[/action],
 an alert will appear.

--- a/packages/idyll-document/src/runtime.js
+++ b/packages/idyll-document/src/runtime.js
@@ -75,7 +75,7 @@ const createWrapper = ({ theme, layout, authorView, userViewComponent }) => {
     constructor(props) {
       super(props);
 
-      this.key = wrapperKey++;
+      this.key = props.idyllASTNode.id || wrapperKey++;
       this.ref = {};
       this.onUpdateRefs = this.onUpdateRefs.bind(this);
       this.onUpdateProps = this.onUpdateProps.bind(this);


### PR DESCRIPTION
Using the ID from the AST rather than keeping an internal counter in the runtime is a more reliable way for keying the elements in React. 