### PR TITLE
Add classname to display component

### DIFF
--- a/packages/idyll-components/src/display.js
+++ b/packages/idyll-components/src/display.js
@@ -23,7 +23,15 @@ class Display extends React.PureComponent {
   render() {
     const { value } = this.props;
     const v = value !== undefined ? value : this.props.var;
-    return <span>{this.formatValue(v)}</span>;
+    return (
+      <span
+        className={`idyll-display ${
+          this.props.className ? this.props.className : ''
+        }`.trim()}
+      >
+        {this.formatValue(v)}
+      </span>
+    );
   }
 }
 


### PR DESCRIPTION
To keep things consistent with each component adding a class name like `idyll-X`, enables easier styling by the user in CSS. 