### PR TITLE
Dynamic: include updateProps in doc API?

### DIFF
--- a/packages/idyll-components/src/dynamic.js
+++ b/packages/idyll-components/src/dynamic.js
@@ -70,6 +70,12 @@ Dynamic._idyll = {
       example: '100',
       defaultValue: 'none',
       description: 'The maximum value.'
+    },
+    {
+      name: 'updateProps',
+      type: 'function',
+      example: '(x) => console.log(x.value)',
+      description: 'The callback function when the dynamic value x has updated.'
     }
   ]
 };


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Docs update

* **What is the current behavior?** (You can also link to an open issue here)

It seems like `props.updateProps` is used inside the `Dynamic` component but is not mentioned in the documentation: https://idyll-lang.org/docs/components/default/dynamic

* **What is the new behavior (if this is a feature change)?**

List `updateProps` as one of the `props` for `Dynamic` in the documentation 

I'm not sure if this is intentional though. Maybe you don't want people to pass in callbacks when writing markdown? 

My motivation for adding it was that I want to reuse the Dynamic React component directly (not in markdown)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
