### PR TITLE
fix compiler tests

### DIFF
--- a/packages/idyll-compiler/test/test.js
+++ b/packages/idyll-compiler/test/test.js
@@ -1440,7 +1440,7 @@ End text
       );
     });
 
-    it.only('should handle bold at the end of a paragraph', function() {
+    it('should handle bold at the end of a paragraph', function() {
       const input = `
         This is **bold text.**
 


### PR DESCRIPTION
Removes `it.only` from compiler tests.
