### PR TITLE
improve hashing when AST is passed instead of markup

### DIFF
--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -37,7 +37,7 @@ class IdyllDocument extends React.Component {
     this.state = {
       ast: props.ast || defaultAST,
       previousAST: props.ast || defaultAST,
-      hash: props.ast ? JSON.stringify(props.ast) : hashCode(props.markup),
+      hash: props.ast ? JSON.stringify(props.ast) : '',
       error: null
     };
   }

--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -37,9 +37,7 @@ class IdyllDocument extends React.Component {
     this.state = {
       ast: props.ast || defaultAST,
       previousAST: props.ast || defaultAST,
-      hash: props.ast
-        ? JSON.stringify(props.ast)
-        : props.hashCode(props.markup),
+      hash: props.ast ? JSON.stringify(props.ast) : hashCode(props.markup),
       error: null
     };
   }
@@ -136,7 +134,6 @@ class IdyllDocument extends React.Component {
             (this.idyllContext ? this.idyllContext.data() : {})
           }
           ast={this.props.ast || this.state.ast}
-          userViewComponent={this.props.userViewComponent}
         />
         {this.getErrorComponent()}
       </div>

--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -37,7 +37,9 @@ class IdyllDocument extends React.Component {
     this.state = {
       ast: props.ast || defaultAST,
       previousAST: props.ast || defaultAST,
-      hash: '',
+      hash: props.ast
+        ? JSON.stringify(props.ast)
+        : props.hashCode(props.markup),
       error: null
     };
   }
@@ -90,6 +92,7 @@ class IdyllDocument extends React.Component {
     }
 
     if (newProps.ast) {
+      this.setState({ hash: JSON.stringify(newProps.ast) });
       return;
     }
 

--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -402,7 +402,11 @@ export const findWrapTargets = (schema, state, components) => {
     }
 
     if (node.component) {
-      if (componentNames.includes(node.component.toLowerCase())) {
+      const checkName = node.component
+        .toLowerCase()
+        .split('-')
+        .join('');
+      if (componentNames.includes(checkName)) {
         targets.push(node);
         return node;
       }


### PR DESCRIPTION
This improves how the hash is generated in the idyll runtime, which determines when the component will re-render. It is currently broken if you pass in an updated AST and won't re-render properly unless you manually provide an updated key. This fixes that issue. 