### PR TITLE
Enable custom wrappers for text nodes

### DIFF
--- a/packages/idyll-document/src/runtime.js
+++ b/packages/idyll-document/src/runtime.js
@@ -382,6 +382,20 @@ class IdyllRuntime extends React.PureComponent {
       }
       //Inspect for isHTMLNode  props and to check for dynamic components.
       if (!wrapTargets.includes(node)) {
+        // console.log('node not wrapped', node);
+
+        if (
+          this.props.wrapTextComponents.indexOf(node.component) > -1 &&
+          this.props.textEditComponent
+        ) {
+          const { idyllASTNode, ...rest } = node;
+          return {
+            component: this.props.textEditComponent,
+            idyllASTNode: idyllASTNode,
+            children: [rest]
+          };
+        }
+
         // Don't include the AST node reference on unwrapped components
         const { idyllASTNode, ...rest } = node;
         return rest;
@@ -522,7 +536,8 @@ IdyllRuntime.defaultProps = {
   layout: 'blog',
   theme: 'github',
   authorView: false,
-  insertStyles: false
+  insertStyles: false,
+  wrapTextComponents: ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'CodeHighlight']
 };
 
 export default IdyllRuntime;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This updates the runtime so that text nodes may be wrapped in a user provided component, to facilitate e.g. [direct text editing](https://github.com/idyll-lang/idyll-desktop).


* **What is the current behavior?** (You can also link to an open issue here)
Only dynamic components are wrapped.


* **What is the new behavior (if this is a feature change)?**
Dynamic components and text components are wrapped, with custom user-provided components per type.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


