### PR TITLE
Fix spacing issue with numbers in text

### DIFF
--- a/packages/idyll-compiler/package.json
+++ b/packages/idyll-compiler/package.json
@@ -10,7 +10,7 @@
     "build:es": "cross-env BABEL_ENV=es babel src -d dist/es",
     "compile": "nearleyc src/grammar.ne -o src/grammar.js",
     "build": "npm run compile && npm run build:es && npm run build:cjs",
-    "dev": "concurrently \"yarn run build:es --watch\" \"yarn run build:cjs --watch\"",
+    "dev": "concurrently \"yarn run compile\" \"yarn run build:es --watch\" \"yarn run build:cjs --watch\"",
     "test": "npm run compile && mocha",
     "prepublish": "npm run build",
     "prepublishOnly": "npm run build"

--- a/packages/idyll-compiler/src/lexer.js
+++ b/packages/idyll-compiler/src/lexer.js
@@ -311,7 +311,7 @@ const lex = function(options) {
   });
   // Match on separately so we can greedily match the
   // other tags.
-  lexer.addRule(/[!\d\*_`]/, function(lexeme) {
+  lexer.addRule(/[!\d\*_`]\s*/, function(lexeme) {
     this.reject = inComponent || lexeme.trim() === '';
     if (this.reject) return;
     updatePosition(lexeme);

--- a/packages/idyll-compiler/test/test.js
+++ b/packages/idyll-compiler/test/test.js
@@ -10,7 +10,7 @@ describe('compiler', function() {
       var lex = Lexer();
       var results = lex('Hello \n\nWorld! []');
       expect(results.tokens.join(' ')).to.eql(
-        'WORDS TOKEN_VALUE_START "Hello " TOKEN_VALUE_END BREAK WORDS TOKEN_VALUE_START "World" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "!" TOKEN_VALUE_END OPEN_BRACKET CLOSE_BRACKET EOF'
+        'WORDS TOKEN_VALUE_START "Hello " TOKEN_VALUE_END BREAK WORDS TOKEN_VALUE_START "World" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "! " TOKEN_VALUE_END OPEN_BRACKET CLOSE_BRACKET EOF'
       );
     });
 
@@ -1483,6 +1483,38 @@ End text
           }
         ]
       });
+    });
+  });
+  it('should handle numbers and symbols with and without spaces', function() {
+    const input = `
+      Test 1 2Three 1 2 Three 123Four
+    `;
+
+    expect(compile(input, { async: false })).to.eql({
+      id: 0,
+      type: 'component',
+      name: 'div',
+      children: [
+        {
+          id: 2,
+          type: 'component',
+          name: 'TextContainer',
+          children: [
+            {
+              id: 3,
+              type: 'component',
+              name: 'p',
+              children: [
+                {
+                  id: 4,
+                  type: 'textnode',
+                  value: 'Test 1 2Three 1 2 Three 123Four'
+                }
+              ]
+            }
+          ]
+        }
+      ]
     });
   });
 });


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix, see #489. This was a more general problem where space after special separator symbols (including numbers) was getting lost. 


* **What is the current behavior?** (You can also link to an open issue here)
See #489.


* **What is the new behavior (if this is a feature change)?**
The text appears as it does in the original markup


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No



