### PR TITLE
Add custom formatting for Dynamic Component

### DIFF
--- a/packages/idyll-components/src/dynamic.js
+++ b/packages/idyll-components/src/dynamic.js
@@ -25,10 +25,25 @@ class Dynamic extends React.PureComponent {
     this.drag(Selection.select(node));
   }
 
-  render() {
-    const { format, value } = this.props;
+  transformValue() {
+    const { format, value, map, min, step } = this.props;
+    const mapOnArray = Array.isArray(map);
+    const mapOnConditions = typeof map === 'string';
+    if (mapOnArray) {
+      const commonDiff = Math.ceil(Math.abs(step));
+      const index = Math.floor((value - min) / commonDiff);
+      return index < map.length ? map[index] : value;
+    }
+    if (mapOnConditions) {
+      return map;
+    }
     const formatter = Format.format(format);
-    return <span className="idyll-dynamic">{formatter(value)}</span>;
+    return formatter(value);
+  }
+
+  render() {
+    const display = this.transformValue();
+    return <span className="idyll-dynamic">{display}</span>;
   }
 }
 
@@ -36,7 +51,8 @@ Dynamic.defaultProps = {
   format: '.2f',
   min: Number.NEGATIVE_INFINITY,
   max: Number.POSITIVE_INFINITY,
-  step: 1
+  step: 1,
+  interval: 0
 };
 
 Dynamic._idyll = {
@@ -70,6 +86,12 @@ Dynamic._idyll = {
       example: '100',
       defaultValue: 'none',
       description: 'The maximum value.'
+    },
+    {
+      name: 'map',
+      type: 'any',
+      example: 'x',
+      description: 'A custom value to be displayed instead of number.'
     }
   ]
 };

--- a/packages/idyll-components/src/dynamic.js
+++ b/packages/idyll-components/src/dynamic.js
@@ -26,12 +26,14 @@ class Dynamic extends React.PureComponent {
   }
 
   transformValue() {
-    const { format, value } = this.props;
-    const customFormat = typeof format === 'function';
-    if (customFormat) {
-      return format(value);
-    }
+    const { format, value, display } = this.props;
     const formatter = Format.format(format);
+    if (display !== undefined) {
+      if (typeof display === 'string') {
+        return display;
+      }
+      return formatter(display);
+    }
     return formatter(value);
   }
 
@@ -46,7 +48,8 @@ Dynamic.defaultProps = {
   min: Number.NEGATIVE_INFINITY,
   max: Number.POSITIVE_INFINITY,
   step: 1,
-  interval: 0
+  interval: 0,
+  display: undefined
 };
 
 Dynamic._idyll = {
@@ -80,6 +83,12 @@ Dynamic._idyll = {
       example: '100',
       defaultValue: 'none',
       description: 'The maximum value.'
+    },
+    {
+      name: 'display',
+      type: 'expression',
+      example: '`x === 0 ? "none" : x`',
+      description: 'A custom display transform to use'
     }
   ]
 };

--- a/packages/idyll-components/src/dynamic.js
+++ b/packages/idyll-components/src/dynamic.js
@@ -26,16 +26,10 @@ class Dynamic extends React.PureComponent {
   }
 
   transformValue() {
-    const { format, value, map, min, step } = this.props;
-    const mapOnArray = Array.isArray(map);
-    const mapOnConditions = typeof map === 'string';
-    if (mapOnArray) {
-      const commonDiff = Math.ceil(Math.abs(step));
-      const index = Math.floor((value - min) / commonDiff);
-      return index < map.length ? map[index] : value;
-    }
-    if (mapOnConditions) {
-      return map;
+    const { format, value } = this.props;
+    const customFormat = typeof format === 'function';
+    if (customFormat) {
+      return format(value);
     }
     const formatter = Format.format(format);
     return formatter(value);
@@ -86,12 +80,6 @@ Dynamic._idyll = {
       example: '100',
       defaultValue: 'none',
       description: 'The maximum value.'
-    },
-    {
-      name: 'map',
-      type: 'any',
-      example: 'x',
-      description: 'A custom value to be displayed instead of number.'
     }
   ]
 };


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature Update.



* **What is the current behavior?** (You can also link to an open issue here)
Addresses #490 


* **What is the new behavior (if this is a feature change)?**
Dynamic Component will accept a prop `map` that will map a give value to the `value` prop of the component. e.g.

``[Dynamic value:Var1 min:50 max:100 step:10 map:`['Red', 'Red', 'Blue', 'Green']`/]``
``[Dynamic value:Var2 min:0 max:4 step:1 map:`(Var2 % 2 === 0) ? 'even' : 'odd' ` /]``

This will be the output of above
![custom_formatting](https://user-images.githubusercontent.com/13509968/58608975-88fc9900-82c3-11e9-9108-01192a206dc0.gif)
 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Other information**:
