### PR TITLE
bugfix for syntax highlighting

### DIFF
--- a/packages/idyll-cli/src/pipeline/parse.js
+++ b/packages/idyll-cli/src/pipeline/parse.js
@@ -100,10 +100,6 @@ exports.getHighlightJS = (ast, paths, server) => {
       cleanedLanguage = languageMap[language];
     }
     try {
-      rsh.registerLanguage(
-        language,
-        require(slash(path.join(rshPath, 'languages', cleanedLanguage))).default
-      );
       js += `
         try {
           rsh.registerLanguage('${language}', require('${slash(
@@ -114,6 +110,7 @@ exports.getHighlightJS = (ast, paths, server) => {
         }
       `;
     } catch (e) {
+      console.log(e);
       console.warn(
         `Warning: not including syntax highlighting for ${language}`
       );

--- a/packages/idyll-cli/src/pipeline/parse.js
+++ b/packages/idyll-cli/src/pipeline/parse.js
@@ -110,7 +110,6 @@ exports.getHighlightJS = (ast, paths, server) => {
         }
       `;
     } catch (e) {
-      console.log(e);
       console.warn(
         `Warning: not including syntax highlighting for ${language}`
       );


### PR DESCRIPTION
Hotfix for issue where all syntax highlighters were not working. 


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes error so that language specific codeblocks work properly, e.g. 

````
My code:

```js
Math.pow(x, 2);
```
````


* **What is the current behavior?** (You can also link to an open issue here)
Any language-specific code-highlighting fails to load. 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

