### PR TITLE
fill [slug] in template idyll options

### DIFF
--- a/packages/idyll-cli/bin/cmds/create-project.js
+++ b/packages/idyll-cli/bin/cmds/create-project.js
@@ -185,14 +185,22 @@ async function createProject(answers) {
     let packageJson = JSON.parse(await fs.readFile(packagePath));
     let indexIdyll = await fs.readFile(indexPath, { encoding: 'utf-8' });
 
-    packageJson.name = name
+    const slug = name
       .split(' ')
       .join('-')
       .toLowerCase();
+
+    packageJson.name = slug;
     var title = name
       .split('-')
       .join(' ')
       .replace(/\b\w/g, l => l.toUpperCase());
+
+    if (packageJson.idyll) {
+      Object.keys(packageJson.idyll).forEach(key => {
+        packageJson.idyll[key] = packageJson.idyll[key].replace('[slug]', slug);
+      });
+    }
 
     await fs.writeFile(packagePath, JSON.stringify(packageJson, null, 2));
     // TODO: could add more templating.


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This addresses https://github.com/idyll-lang/idyll/issues/510 and improves the workflow for https://github.com/idyll-lang/idyll/issues/421. It allows parameters in the package.json file to be filled in at the time of post creation to support flexible per-post options.


* **What is the current behavior?** (You can also link to an open issue here)
The options are copied as-is and must be hand edited after running `idyll create`. 


* **What is the new behavior (if this is a feature change)?**
Any option containing the `[slug]` tag will have it replaced with the post's slug.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
