### PR TITLE
Remove `width` styles from `.article-header`

### DIFF
--- a/packages/idyll-layouts/src/blog/styles.js
+++ b/packages/idyll-layouts/src/blog/styles.js
@@ -25,8 +25,6 @@ body {
 }
 
 .article-header {
-  width: 600px;
-  width: 100%;
   text-align: left;
   padding-left: 50px;
   margin-bottom: 45px;


### PR DESCRIPTION
First of all, there are two different `width` styles here. That can't be right, right?

Second of all: Having `width: 100%;` together with `padding-left: 50px;` means that `.article-header` will be 50px larger than the full width of the browser, so the body will overflow with a horizontal scroll bar. This is bummer. Removing these `width` styles prevents this problem.

(But I can't be sure that there aren't reasons these should be here.)

Thanks!