### PR TITLE
use system magenta in chalk calls for better compatibility

### DIFF
--- a/packages/idyll-cli/bin/cmds/build.js
+++ b/packages/idyll-cli/bin/cmds/build.js
@@ -79,7 +79,7 @@ exports.handler = argv => {
   console.log(
     `\n${chalk.green(
       'Building Idyll project with output directory:'
-    )} ${chalk.hex('#6122fb')(argv['output'])}\n`
+    )} ${chalk.magenta(argv['output'])}\n`
   );
   idyll(argv)
     .build()

--- a/packages/idyll-cli/bin/cmds/create-project.js
+++ b/packages/idyll-cli/bin/cmds/create-project.js
@@ -16,7 +16,7 @@ const TEMPLATES_DIR = p.join(
 );
 
 const colors = {
-  progress: chalk.hex('#6122fb'),
+  progress: chalk.magenta,
   success: chalk.green,
   failure: chalk.red
 };

--- a/packages/idyll-cli/bin/cmds/publish.js
+++ b/packages/idyll-cli/bin/cmds/publish.js
@@ -11,7 +11,7 @@ const IDYLL_PUB_API = 'https://api.idyll.pub';
 const DEFAULT_BUILD_DIR = 'build';
 
 const colors = {
-  progress: chalk.hex('#6122fb'),
+  progress: chalk.magenta,
   success: chalk.green,
   failure: chalk.red
 };


### PR DESCRIPTION
Switch the purple output in the CLI to always use built-in colors, ensuring there won't be issues with light/dark backgrounds caused by idyll. 