### PR TITLE
fix component replacement bug

### DIFF
--- a/packages/idyll-components/src/aside.js
+++ b/packages/idyll-components/src/aside.js
@@ -3,19 +3,16 @@ import React from 'react';
 class Aside extends React.PureComponent {
   render() {
     return (
-      <div className={'aside-container'}>
-        <div className={'aside'}>
-          {this.props.children}
-        </div>
-      </div>
+      <span className={'aside-container'}>
+        <span className={'aside'}>{this.props.children}</span>
+      </span>
     );
   }
 }
 
-
 Aside._idyll = {
-  name: "Aside",
-  tagType: "open"
-}
+  name: 'Aside',
+  tagType: 'open'
+};
 
 export default Aside;

--- a/packages/idyll-layouts/src/blog/styles.js
+++ b/packages/idyll-layouts/src/blog/styles.js
@@ -44,8 +44,10 @@ input {
 }
 .aside-container {
   position: relative;
+  display: block;
 }
 .aside {
+  display: block;
   position: absolute;
   width: 300px;
   right: calc((10vw + 600px + 150px) / -2);

--- a/packages/idyll-layouts/src/centered/styles.js
+++ b/packages/idyll-layouts/src/centered/styles.js
@@ -33,8 +33,10 @@ input {
 
 .aside-container {
   position: relative;
+  display: block;
 }
 .aside {
+  display: block;
   position: absolute;
   width: 300px;
   right: calc((10vw + 350px + 150px) / -2);

--- a/packages/idyll-themes/src/tufte/styles.js
+++ b/packages/idyll-themes/src/tufte/styles.js
@@ -1,5 +1,3 @@
-
-
 export default () => `
 @charset "UTF-8";
 
@@ -196,9 +194,9 @@ blockquote .sidenote, blockquote .marginnote, blockquote .aside { margin-right: 
                                                min-width: 59%;
                                                text-align: left; }
 
-.aside-container { width: 55%; }
 .aside-container {
   position: static;
+  width: 55%;
 }
 div.fullwidth, table.fullwidth { width: 100%; }
 
@@ -371,4 +369,4 @@ pre {
   overflow-x: auto;
 }
 
-`
+`;


### PR DESCRIPTION
Bugfix for https://github.com/idyll-lang/idyll/issues/566. 

In this case the React diffing algorithm was getting confused when matching up server rendered HTML with client rendered HTML. This was due to the `Aside` component nesting `div`s inside of a `p` tag, which threw some warnings and led to some difference in the final HTML output. 

This PR updates the aside component to use `span`s with `display: block` rather than `div`s, removing the warnings and the bug. 