### PR TITLE
fix alias

### DIFF
--- a/packages/idyll-cli/bin/cmds/create-project.js
+++ b/packages/idyll-cli/bin/cmds/create-project.js
@@ -30,12 +30,10 @@ let _customTemplate;
 
 function buildOptions(yargs) {
   return yargs
-    .alias([
-      {
-        t: 'template'
-      },
-      { i: 'install' }
-    ])
+    .alias({
+      t: 'template',
+      i: 'install'
+    })
     .default('install', true)
     .nargs('t', 1)
     .describe(


### PR DESCRIPTION
Bugfix for error in `idyll create`:

```
TypeError: Cannot read property 'length' of undefined
    at /Users/mathisonian/.nvm/versions/node/v11.2.0/lib/node_modules/idyll/node_modules/yargs/node_modules/yargs-parser/index.js:738:17
    at Array.forEach (<anonymous>)
    at /Users/mathisonian/.nvm/versions/node/v11.2.0/lib/node_modules/idyll/node_modules/yargs/node_modules/yargs-parser/index.js:737:40
    at Array.forEach (<anonymous>)
    at /Users/mathisonian/.nvm/versions/node/v11.2.0/lib/node_modules/idyll/node_modules/yargs/node_modules/yargs-parser/index.js:719:30
    at Array.forEach (<anonymous>)
    at extendAliases (/Users/mathisonian/.nvm/versions/node/v11.2.0/lib/node_modules/idyll/node_modules/yargs/node_modules/yargs-parser/index.js:718:10)
    at parse (/Users/mathisonian/.nvm/versions/node/v11.2.0/lib/node_modules/idyll/node_modules/yargs/node_modules/yargs-parser/index.js:126:3)
    at Function.Parser.detailed (/Users/mathisonian/.nvm/versions/node/v11.2.0/lib/node_modules/idyll/node_modules/yargs/node_modules/yargs-parser/index.js:902:10)
    at Object.parseArgs [as _parseArgs] (/Users/mathisonian/.nvm/versions/node/v11.2.0/lib/node_modules/idyll/node_modules/yargs/yargs.js:1030:27)
    at Object.runCommand (/Users/mathisonian/.nvm/versions/node/v11.2.0/lib/node_modules/idyll/node_modules/yargs/lib/command.js:200:45)
    at Object.parseArgs [as _parseArgs] (/Users/mathisonian/.nvm/versions/node/v11.2.0/lib/node_modules/idyll/node_modules/yargs/yargs.js:1078:30)
    at Object.get [as argv] (/Users/mathisonian/.nvm/versions/node/v11.2.0/lib/node_modules/idyll/node_modules/yargs/yargs.js:1012:21)
    at Object.<anonymous> (/Users/mathisonian/.nvm/versions/node/v11.2.0/lib/node_modules/idyll/bin/cli.js:35:3)
    at Module._compile (internal/modules/cjs/loader.js:722:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:733:10)
```