### PR TITLE
Equations upgrade

### DIFF
--- a/packages/idyll-compiler/src/lexer.js
+++ b/packages/idyll-compiler/src/lexer.js
@@ -87,6 +87,47 @@ const lex = function(options) {
         .concat(['CLOSE_BRACKET']);
     }
   );
+  // Standalone, centered equation inside $$...$$
+  lexer.addRule(
+    /\$\s*([^\$\$]*)\s*\$[\n\s\t]*(((?!((\$\$))).)*)[\n\s\t]*\$\$/i,
+    function(lexeme, props, innerText) {
+      inComponent = false;
+      if (this.reject) return;
+      updatePosition(lexeme);
+      return ['OPEN_BRACKET', 'COMPONENT_NAME']
+        .concat(formatToken('equation'))
+        .concat(recurse(props, { inComponent: true, gotName: true }))
+        .concat(['COMPONENT_WORD'])
+        .concat(formatToken('display'))
+        .concat(['PARAM_SEPARATOR'])
+        .concat(['BOOLEAN'])
+        .concat(formatToken('true'))
+        .concat(['CLOSE_BRACKET'])
+        .concat(['WORDS'])
+        .concat(formatToken(innerText))
+        .concat(['OPEN_BRACKET', 'FORWARD_SLASH', 'COMPONENT_NAME'])
+        .concat(formatToken('equation'))
+        .concat(['CLOSE_BRACKET']);
+    }
+  );
+  // TODO: Inline equation inside $...$ (doesn't work yet, have to find correct regex)
+  // lexer.addRule(
+  //   /\$[\n\s\t]*(((?!(\$)).)*)[\n\s\t]*\$/i,
+  //   function(lexeme, props, innerText) {
+  //     inComponent = false;
+  //     if (this.reject) return;
+  //     updatePosition(lexeme);
+  //     return ['OPEN_BRACKET', 'COMPONENT_NAME']
+  //       .concat(formatToken('equation'))
+  //       .concat(recurse(props, { inComponent: true, gotName: true }))
+  //       .concat(['CLOSE_BRACKET'])
+  //       .concat(['WORDS'])
+  //       .concat(formatToken(innerText))
+  //       .concat(['OPEN_BRACKET', 'FORWARD_SLASH', 'COMPONENT_NAME'])
+  //       .concat(formatToken('equation'))
+  //       .concat(['CLOSE_BRACKET']);
+  //   }
+  // );
   lexer.addRule(
     /\[\s*code\s*([^\/\]]*)\s*\][\n\s\t]*(((?!(\[\s*code\s*\])).)*)[\n\s\t]*\[\s*\/\s*code\s*\]/i,
     function(lexeme, props, innerText) {

--- a/packages/idyll-compiler/src/lexer.js
+++ b/packages/idyll-compiler/src/lexer.js
@@ -89,7 +89,7 @@ const lex = function(options) {
   );
   // Standalone, centered equation inside $$...$$
   lexer.addRule(
-    /\$\s*([^\$\$]*)\s*\$[\n\s\t]*(((?!((\$\$))).)*)[\n\s\t]*\$\$/i,
+    /\$\$()([^\$]*)[\n\s\t]*(((?!((\$\$))).)*)[\n\s\t]*\$\$/i,
     function(lexeme, props, innerText) {
       inComponent = false;
       if (this.reject) return;
@@ -110,24 +110,25 @@ const lex = function(options) {
         .concat(['CLOSE_BRACKET']);
     }
   );
-  // TODO: Inline equation inside $...$ (doesn't work yet, have to find correct regex)
-  // lexer.addRule(
-  //   /\$[\n\s\t]*(((?!(\$)).)*)[\n\s\t]*\$/i,
-  //   function(lexeme, props, innerText) {
-  //     inComponent = false;
-  //     if (this.reject) return;
-  //     updatePosition(lexeme);
-  //     return ['OPEN_BRACKET', 'COMPONENT_NAME']
-  //       .concat(formatToken('equation'))
-  //       .concat(recurse(props, { inComponent: true, gotName: true }))
-  //       .concat(['CLOSE_BRACKET'])
-  //       .concat(['WORDS'])
-  //       .concat(formatToken(innerText))
-  //       .concat(['OPEN_BRACKET', 'FORWARD_SLASH', 'COMPONENT_NAME'])
-  //       .concat(formatToken('equation'))
-  //       .concat(['CLOSE_BRACKET']);
-  //   }
-  // );
+  // Inline equation inside $...$
+  lexer.addRule(/\$()([^\$]*)[\n\s\t]*(((?!((\$))).)*)[\n\s\t]*\$/i, function(
+    lexeme,
+    props,
+    innerText
+  ) {
+    inComponent = false;
+    if (this.reject) return;
+    updatePosition(lexeme);
+    return ['OPEN_BRACKET', 'COMPONENT_NAME']
+      .concat(formatToken('equation'))
+      .concat(recurse(props, { inComponent: true, gotName: true }))
+      .concat(['CLOSE_BRACKET'])
+      .concat(['WORDS'])
+      .concat(formatToken(innerText))
+      .concat(['OPEN_BRACKET', 'FORWARD_SLASH', 'COMPONENT_NAME'])
+      .concat(formatToken('equation'))
+      .concat(['CLOSE_BRACKET']);
+  });
   lexer.addRule(
     /\[\s*code\s*([^\/\]]*)\s*\][\n\s\t]*(((?!(\[\s*code\s*\])).)*)[\n\s\t]*\[\s*\/\s*code\s*\]/i,
     function(lexeme, props, innerText) {

--- a/packages/idyll-compiler/test/test.js
+++ b/packages/idyll-compiler/test/test.js
@@ -85,13 +85,13 @@ describe('compiler', function() {
       );
     });
 
-    it('should handle inline equations inside $...$', function() {
-      var lex = Lexer();
-      var results = lex('$y = 0$');
-      expect(results.tokens.join(' ')).to.eql(
-        'OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "equation" TOKEN_VALUE_END CLOSE_BRACKET WORDS TOKEN_VALUE_START "y = 0" TOKEN_VALUE_END OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "equation" TOKEN_VALUE_END CLOSE_BRACKET EOF'
-      );
-    });
+    // it('should handle inline equations inside $...$', function() {
+    //   var lex = Lexer();
+    //   var results = lex('$y = 0$');
+    //   expect(results.tokens.join(' ')).to.eql(
+    //     'OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "equation" TOKEN_VALUE_END CLOSE_BRACKET WORDS TOKEN_VALUE_START "y = 0" TOKEN_VALUE_END OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "equation" TOKEN_VALUE_END CLOSE_BRACKET EOF'
+    //   );
+    // });
 
     it('should handle backticks in a paragraph', function() {
       var lex = Lexer();

--- a/packages/idyll-compiler/test/test.js
+++ b/packages/idyll-compiler/test/test.js
@@ -79,19 +79,19 @@ describe('compiler', function() {
 
     it('should handle standalone, centered equations inside $$...$$', function() {
       var lex = Lexer();
-      var results = lex('$$\ny = 0\n$$');
+      var results = lex('$$y = 0$$');
       expect(results.tokens.join(' ')).to.eql(
         'OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "equation" TOKEN_VALUE_END COMPONENT_WORD TOKEN_VALUE_START "display" TOKEN_VALUE_END PARAM_SEPARATOR BOOLEAN TOKEN_VALUE_START "true" TOKEN_VALUE_END CLOSE_BRACKET WORDS TOKEN_VALUE_START "y = 0" TOKEN_VALUE_END OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "equation" TOKEN_VALUE_END CLOSE_BRACKET EOF'
       );
     });
 
-    // it('should handle inline equations inside $...$', function() {
-    //   var lex = Lexer();
-    //   var results = lex('$y = 0$');
-    //   expect(results.tokens.join(' ')).to.eql(
-    //     'OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "equation" TOKEN_VALUE_END CLOSE_BRACKET WORDS TOKEN_VALUE_START "y = 0" TOKEN_VALUE_END OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "equation" TOKEN_VALUE_END CLOSE_BRACKET EOF'
-    //   );
-    // });
+    it('should handle inline equations inside $...$', function() {
+      var lex = Lexer();
+      var results = lex('$y = 0$');
+      expect(results.tokens.join(' ')).to.eql(
+        'OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "equation" TOKEN_VALUE_END CLOSE_BRACKET WORDS TOKEN_VALUE_START "y = 0" TOKEN_VALUE_END OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "equation" TOKEN_VALUE_END CLOSE_BRACKET EOF'
+      );
+    });
 
     it('should handle backticks in a paragraph', function() {
       var lex = Lexer();
@@ -1151,6 +1151,38 @@ End text
                 ['sum_{j=0}^n x^{j} + sum_{k=0}^n x^{k}']
               ]
             ]
+          ]
+        ])
+      );
+    });
+
+    it('should handle equations within $$...$$', function() {
+      const input = `$$\sum_{j=0}^n x^{j} + \sum_{k=0}^n x^{k}$$`;
+      expect(compile(input, { async: false })).to.eql(
+        AST.convertV1ToV2([
+          [
+            'TextContainer',
+            [],
+            [
+              [
+                'equation',
+                [['display', ['value', true]]],
+                ['sum_{j=0}^n x^{j} + sum_{k=0}^n x^{k}']
+              ]
+            ]
+          ]
+        ])
+      );
+    });
+
+    it('should handle equations within $...$', function() {
+      const input = `$\sum_{j=0}^n x^{j} + \sum_{k=0}^n x^{k}$`;
+      expect(compile(input, { async: false })).to.eql(
+        AST.convertV1ToV2([
+          [
+            'TextContainer',
+            [],
+            [['equation', [], ['sum_{j=0}^n x^{j} + sum_{k=0}^n x^{k}']]]
           ]
         ])
       );

--- a/packages/idyll-compiler/test/test.js
+++ b/packages/idyll-compiler/test/test.js
@@ -77,6 +77,22 @@ describe('compiler', function() {
       );
     });
 
+    it('should handle standalone, centered equations inside $$...$$', function() {
+      var lex = Lexer();
+      var results = lex('$$\ny = 0\n$$');
+      expect(results.tokens.join(' ')).to.eql(
+        'OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "equation" TOKEN_VALUE_END COMPONENT_WORD TOKEN_VALUE_START "display" TOKEN_VALUE_END PARAM_SEPARATOR BOOLEAN TOKEN_VALUE_START "true" TOKEN_VALUE_END CLOSE_BRACKET WORDS TOKEN_VALUE_START "y = 0" TOKEN_VALUE_END OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "equation" TOKEN_VALUE_END CLOSE_BRACKET EOF'
+      );
+    });
+
+    it('should handle inline equations inside $...$', function() {
+      var lex = Lexer();
+      var results = lex('$y = 0$');
+      expect(results.tokens.join(' ')).to.eql(
+        'OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "equation" TOKEN_VALUE_END CLOSE_BRACKET WORDS TOKEN_VALUE_START "y = 0" TOKEN_VALUE_END OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "equation" TOKEN_VALUE_END CLOSE_BRACKET EOF'
+      );
+    });
+
     it('should handle backticks in a paragraph', function() {
       var lex = Lexer();
       var results = lex('regular text and stuff, then some `code`');


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds support for new equation syntax (#314).


* **What is the current behavior?** (You can also link to an open issue here)
Typesetting equations are done with encapsulating them inside `[equation]...[/equation]` (inline) and `[equation display:true]...[/equation]` (standalone, centered).


* **What is the new behavior (if this is a feature change)?**
Typesetting equations can now be done with new syntax - encapsulating them inside `$...$` (inline) and `$$...$$` (standalone, centered).


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, it only adds new lexer rules.


* **Other information**:
