### PR TITLE
case insensitive AST.modifyNodesByName

### DIFF
--- a/packages/idyll-ast/src/index.js
+++ b/packages/idyll-ast/src/index.js
@@ -354,7 +354,7 @@ const modifyNodesByName = function(ast, name, modifier) {
   const modifiedAST = [ast].map(node => {
     if (['textnode', 'var', 'derived', 'data'].indexOf(node.type) === -1) {
       node = Object.assign({}, node, {
-        children: modifyHelper(getChildren(node), name, modifier)
+        children: modifyHelper(getChildren(node), name.toLowerCase(), modifier)
       });
     }
     node = handleNodeByName(node, name, modifier);


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)
modifyNodesByName is case sensitive and only accepts a node name if it is in lower case.


* **What is the new behavior (if this is a feature change)?**
Makes modifyNodesByName case insensitive.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:
