### PR TITLE
Fix: comment adds a line between previous and later components

### DIFF
--- a/packages/idyll-compiler/src/lexer.js
+++ b/packages/idyll-compiler/src/lexer.js
@@ -294,6 +294,9 @@ const lex = function(options) {
 
   lexer.addRule(/(\n\s*\/\/[^\n]*|\/\/\s+[^\n]*)/, function(lexeme) {
     updatePosition(lexeme);
+    if (lexeme.startsWith('\n')) {
+      return ['BREAK'];
+    }
   });
 
   lexer.addRule(/\/(\n?[^`\*\[\/\n\]!\\\d_])*/gm, function(lexeme) {

--- a/packages/idyll-compiler/test/test.js
+++ b/packages/idyll-compiler/test/test.js
@@ -146,7 +146,7 @@ describe('compiler', function() {
         not a comment: https://stuff.com
       `);
       expect(results.tokens.join(' ')).to.eql(
-        'WORDS TOKEN_VALUE_START "Text. " TOKEN_VALUE_END WORDS TOKEN_VALUE_START "/ Not a comment.\n        " TOKEN_VALUE_END OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "component" TOKEN_VALUE_END CLOSE_BRACKET WORDS TOKEN_VALUE_START "/" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "/not a comment\n          " TOKEN_VALUE_END OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "component" TOKEN_VALUE_END CLOSE_BRACKET BREAK WORDS TOKEN_VALUE_START "not a comment: https:" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "/" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "/stuff.com" TOKEN_VALUE_END EOF'
+        'WORDS TOKEN_VALUE_START "Text. " TOKEN_VALUE_END WORDS TOKEN_VALUE_START "/ Not a comment.\n        " TOKEN_VALUE_END BREAK OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "component" TOKEN_VALUE_END CLOSE_BRACKET WORDS TOKEN_VALUE_START "/" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "/not a comment\n          " TOKEN_VALUE_END OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "component" TOKEN_VALUE_END CLOSE_BRACKET BREAK WORDS TOKEN_VALUE_START "not a comment: https:" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "/" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "/stuff.com" TOKEN_VALUE_END EOF'
       );
     });
 
@@ -606,20 +606,15 @@ End text
 
         not a comment: https://stuff.com
       `;
+
       expect(compile(input, { async: false })).to.eql(
         AST.convertV1ToV2([
           [
             'TextContainer',
             [],
             [
-              [
-                'p',
-                [],
-                [
-                  'Text. / Not a comment.\n        ',
-                  ['component', [], ['//not a comment\n          ']]
-                ]
-              ],
+              ['p', [], ['Text. / Not a comment.\n        ']],
+              ['component', [], ['//not a comment\n          ']],
               [
                 'p',
                 [],


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds a break when a new line comment is used.


* **What is the current behavior?** (You can also link to an open issue here)
```
Hello
// comment
World
```
turns to
![Screenshot from 2019-08-03 16-53-46](https://user-images.githubusercontent.com/14182492/62411371-4f237800-b60f-11e9-88cd-844d73724b37.png)



* **What is the new behavior (if this is a feature change)?**
```
Hello
// comment
World
```
turns to 

![Screenshot from 2019-08-03 16-47-22](https://user-images.githubusercontent.com/14182492/62411300-6ada4e80-b60e-11e9-86f8-52fb1a3f4cc1.png)



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
As `BREAK` ends the `<p>` there is a margin between the previous and later components


* **Other information**:
Issue: #504 