### PR TITLE
fix multiline equation pre-processing

### DIFF
--- a/packages/idyll-compiler/src/lexer.js
+++ b/packages/idyll-compiler/src/lexer.js
@@ -81,14 +81,14 @@ const lex = function(options) {
         .concat(recurse(props, { inComponent: true, gotName: true }))
         .concat(['CLOSE_BRACKET'])
         .concat(['WORDS'])
-        .concat(formatToken(innerText))
+        .concat(formatToken(innerText.trim()))
         .concat(['OPEN_BRACKET', 'FORWARD_SLASH', 'COMPONENT_NAME'])
         .concat(formatToken('equation'))
         .concat(['CLOSE_BRACKET']);
     }
   );
   lexer.addRule(
-    /\[\s*code\s*([^\/\]]*)\s*\][\n\s\t]*(((?!(\[\s*code\s*\])).)*)[\n\s\t]*\[\s*\/\s*code\s*\]/i,
+    /\[\s*code\s*([^\/\]]*)\s*\][\n\s\t]*(((?!(\[\s*\/code\s*\])).\n?)*)[\n\s\t]*\[\s*\/\s*code\s*\]/i,
     function(lexeme, props, innerText) {
       inComponent = false;
       if (this.reject) return;
@@ -98,7 +98,7 @@ const lex = function(options) {
         .concat(recurse(props, { inComponent: true, gotName: true }))
         .concat(['CLOSE_BRACKET'])
         .concat(['WORDS'])
-        .concat(formatToken(innerText))
+        .concat(formatToken(innerText.trim()))
         .concat(['OPEN_BRACKET', 'FORWARD_SLASH', 'COMPONENT_NAME'])
         .concat(formatToken('code'))
         .concat(['CLOSE_BRACKET']);

--- a/packages/idyll-compiler/src/lexer.js
+++ b/packages/idyll-compiler/src/lexer.js
@@ -71,7 +71,7 @@ const lex = function(options) {
   // that shouldn't be formatted.
 
   lexer.addRule(
-    /\[\s*equation\s*([^\/\]]*)\s*\][\n\s\t]*(((?!(\[\s*equation\s*\])).)*)[\n\s\t]*\[\s*\/\s*equation\s*\]/i,
+    /\[\s*equation\s*([^\/\]]*)\s*\][\n\s\t]*(((?!(\[\s*\/equation\s*\])).\n?)*)[\n\s\t]*\[\s*\/\s*equation\s*\]/i,
     function(lexeme, props, innerText) {
       inComponent = false;
       if (this.reject) return;

--- a/packages/idyll-compiler/test/test.js
+++ b/packages/idyll-compiler/test/test.js
@@ -1547,4 +1547,50 @@ End text
       ]
     });
   });
+
+  it('should preprocess multiline equations', function() {
+    const input = `
+      [Equation display:true]
+      \begin{aligned}
+      (\overline{p + a})\star(\chi - p - a) &= \chi \star(\overline{p + a}) - (p + a)\star(\overline{p + a}) \\
+      &= \chi\star\bar p + \chi\star\bar a - p\star\bar p - a\star\bar a - 2 p\star\bar a \\
+      &= \bar p\star(\chi - p) + \bar a\star(\chi - a) - 2 p\star\bar a
+      \end{aligned}
+      [/Equation]
+    `;
+
+    expect(compile(input, { async: false })).to.eql({
+      id: 0,
+      type: 'component',
+      name: 'div',
+      children: [
+        {
+          id: 2,
+          type: 'component',
+          name: 'TextContainer',
+          children: [
+            {
+              id: 3,
+              type: 'component',
+              name: 'equation',
+              properties: {
+                display: {
+                  type: 'value',
+                  value: true
+                }
+              },
+              children: [
+                {
+                  id: 4,
+                  type: 'textnode',
+                  value:
+                    '\begin{aligned}\n      (overline{p + a})star(chi - p - a) &= chi star(overline{p + a}) - (p + a)star(overline{p + a}) \\\n      &= chistar\bar p + chistar\bar a - pstar\bar p - astar\bar a - 2 pstar\bar a \\\n      &= \bar pstar(chi - p) + \bar astar(chi - a) - 2 pstar\bar a\n      end{aligned}'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    });
+  });
 });


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This improves the equation pre-processing step so that it matches multiline equations properly. I'll tests shortly.  /cc @suhr.  

* **What is the current behavior?** (You can also link to an open issue here)
Multiline equations fall through to the standard component processing logic and sometimes this causes improper parsing of the provided latex.

* **What is the new behavior (if this is a feature change)?**
Both single and multiline equations are captured in the preprocessing step. See https://idyll.pub/post/equation-test-case-00073177b81f3f42105d4a39/ for an example the new behavior. 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
See issue https://github.com/idyll-lang/idyll/issues/576
