### PR TITLE
New variable syntax

### DIFF
--- a/packages/idyll-compiler/src/lexer.js
+++ b/packages/idyll-compiler/src/lexer.js
@@ -293,26 +293,27 @@ const lex = function(options, alias = {}) {
     });
     return output.concat(['LIST_END']);
   });
+
   lexer.addRule(
     /\s*~((\s*\w*\s*(:?=)\s*[^\n,]*)[^\n,](,[^\n]\s*\w*\s*(:?=)\s*[^\n,]*)*)/g,
-    function(lexeme, definitions) {
+    function(lexeme, variableDeclarations) {
       if (this.reject) return;
       updatePosition(lexeme);
       let output = [];
-      definitions.split(',').forEach(definition => {
-        if (definition[definition.indexOf('=') - 1] === ':') {
+      variableDeclarations.split(',').forEach(declaration => {
+        if (declaration[declaration.indexOf('=') - 1] === ':') {
           output = output
             .concat(['OPEN_BRACKET', 'COMPONENT_NAME'])
             .concat(formatToken('derived'))
             .concat(['COMPONENT_WORD'])
             .concat(formatToken('name'))
             .concat('PARAM_SEPARATOR', 'COMPONENT_WORD')
-            .concat(formatToken(definition.split(':=')[0].trim()))
+            .concat(formatToken(declaration.split(':=')[0].trim()))
             .concat(['COMPONENT_WORD'])
             .concat(formatToken('value'))
             .concat(['PARAM_SEPARATOR'])
             .concat(['EXPRESSION'])
-            .concat(formatToken('`' + definition.split(':=')[1].trim() + '`'))
+            .concat(formatToken('`' + declaration.split(':=')[1].trim() + '`'))
             .concat(['FORWARD_SLASH', 'CLOSE_BRACKET']);
         } else {
           output = output
@@ -321,12 +322,12 @@ const lex = function(options, alias = {}) {
             .concat(['COMPONENT_WORD'])
             .concat(formatToken('name'))
             .concat('PARAM_SEPARATOR', 'COMPONENT_WORD')
-            .concat(formatToken(definition.split('=')[0].trim()))
+            .concat(formatToken(declaration.split('=')[0].trim()))
             .concat(['COMPONENT_WORD'])
             .concat(formatToken('value'))
             .concat('PARAM_SEPARATOR')
             .concat(
-              recurse(definition.split('=')[1].trim(), { inComponent: true })
+              recurse(declaration.split('=')[1].trim(), { inComponent: true })
             )
             .concat(['FORWARD_SLASH', 'CLOSE_BRACKET']);
         }

--- a/packages/idyll-compiler/src/lexer.js
+++ b/packages/idyll-compiler/src/lexer.js
@@ -293,7 +293,47 @@ const lex = function(options, alias = {}) {
     });
     return output.concat(['LIST_END']);
   });
-
+  lexer.addRule(
+    /\s*~((\s*\w*\s*(:?=)\s*[^\n,]*)[^\n,](,[^\n]\s*\w*\s*(:?=)\s*[^\n,]*)*)/g,
+    function(lexeme, definitions) {
+      if (this.reject) return;
+      updatePosition(lexeme);
+      let output = [];
+      definitions.split(',').forEach(definition => {
+        if (definition[definition.indexOf('=') - 1] === ':') {
+          output = output
+            .concat(['OPEN_BRACKET', 'COMPONENT_NAME'])
+            .concat(formatToken('derived'))
+            .concat(['COMPONENT_WORD'])
+            .concat(formatToken('name'))
+            .concat('PARAM_SEPARATOR', 'COMPONENT_WORD')
+            .concat(formatToken(definition.split(':=')[0].trim()))
+            .concat(['COMPONENT_WORD'])
+            .concat(formatToken('value'))
+            .concat(['PARAM_SEPARATOR'])
+            .concat(['EXPRESSION'])
+            .concat(formatToken('`' + definition.split(':=')[1].trim() + '`'))
+            .concat(['FORWARD_SLASH', 'CLOSE_BRACKET']);
+        } else {
+          output = output
+            .concat(['OPEN_BRACKET', 'COMPONENT_NAME'])
+            .concat(formatToken('var'))
+            .concat(['COMPONENT_WORD'])
+            .concat(formatToken('name'))
+            .concat('PARAM_SEPARATOR', 'COMPONENT_WORD')
+            .concat(formatToken(definition.split('=')[0].trim()))
+            .concat(['COMPONENT_WORD'])
+            .concat(formatToken('value'))
+            .concat('PARAM_SEPARATOR')
+            .concat(
+              recurse(definition.split('=')[1].trim(), { inComponent: true })
+            )
+            .concat(['FORWARD_SLASH', 'CLOSE_BRACKET']);
+        }
+      });
+      return output;
+    }
+  );
   lexer.addRule(/!\[([^\]]*)\]\(([^\)]*)\)/, function(lexeme, text, link) {
     this.reject = inComponent;
     if (this.reject) return;

--- a/packages/idyll-compiler/test/test.js
+++ b/packages/idyll-compiler/test/test.js
@@ -1606,10 +1606,9 @@ End text
 
   it('should handle variable syntax', function() {
     const input = `
-    ~ x=1, y:=x*2
-    ~ a:=x+y, b="somestring"
+      ~ x=1, y:=x*2
+      ~ a:=x+y, b="somestring"
     `;
-    console.log(JSON.stringify(compile(input, { async: false })));
     expect(compile(input, { async: false })).to.eql({
       id: 0,
       type: 'component',

--- a/packages/idyll-compiler/test/test.js
+++ b/packages/idyll-compiler/test/test.js
@@ -1603,4 +1603,51 @@ End text
       ]
     });
   });
+
+  it('should handle variable syntax', function() {
+    const input = `
+    ~ x=1, y:=x*2
+    ~ a:=x+y, b="somestring"
+    `;
+    console.log(JSON.stringify(compile(input, { async: false })));
+    expect(compile(input, { async: false })).to.eql({
+      id: 0,
+      type: 'component',
+      name: 'div',
+      children: [
+        {
+          id: 2,
+          type: 'var',
+          properties: {
+            name: { type: 'variable', value: 'x' },
+            value: { type: 'value', value: 1 }
+          }
+        },
+        {
+          id: 3,
+          type: 'var',
+          properties: {
+            name: { type: 'variable', value: 'b' },
+            value: { type: 'value', value: 'somestring' }
+          }
+        },
+        {
+          id: 4,
+          type: 'derived',
+          properties: {
+            name: { type: 'variable', value: 'y' },
+            value: { type: 'expression', value: 'x*2' }
+          }
+        },
+        {
+          id: 5,
+          type: 'derived',
+          properties: {
+            name: { type: 'variable', value: 'a' },
+            value: { type: 'expression', value: 'x+y' }
+          }
+        }
+      ]
+    });
+  });
 });

--- a/packages/idyll-docs/pages/docs/syntax.js
+++ b/packages/idyll-docs/pages/docs/syntax.js
@@ -201,6 +201,14 @@ The above code defines a derived variable \`xSquared\` that depends
 on the value of \`x\`. The value of \`xSquared\` is automatically updated
 based on the value of \`x\`.
 
+Another way to declare a variable is by using the following syntax. 
+
+\`\`\`
+~ x=2, y:=x*5
+\`\`\`
+
+In the above code \`x\` is a normal variable while \`y\` is a derived variable.
+
 <h2 id="datasets">Datasets</h2>
 
 A dataset is similar to a variable, except instead of expecting a


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
allows following syntax to be used to define variables and derived variables.
```
~ x=1, y:=x*2
~ a:=x+y, b="somestring"
```



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
Resolves  #389 