### PR TITLE
Improve mobile layout on gallery

### DIFF
--- a/packages/idyll-docs/components/basic-layout.js
+++ b/packages/idyll-docs/components/basic-layout.js
@@ -1,8 +1,8 @@
-import React from 'react'
-import Link from 'next/link'
-import Head from 'next/head'
-import GlobalStyles from './global-styles'
-import { Contents, hrefFromName } from '../contents'
+import React from 'react';
+import Link from 'next/link';
+import Head from 'next/head';
+import GlobalStyles from './global-styles';
+import { Contents, hrefFromName } from '../contents';
 import TopNav from './top-nav';
 import Fonts from './fonts';
 import { logPageView, initGA } from './analytics';
@@ -15,51 +15,71 @@ const NavTransitionDuration = 0.25; // s
 
 class IdyllDocsLayout extends React.Component {
   constructor(props) {
-    super(props)
-    const {url} = props
-    this.presentPath = url && url.asPath
+    super(props);
+    const { url } = props;
+    this.presentPath = url && url.asPath;
     this.state = {
-      navOpen: false,
-    }
+      navOpen: false
+    };
   }
 
   componentDidMount() {
-    console.log('mount')
+    console.log('mount');
     Fonts();
     if (!window.GA_INITIALIZED) {
-      initGA()
-      window.GA_INITIALIZED = true
+      initGA();
+      window.GA_INITIALIZED = true;
     }
-    logPageView()
+    logPageView();
   }
 
   toggleNavOpen() {
-    this.setState({ navOpen: !this.state.navOpen })
+    this.setState({ navOpen: !this.state.navOpen });
   }
 
   render() {
-    const { title = 'Idyll', selected = "", shareImage, description ="A markup language for interactive documents.", children } = this.props
+    const {
+      title = 'Idyll',
+      selected = '',
+      shareImage,
+      description = 'A markup language for interactive documents.',
+      children
+    } = this.props;
     return (
-      <div id="master" className={ this.state.navOpen ?  'nav-open' : 'nav-closed' }>
+      <div
+        id="master"
+        className={this.state.navOpen ? 'nav-open' : 'nav-closed'}
+      >
         <Head>
-          <title>{ title }</title>
-          <meta charSet='utf-8' />
-          <meta name='viewport' content='initial-scale=1.0, width=device-width' />
-          <link rel="icon" type="image/x-icon" href="/static/images/favicon.ico" />
-          <meta property='og:image' content={shareImage || 'https://idyll-lang.org/static/images/twitter-share.png'} />
-          <meta name='twitter:card' content='summary_large_image' />
-          <meta property='og:description' content={description} />
-          <meta property='og:title' content={title} />
-          <meta property='og:url' content='https://idyll-lang.org' />
-          <meta property='og:type' content='website' />
+          <title>{title}</title>
+          <meta charSet="utf-8" />
+          <meta
+            name="viewport"
+            content="initial-scale=1.0, width=device-width"
+          />
+          <link
+            rel="icon"
+            type="image/x-icon"
+            href="/static/images/favicon.ico"
+          />
+          <meta
+            property="og:image"
+            content={
+              shareImage ||
+              'https://idyll-lang.org/static/images/twitter-share.png'
+            }
+          />
+          <meta name="twitter:card" content="summary_large_image" />
+          <meta property="og:description" content={description} />
+          <meta property="og:title" content={title} />
+          <meta property="og:url" content="https://idyll-lang.org" />
+          <meta property="og:type" content="website" />
         </Head>
 
         <TopNav selected={selected} />
         <div className="content-container">
           <main>
-            <div className="main-container">
-              { children }
-            </div>
+            <div className="main-container">{children}</div>
           </main>
         </div>
 
@@ -89,14 +109,16 @@ class IdyllDocsLayout extends React.Component {
             display: none;
           }
 
-
           @media (max-width: 767px) {
             main {
               width: 100%;
+              padding: 0.5em;
             }
-
+            .main-container {
+              margin-left: 1em;
+              margin-right: 1em;
+            }
           }
-
 
           ul {
             padding: 0;
@@ -117,10 +139,9 @@ class IdyllDocsLayout extends React.Component {
         `}</style>
 
         <GlobalStyles />
-
       </div>
-    )
+    );
   }
 }
 
-export default IdyllDocsLayout
+export default IdyllDocsLayout;

--- a/packages/idyll-docs/pages/gallery.js
+++ b/packages/idyll-docs/pages/gallery.js
@@ -8,18 +8,8 @@ const Examples = () => (
   <section>
     <h1>Made with Idyll</h1>
 
-    <div
-      style={{
-        borderRadius: 5,
-        border: 'solid 1px #ddd',
-        background: '#fefefe',
-        padding: '1em',
-        display: 'flex',
-        flexDirection: 'row',
-        justifyContent: 'space-between'
-      }}
-    >
-      <div>
+    <div className="feature">
+      <div className="feature--text">
         <a style={{ fontSize: '1.25rem' }} href="https://parametric.press">
           Featured: Parametric Press, a digital magazine built with Idyll
         </a>
@@ -30,10 +20,10 @@ const Examples = () => (
         visual, and interactive capabilities of dynamic media are effectively
         combined.
       </div>
-      <div>
+      <div className="feature--image">
         <a href="https://parametric.press">
           <img
-            style={{ maxWidth: 300, height: 'auto' }}
+            style={{ maxWidth: 300, width: '100%', height: 'auto' }}
             src="https://parametric.press/issue-01/static/images/share.png"
           />
         </a>
@@ -73,6 +63,51 @@ const Examples = () => (
     {examples.map(eg => (
       <GalleryGroup {...eg} key={eg.title} />
     ))}
+
+    <style jsx>{`
+      .feature {
+        border-radius: 5px;
+        border: solid 1px #ddd;
+        background: #fefefe;
+        padding: 1em;
+        display: flex;
+        flex-direction: row;
+        align-items: flex-start;
+        justify-content: space-between;
+      }
+
+      .feature--text {
+        padding-right: 4em;
+        max-width: 64%;
+        flex: 2 2 64%;
+      }
+
+      .feature--image {
+        flex: 1 1 300px;
+        max-width: 300px;
+        max-height: 150px;
+      }
+
+      @media (max-width: 769px) {
+        .feature {
+          padding: 0.5em;
+          flex-direction: column;
+          align-items: center;
+        }
+
+        .feature--text {
+          padding: 0;
+          text-align: center;
+          max-width: 100%;
+          flex-basis: 100%;
+        }
+
+        .feature--image {
+          margin-top: 1em;
+          max-width: 100%;
+        }
+      }
+    `}</style>
   </section>
 );
 


### PR DESCRIPTION


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Small visual updates to the basic-layout and mostly the gallery page:
* Update gallery layout & basic-layout on mobile to give the content more space
* Add a breakpoint in featured section of gallery where it becomes a column for small devices
Related to #565 

* **What is the current behavior?** (You can also link to an open issue here)

Mobile layout is cluttered with margins & the image for the feature does not sit well

* **What is the new behavior (if this is a feature change)?**
Reduced margins in mobile layout, changed feature to a column so the image has a place on the page

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Preview**:
Uploaded to imgur because it has a long height: https://imgur.com/a/ZFsquCC

Seems like some of the indenting\code styling was updated by precommit hook on the basic-layout file.