### PR TITLE
fix bug in generate header component

### DIFF
--- a/packages/idyll-components/src/generateHeaders.js
+++ b/packages/idyll-components/src/generateHeaders.js
@@ -25,7 +25,7 @@ const GenerateHeaders = props => {
     attributeProps.id = generateId(headerText);
   }
 
-  return <HeaderTag {...attributeProps}>{headerText}</HeaderTag>;
+  return <HeaderTag {...attributeProps}>{children}</HeaderTag>;
 };
 
 export default GenerateHeaders;


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix: the current implementation of header components will throw an error if the header contains components as children rather than just a string of text. 


* **What is the current behavior?** (You can also link to an open issue here)
An error is thrown if components are provided as children to, e.g., an `[h1][/h1]` tag.  

* **What is the new behavior (if this is a feature change)?**
No error is thrown, the children are rendered as expected.




* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.
