### PR TITLE
Add byline template

### DIFF
--- a/packages/idyll-components/src/header.js
+++ b/packages/idyll-components/src/header.js
@@ -15,13 +15,13 @@ class Header extends React.PureComponent {
         )}
         {this.props.author && (
           <div className={'byline'}>
-            {`${prefix} `}
+            {`${prefix.trim()} `}
             <a href={this.props.authorLink}>{this.props.author}</a>
           </div>
         )}
         {this.props.authors ? (
           <div className={'byline'}>
-            {`${prefix} `}
+            {`${prefix.trim()} `}
             {this.props.authors.map((author, i) => {
               if (typeof author === 'string') {
                 return author;
@@ -31,8 +31,8 @@ class Header extends React.PureComponent {
                   <a href={author.link}>{author.name}</a>
                   {i < this.props.authors.length - 1
                     ? i === this.props.authors.length - 2
-                      ? ` ${suffix} `
-                      : `${joint} `
+                      ? ` ${suffix.trim()} `
+                      : `${joint.trim()} `
                     : ''}
                 </span>
               ) : (
@@ -97,7 +97,7 @@ Header._idyll = {
     {
       name: 'byLineTemplate',
       type: 'object',
-      example: "{ prefix: 'Made by', joint: ' -', suffix: '&' }",
+      example: "{ prefix: 'Made by', joint: ' ', suffix: '&' }",
       description: 'Optional template to use in by line.'
     },
     {

--- a/packages/idyll-components/src/header.js
+++ b/packages/idyll-components/src/header.js
@@ -1,8 +1,12 @@
 import React from 'react';
 
+const byLineDefault = { prefix: 'By:', joint: ',', suffix: 'and' };
+
 class Header extends React.PureComponent {
   render() {
-    const { background, color } = this.props;
+    const { background, color, byLineTemplate } = this.props;
+    const { joint, prefix, suffix } = { ...byLineDefault, ...byLineTemplate };
+
     return (
       <div className={'article-header'} style={{ background, color }}>
         <h1 className={'hed'}>{this.props.title}</h1>
@@ -11,12 +15,13 @@ class Header extends React.PureComponent {
         )}
         {this.props.author && (
           <div className={'byline'}>
-            By: <a href={this.props.authorLink}>{this.props.author}</a>
+            {`${prefix} `}
+            <a href={this.props.authorLink}>{this.props.author}</a>
           </div>
         )}
         {this.props.authors ? (
           <div className={'byline'}>
-            By:{' '}
+            {`${prefix} `}
             {this.props.authors.map((author, i) => {
               if (typeof author === 'string') {
                 return author;
@@ -26,8 +31,8 @@ class Header extends React.PureComponent {
                   <a href={author.link}>{author.name}</a>
                   {i < this.props.authors.length - 1
                     ? i === this.props.authors.length - 2
-                      ? ' and '
-                      : ', '
+                      ? ` ${suffix} `
+                      : `${joint} `
                     : ''}
                 </span>
               ) : (
@@ -88,6 +93,12 @@ Header._idyll = {
       example: '"blue"',
       defaultValue: '"#222"',
       description: 'The background of the header. Can pass a color or a url().'
+    },
+    {
+      name: 'byLineTemplate',
+      type: 'object',
+      example: "{ prefix: 'Made by', joint: ' -', suffix: '&' }",
+      description: 'Optional template to use in by line.'
     },
     {
       name: 'color',


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
First of all sorry this took a while, end of semester got busy :rofl: 

* Add ByLine template to header component. Closes #593 


* **What is the current behavior?** (You can also link to an open issue here)

* By line prefix, suffix & joint is hardcoded

* **What is the new behavior (if this is a feature change)?**

* Header component accepts a `bylineTemplate` prop (optional) that let's the user customize the template.

For example

```
[Header
  title:"Animal Farm"
  subtitle:"Welcome to the jungle"
  authors:`[
    {name: 'Dog', link: 'https://website.com'}, 
    {name: 'Monkey', link: 'https://www.com'},
    {name: 'Duck', link: 'https://www.example.org'}
  ]`
  byLineTemplate: `{
    prefix: 'Made by',
    joint: ' ',
    suffix: '&'
  }`
/]

```

will render the following:

![image](https://user-images.githubusercontent.com/28638133/69830398-7ed03e80-1203-11ea-90a2-30cb739fa9b6.png)


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

Found a bug where the template is not applied in some context, will be opening a related issue so it can be discussed
