### PR TITLE
fix: Exclamation mark removes paragraph break

### DIFF
--- a/packages/idyll-compiler/src/lexer.js
+++ b/packages/idyll-compiler/src/lexer.js
@@ -330,7 +330,7 @@ const lex = function(options, alias = {}) {
   });
   // Match on separately so we can greedily match the
   // other tags.
-  lexer.addRule(/[!\d\*_`]\s*/, function(lexeme) {
+  lexer.addRule(/[!\d\*_`]/, function(lexeme) {
     this.reject = inComponent || lexeme.trim() === '';
     if (this.reject) return;
     updatePosition(lexeme);

--- a/packages/idyll-compiler/src/lexer.js
+++ b/packages/idyll-compiler/src/lexer.js
@@ -330,7 +330,7 @@ const lex = function(options, alias = {}) {
   });
   // Match on separately so we can greedily match the
   // other tags.
-  lexer.addRule(/[!\d\*_`]/, function(lexeme) {
+  lexer.addRule(/[!\d\*_`] */, function(lexeme) {
     this.reject = inComponent || lexeme.trim() === '';
     if (this.reject) return;
     updatePosition(lexeme);

--- a/packages/idyll-compiler/test/test.js
+++ b/packages/idyll-compiler/test/test.js
@@ -243,6 +243,19 @@ describe('compiler', function() {
         'OPEN_BRACKET COMPONENT_NAME TOKEN_VALUE_START "code" TOKEN_VALUE_END CLOSE_BRACKET WORDS TOKEN_VALUE_START "y = 0" TOKEN_VALUE_END OPEN_BRACKET FORWARD_SLASH COMPONENT_NAME TOKEN_VALUE_START "code" TOKEN_VALUE_END CLOSE_BRACKET EOF'
       );
     });
+    it("symbols or numbers at end of paragraph doesn't remove paragraph break", function() {
+      const input = `
+        Idyll is based on Markdown!
+
+        Idyll posts are designed to support interaction and
+        data-driven graphics.
+      `;
+      const lex = Lexer();
+      const results = lex(input);
+      expect(results.tokens.join(' ')).to.eql(
+        'WORDS TOKEN_VALUE_START "Idyll is based on Markdown" TOKEN_VALUE_END WORDS TOKEN_VALUE_START "!" TOKEN_VALUE_END BREAK WORDS TOKEN_VALUE_START "Idyll posts are designed to support interaction and\n        data-driven graphics." TOKEN_VALUE_END EOF'
+      );
+    });
   });
 
   describe('parser', function() {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Exclamation mark at end of paragraph removes paragraph break


* **What is the new behavior (if this is a feature change)?**
Symbols like *, !, _, `, numbers at end of a paragraph won't merge the following paragraph with itself

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
Resolves #542 
