### PR TITLE
feat: component resolver change

### DIFF
--- a/packages/idyll-cli/src/index.js
+++ b/packages/idyll-cli/src/index.js
@@ -65,9 +65,7 @@ const idyll = (options = {}, cb) => {
     opts.compiler.postProcessors = opts.compiler.postProcessors.map(
       processor => {
         try {
-          return require(require.resolve(processor, {
-            paths: [paths.INPUT_DIR]
-          }));
+          return require(processor, { basedir: paths.INPUT_DIR });
         } catch (e) {
           console.log(e);
           console.warn('\n\nCould not find post-processor plugin: ', processor);

--- a/packages/idyll-cli/src/index.js
+++ b/packages/idyll-cli/src/index.js
@@ -65,7 +65,9 @@ const idyll = (options = {}, cb) => {
     opts.compiler.postProcessors = opts.compiler.postProcessors.map(
       processor => {
         try {
-          return require(processor, { basedir: paths.INPUT_DIR });
+          return require(require.resolve(processor, {
+            paths: [paths.INPUT_DIR]
+          }));
         } catch (e) {
           console.log(e);
           console.warn('\n\nCould not find post-processor plugin: ', processor);
@@ -150,16 +152,18 @@ const idyll = (options = {}, cb) => {
 
             // Each resolver is responsible for generating a list of directories to watch for
             // their corresponding data types.
-            resolvers.forEach((resolver, name) => {
-              let watcher = bs.watch(
-                resolver.getDirectories(),
-                { ignoreInitial: true },
-                () => {
-                  inst.build();
-                }
-              );
-              watchers.push(watcher);
-            });
+            if (!opts.compiler.postProcessors) {
+              resolvers.forEach((resolver, name) => {
+                let watcher = bs.watch(
+                  resolver.getDirectories(),
+                  { ignoreInitial: true },
+                  () => {
+                    inst.build();
+                  }
+                );
+                watchers.push(watcher);
+              });
+            }
 
             bs.init({
               cors: true,

--- a/packages/idyll-cli/src/pipeline/index.js
+++ b/packages/idyll-cli/src/pipeline/index.js
@@ -6,6 +6,7 @@ const compile = require('idyll-compiler');
 const Terser = require('terser');
 const { paramCase } = require('change-case');
 const debug = require('debug')('idyll:cli');
+const { ComponentResolver } = require('../resolvers');
 
 const {
   getComponentNodes,
@@ -40,6 +41,7 @@ const build = (opts, paths, resolvers) => {
         const template = fs.readFileSync(paths.HTML_TEMPLATE_FILE, 'utf8');
 
         /* Change here */
+        resolvers.set('components', new ComponentResolver(opts, paths));
 
         let nameArray = [];
         getComponentNodes(ast).forEach(node => {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Enhancement


* **What is the current behavior?** (You can also link to an open issue here)
Component resolver is initialized at the start of compile process and when a compiler postprocessor plugin creates a new component in components directory, it won't be available till the next build and the current build fails with component not found error.


* **What is the new behavior (if this is a feature change)?**
Component resolver is reloaded after every compile. 
Components directory is removed from browser-sync file watcher when a compiler post-processor is present so that file-watcher doesn't trigger a new build when a component is added to components directory, hence preventing a build loop 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes. When users add a compiler plugin, file watcher is disabled for components directory.


* **Other information**:
