### PR TITLE
[WIP] AST should include reference to markup 

### DIFF
--- a/packages/idyll-ast/src/converters/index.js
+++ b/packages/idyll-ast/src/converters/index.js
@@ -113,6 +113,7 @@ function inverseConvertHelper(arrayElement, id) {
   } else {
     elementJson.type = 'component';
     elementJson.name = arrayElement[0];
+    elementJson.raw = arrayElement[3];
     if (arrayElement[1].length !== 0) {
       elementJson.properties = {};
       arrayElement[1].forEach(property => {

--- a/packages/idyll-compiler/src/index.js
+++ b/packages/idyll-compiler/src/index.js
@@ -8,7 +8,8 @@ const {
   cleanResults,
   makeFullWidth,
   wrapText,
-  autoLinkify
+  autoLinkify,
+  linkMarkupToNode
 } = require('./processors/post');
 const { convertV1ToV2 } = require('idyll-ast').converters;
 const matter = require('gray-matter');
@@ -44,7 +45,10 @@ module.exports = function(input, options, alias, callback) {
     return new Promise((resolve, reject) => reject(err));
   }
 
+  const referenceMarkup = linkMarkupToNode(lexResults.positions, content);
+
   let astTransform = Processor(output, options)
+    .pipe(referenceMarkup)
     .pipe(hoistVariables)
     .pipe(flattenChildren)
     .pipe(makeFullWidth)

--- a/packages/idyll-compiler/src/lexer.js
+++ b/packages/idyll-compiler/src/lexer.js
@@ -26,6 +26,7 @@ const shouldBreak = text => {
 let currentInput = null;
 
 const lex = function(options, alias = {}) {
+  const positions = [];
   let { row, column, outer, skipLists, inComponent, gotName } = Object.assign(
     {},
     {
@@ -66,13 +67,19 @@ const lex = function(options, alias = {}) {
       )
     ].join('|');
   };
-  var updatePosition = function(lexeme) {
+  var updatePosition = function(lexeme, shouldNotPush) {
+    if (!shouldNotPush) {
+      positions.push([row, column]);
+    }
     var lines = lexeme.split('\n');
     row += lines.length - 1;
     if (lines.length > 1) {
-      column = 0;
+      column = 1;
     }
     column += lines[lines.length - 1].length;
+    if (!shouldNotPush) {
+      positions.push([row, column]);
+    }
   };
 
   // Rules at the front are pre-processed,
@@ -163,22 +170,18 @@ const lex = function(options, alias = {}) {
     return ['INLINE_CODE'].concat(formatToken(text.trim()));
   });
 
-  lexer.addRule(/[\s\n]*(#{1,6})\s*([^\n\[]+)[\n\s]*/gm, function(
-    lexeme,
-    hashes,
-    text
-  ) {
+  lexer.addRule(/(#{1,6})\s*([^\n\[]+)/gm, function(lexeme, hashes, text) {
     if (this.reject) return;
     updatePosition(lexeme);
-    return ['BREAK', 'HEADER_' + hashes.length]
+    return ['HEADER_' + hashes.length]
       .concat(recurse(text, { skipLists: true }))
       .concat(['HEADER_END']);
   });
 
-  lexer.addRule(/[\s\n]*>\s*([^\n\[]+)[\n\s]*/gm, function(lexeme, text) {
+  lexer.addRule(/>\s*([^\n\[]+)/gm, function(lexeme, text) {
     if (this.reject) return;
     updatePosition(lexeme);
-    return ['BREAK', 'QUOTE_START']
+    return ['QUOTE_START']
       .concat(recurse(text, { skipLists: true }))
       .concat(['QUOTE_END']);
   });
@@ -315,14 +318,14 @@ const lex = function(options, alias = {}) {
     }
   });
 
-  lexer.addRule(/\/(\n?[^`\*\[\/\n\]!\\\d_])*/gm, function(lexeme) {
+  lexer.addRule(/\/([^`\*\[\/\n\]!\\\d_])*/gm, function(lexeme) {
     this.reject = inComponent || lexeme.trim() === '';
     if (this.reject) return;
     updatePosition(lexeme);
     return ['WORDS'].concat(formatToken(lexeme));
   });
 
-  lexer.addRule(/(\n?[^`\*\[\/\n\]!\\\d_])+/, function(lexeme) {
+  lexer.addRule(/([^`\*\[\/\n\]!\\\d_])+/, function(lexeme) {
     this.reject = inComponent || lexeme.trim() === '';
     if (this.reject) return;
     updatePosition(lexeme);
@@ -330,7 +333,7 @@ const lex = function(options, alias = {}) {
   });
   // Match on separately so we can greedily match the
   // other tags.
-  lexer.addRule(/[!\d\*_`] */, function(lexeme) {
+  lexer.addRule(/[!\d\*_`]\s*/, function(lexeme) {
     this.reject = inComponent || lexeme.trim() === '';
     if (this.reject) return;
     updatePosition(lexeme);
@@ -343,10 +346,10 @@ const lex = function(options, alias = {}) {
     return ['WORDS'].concat(formatToken(lexeme));
   });
 
-  lexer.addRule(/\s*\n{2,}\s*/, function(lexeme) {
+  lexer.addRule(/\s*\n+?\s*/, function(lexeme) {
     this.reject = inComponent;
     if (this.reject) return;
-    updatePosition(lexeme);
+    updatePosition(lexeme, true);
     return ['BREAK'];
   });
 
@@ -443,21 +446,18 @@ const lex = function(options, alias = {}) {
   lexer.addRule(/\s*$/, function(lexeme) {
     this.reject = !outer;
     if (this.reject) return;
-    updatePosition(lexeme);
+    updatePosition(lexeme, true);
     return ['EOF'];
   });
 
   return function(str) {
     currentInput = str;
-    var vals = [];
     var output = [];
-    var positions = [];
 
     lexer.input = str.trim();
     var token = lexer.lex();
     while (token) {
       output.push(token);
-      positions.push([row, column]);
       token = lexer.lex();
     }
     return {

--- a/packages/idyll-compiler/src/processors/post.js
+++ b/packages/idyll-compiler/src/processors/post.js
@@ -60,6 +60,9 @@ const cleanResults = (ast, options) => {
     if (rawNodes.indexOf(name) > -1) {
       return node;
     }
+    if (node[3]) {
+      return [node[0], node[1], cleanResults(node[2], options), node[3]];
+    }
     return [node[0], node[1], cleanResults(node[2], options)];
   });
 };
@@ -256,6 +259,28 @@ function getHyperLinksFromText(textNode) {
   return textNode.match(regexURL);
 }
 
+const linkMarkupToNode = (lexPositions, content) => {
+  return ast => {
+    const positions = [...lexPositions];
+    const lines = content.split('\n');
+    return ast.map(node => {
+      let [startRow, startColumn] = positions.shift();
+      let [endRow, endColumn] = positions.shift();
+      let markup = lines[startRow - 1].substring(startColumn - 1);
+      while (startRow < endRow) {
+        startRow++;
+        if (startRow === endRow) {
+          markup += lines[startRow - 1].substring(0, endColumn - 1);
+        } else {
+          markup += lines[startRow - 1];
+        }
+      }
+      node[3] = markup;
+      return node;
+    });
+  };
+};
+
 module.exports = {
   cleanResults,
   flattenChildren,
@@ -266,5 +291,6 @@ module.exports = {
   autoLinkifyHelper,
   hyperLinkifiedVersion,
   seperateTextAndHyperLink,
-  getHyperLinksFromText
+  getHyperLinksFromText,
+  linkMarkupToNode
 };


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
AST does not have a reference to markup which created the node in AST


* **What is the new behavior (if this is a feature change)?**
Both v1 and v2 version of AST is changed to include a reference to the original markup. In array-based v1 AST, a string is added at last to the node. In ast-v2, a key "raw" is included


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
Closes #530 