### PR TITLE
Template projects: Add link markup around bare URL to prevent 404 link

### DIFF
--- a/packages/idyll-template-projects/templates/article/index.idyll
+++ b/packages/idyll-template-projects/templates/article/index.idyll
@@ -113,7 +113,7 @@ Here is how you can instantiate a variable and bind it to a component:
 
 ## Learn More
 
-To learn more see the documentation at https://idyll-lang.org/docs/,
+To learn more see the documentation at [https://idyll-lang.org/docs/](https://idyll-lang.org/docs/),
 join our [chatroom](https://gitter.im/idyll-lang/Lobby), or see the project on [GitHub](https://github.com/idyll-lang/idyll).
 
 [hr /]

--- a/packages/idyll-template-projects/templates/multipage/posts/post-1/index.idyll
+++ b/packages/idyll-template-projects/templates/multipage/posts/post-1/index.idyll
@@ -113,5 +113,5 @@ Here is how you can instantiate a variable and bind it to a component:
 
 ## Learn More
 
-To learn more see the documentation at https://idyll-lang.org/docs/,
+To learn more see the documentation at [https://idyll-lang.org/docs/](https://idyll-lang.org/docs/),
 join our [chatroom](https://gitter.im/idyll-lang/Lobby), or see the project on [GitHub](https://github.com/idyll-lang/idyll).

--- a/packages/idyll-template-projects/templates/multipage/template/index.idyll
+++ b/packages/idyll-template-projects/templates/multipage/template/index.idyll
@@ -112,5 +112,5 @@ Here is how you can instantiate a variable and bind it to a component:
 
 ## Learn More
 
-To learn more see the documentation at https://idyll-lang.org/docs/,
+To learn more see the documentation at [https://idyll-lang.org/docs/](https://idyll-lang.org/docs/),
 join our [chatroom](https://gitter.im/idyll-lang/Lobby), or see the project on [GitHub](https://github.com/idyll-lang/idyll).

--- a/packages/idyll-template-projects/templates/scrollytelling/index.idyll
+++ b/packages/idyll-template-projects/templates/scrollytelling/index.idyll
@@ -136,7 +136,7 @@ Configuration can be done via the `idyll` field in `package.json`.
 
     ## Learn More
 
-    To learn more see the documentation at https://idyll-lang.org/docs/,
+    To learn more see the documentation at [https://idyll-lang.org/docs/](https://idyll-lang.org/docs/),
     join our [chatroom](https://gitter.im/idyll-lang/Lobby), or see the project on [GitHub](https://github.com/idyll-lang/idyll).
   [hr /]
     


### PR DESCRIPTION
The template pages in this commit each contain a bare URL pointing to
the idyll docs. The idyll compiler compiles these into links. But since
there is a comma adjacent to the end of each link, the idyll compiler
includes the comma in the linked-to URL, causing a 404 upon clicking the
link.

This commit replaces each `bare url,` with `[bare url](bare url),` to
prevent this behavior.

Github issue: https://github.com/idyll-lang/idyll/issues/614

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

https://github.com/idyll-lang/idyll/issues/614

* **What is the new behavior (if this is a feature change)?**

N/A

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No
