### PR TITLE
add compile libs option

### DIFF
--- a/packages/idyll-cli/src/index.js
+++ b/packages/idyll-cli/src/index.js
@@ -38,7 +38,8 @@ const idyll = (options = {}, cb) => {
       temp: '.idyll',
       template: join(__dirname, 'client', '_index.html'),
       transform: [],
-      compiler: {}
+      compiler: {},
+      compileLibs: false
     },
     options
   );
@@ -59,6 +60,8 @@ const idyll = (options = {}, cb) => {
   opts.transform = options.transform || inputConfig.transform || opts.transform;
   opts.compiler = options.compiler || inputConfig.compiler || opts.compiler;
   opts.context = options.context || inputConfig.context || opts.context;
+  opts.compileLibs =
+    options.compileLibs || inputConfig.compileLibs || opts.compileLibs;
 
   // Resolve compiler plugins:
   if (opts.compiler.postProcessors) {

--- a/packages/idyll-cli/src/pipeline/bundle-js.js
+++ b/packages/idyll-cli/src/pipeline/bundle-js.js
@@ -64,9 +64,9 @@ const getTransform = (opts, paths) => {
         presets: [envPreset, stage2Preset, reactPreset],
         babelrc: false,
         // Ensure that Babel doesn't process both the local and global node_modules.
-        ignore: new RegExp(
-          `(${getLocalModules(paths)}|${getGlobalModules(paths)})`
-        )
+        ignore: opts.compileLibs
+          ? null
+          : new RegExp(`(${getLocalModules(paths)}|${getGlobalModules(paths)})`)
       }
     ]
   ]


### PR DESCRIPTION
Add a new `compileLibs` option. I'm going to merge this for testing purposes now because we need it to help debug why vega-lite isn't working and will update docs and add tests later.