### PR TITLE
Add regenerator runtime

### DIFF
--- a/packages/idyll-cli/package.json
+++ b/packages/idyll-cli/package.json
@@ -61,6 +61,7 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "recursive-readdir": "^2.2.2",
+    "regenerator-runtime": "^0.13.5",
     "request": "^2.87.0",
     "request-promise-native": "^1.0.5",
     "resolve": "^1.3.3",

--- a/packages/idyll-cli/src/client/build.js
+++ b/packages/idyll-cli/src/client/build.js
@@ -11,6 +11,10 @@ var ReactDOM = require('react-dom');
 var IdyllDocument = require('idyll-document').default;
 var mountNode = document.getElementById('idyll-mount');
 
+// Included only so that VegaLite will
+// work properly with our ecosystem.
+require('regenerator-runtime/runtime');
+
 var ast = require('__IDYLL_AST__');
 var components = require('__IDYLL_COMPONENTS__');
 var datasets = require('__IDYLL_DATA__');

--- a/packages/idyll-cli/test/basic-project/test.js
+++ b/packages/idyll-cli/test/basic-project/test.js
@@ -84,6 +84,7 @@ test('options work as expected', () => {
     ssr: true,
     watch: false,
     open: true,
+    compileLibs: false,
     inputFile: join(PROJECT_DIR, 'index.idl'),
     output: PROJECT_BUILD_DIR,
     htmlTemplate: join(PROJECT_DIR, '_index.html'),

--- a/packages/idyll-cli/test/minified-project/test.js
+++ b/packages/idyll-cli/test/minified-project/test.js
@@ -84,6 +84,7 @@ test('options work as expected', () => {
     ssr: true,
     watch: false,
     open: true,
+    compileLibs: false,
     inputFile: join(PROJECT_DIR, 'index.idl'),
     output: PROJECT_BUILD_DIR,
     htmlTemplate: join(PROJECT_DIR, '_index.html'),

--- a/packages/idyll-cli/test/multiple-component-dirs/test.js
+++ b/packages/idyll-cli/test/multiple-component-dirs/test.js
@@ -86,6 +86,7 @@ test('options work as expected', () => {
     ssr: true,
     watch: false,
     open: true,
+    compileLibs: false,
     inputFile: join(PROJECT_DIR, 'index.idl'),
     output: PROJECT_BUILD_DIR,
     outputCSS: 'idyll_styles.css',

--- a/packages/idyll-cli/test/static-assets/test.js
+++ b/packages/idyll-cli/test/static-assets/test.js
@@ -88,6 +88,7 @@ test('options work as expected', () => {
     layout: 'centered',
     theme: join(PROJECT_DIR, 'custom-theme.css'),
     context: undefined,
+    compileLibs: false,
     minify: false,
     ssr: true,
     watch: true,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR includes the regenerator runtime in the Idyll client-side output so that it is compatible with libraries like VegaLite.

* **What is the current behavior?** (You can also link to an open issue here)
Libraries which expect this runtime to be available will break with an error message `Uncaught ReferenceError: regeneratorRuntime is not defined` (see #635). 


* **What is the new behavior (if this is a feature change)?**
No errors, the libraries work as expected.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.
