### PR TITLE
updating sytax page, plugin page, component pages

### DIFF
--- a/packages/idyll-docs/idyll-components/examples/SVG.idl
+++ b/packages/idyll-docs/idyll-components/examples/SVG.idl
@@ -1,1 +1,1 @@
-[SVG src:"path/to/file.svg" /]
+[SVG src:"static/images/logo-text.svg" /]

--- a/packages/idyll-docs/idyll-components/examples/Table.idl
+++ b/packages/idyll-docs/idyll-components/examples/Table.idl
@@ -1,1 +1,1 @@
-[Table data:`[{columnName1: value, columnName2: value}, {columnName1: value, columnName2: value}]` /]
+[Table value:`[{columnName1: value, columnName2: value}, {columnName1: value, columnName2: value}]` /]

--- a/packages/idyll-docs/idyll-components/examples/Youtube.idl
+++ b/packages/idyll-docs/idyll-components/examples/Youtube.idl
@@ -1,11 +1,8 @@
-
 [Youtube
-  id:"videoID"
+  id:"KnPe6dZuwlg"
   play:true
   audio:true
   width:500
   height:300
   options:`{ controls: 1 }`
   /]
-
-

--- a/packages/idyll-docs/pages/docs/component.js
+++ b/packages/idyll-docs/pages/docs/component.js
@@ -47,11 +47,24 @@ class IdyllComponentDoc extends React.Component {
         )}
         {liveExample && exampleCode && (
           <div>
-            <h3>Live Example</h3>
-            <IdyllDocument markup={exampleCode} components={IdyllComponents} />
+            <h4>Input:</h4>
             <pre>
-              <code>{exampleCode}</code>
+              <code>{(exampleCode || '').trim()}</code>
             </pre>
+            <h4>Output:</h4>
+            <div
+              style={{
+                border: 'solid 1px black',
+                borderRadius: 5,
+                padding: '1em',
+                boxShadow: '3px 3px 5px #ccc'
+              }}
+            >
+              <IdyllDocument
+                markup={exampleCode}
+                components={IdyllComponents}
+              />
+            </div>
           </div>
         )}
         {((component && component._idyll.props) || idyllProps) && (

--- a/packages/idyll-docs/pages/docs/plugin-system.js
+++ b/packages/idyll-docs/pages/docs/plugin-system.js
@@ -11,28 +11,66 @@ export default ({ url }) => (
     <div>
       <h1>Plugin System</h1>
 
-      <p>
-        See available plugins:
-        <ul>
-          <li>
-            <a href="https://github.com/idyll-lang/idyll-plugins">
-              https://github.com/idyll-lang/idyll-plugins
-            </a>
-          </li>
-        </ul>
-      </p>
+      <h2>Using Plugins</h2>
 
       <p>
-        This section details how to work with the custom hooks exposed by
-        Idyll's compiler and runtime. If you want to learn about basic
-        configuration options and styling,{' '}
-        <Link href="/docs/configuration-and-styles">
-          <a>see this page</a>
-        </Link>
+        Plugins are sorted into two categories, compiler plugins and runtime
+        plugins. Compiler plugins can affect how the project builds or modify
+        the abstract syntax tree that Idyll produces. Runtime plugins can
+        inspect and affect Idyll's reactive variable system in the browser.
+      </p>
+
+      <p>See each plugin for specific installation and usage instructions.</p>
+
+      <h3>Compiler Plugins</h3>
+      <ul>
+        <li>
+          <a href="https://github.com/idyll-lang/idyll-plugin-spellcheck">
+            Spellcheck
+          </a>
+        </li>
+        <li>
+          <a href="https://github.com/idyll-lang/idyll-plugin-table-of-contents">
+            Table of Contents
+          </a>
+        </li>
+        <li>
+          <a href="https://github.com/idyll-lang/idyll-plugin-revision">
+            Git Revisions
+          </a>
+        </li>
+      </ul>
+      <h3>Runtime Plugins</h3>
+      <ul>
+        <li>
+          <a href="https://github.com/idyll-lang/idyll-plugin-url-state">
+            URL State Synchronization
+          </a>{' '}
+          - serialize the article state into the URL. Allows readers to share
+          the article in a particular configuration.
+        </li>
+        <li>
+          <a href="https://github.com/idyll-lang/idyll-analytics">Analytics</a>{' '}
+          - collect detailed usage data to learn how readers are interacting
+          with your article.
+        </li>
+      </ul>
+      <p>
+        To use multiple runtime plugins simultaneously, use{' '}
+        <a href="https://github.com/idyll-lang/idyll-context-compose">
+          idyll-context-compose
+        </a>
         .
       </p>
 
-      <h2>Compiler Plugins</h2>
+      <h2>Developing Plugins</h2>
+
+      <p>
+        This section details how to work with the custom hooks exposed by
+        Idyll's compiler and runtime.
+      </p>
+
+      <h3>Compiler Plugins</h3>
 
       <p>
         The compiler is responsible for transforming Idyll markup into a
@@ -73,7 +111,7 @@ module.exports = (ast) => {
 }`}
       </Highlight>
 
-      <h2>Runtime Context</h2>
+      <h3>Runtime Context</h3>
 
       <p>
         If you want to write custom code that reads or writes to Idyll's

--- a/packages/idyll-docs/pages/docs/syntax.js
+++ b/packages/idyll-docs/pages/docs/syntax.js
@@ -1,32 +1,13 @@
-import Link from 'next/link'
-import markdown from 'markdown-in-js'
-import Layout from '../../components/layout'
-
+import Link from 'next/link';
+import markdown from 'markdown-in-js';
+import Layout from '../../components/layout';
 
 const Content = () => markdown`
 # Syntax
 
-
-#### Contents
-
-* [Text](#text)
-  * [Bold and Italic](#bold-italic)
-  * [Headers](#headers)
-  * [Code](#code)
-  * [Lists](#lists)
-* [Components](#components)
-  * [Properties](#component-properties)
-    * [Literals](#literals)
-    * [Variables and Datasets](#variables-and-datasets)
-    * [Expressions](#expressions)
-    * [Refs](#refs)
-* [Variables](#variables)
-  * [Derived Variables](#derived-variables)
-* [Datasets](#datasets)
-
-
-#### A short note
-
+Idyll markup is an extension of [markdown](https://daringfireball.net/projects/markdown/syntax),
+which is meant to be easy to read and write. The main extensions are _reactive variables_, and _components_. Together these two elements
+can be used to create dynamic, interactive articles.
 
 We provide syntax highlighting plugins for several editors:
 
@@ -35,10 +16,26 @@ We provide syntax highlighting plugins for several editors:
 
 If you'd like a syntax highlighter for a different editor, please [open an issue on github](https://github.com/idyll-lang/idyll/issues).
 
-*Idyll tries to maintain parity with popular markdown implementations,
+_Idyll tries to maintain parity with popular markdown implementations,
 but sometimes doesn't get things exactly right. If something seems off,
-feel free to [open an issue](https://github.com/idyll-lang/idyll/issues?q=is%3Aissue+is%3Aopen+label%3ACompiler).*
+feel free to [open an issue](https://github.com/idyll-lang/idyll/issues?q=is%3Aissue+is%3Aopen+label%3ACompiler)._
 
+#### Contents
+
+- [Text](#text)
+  - [Bold and Italic](#bold-italic)
+  - [Headers](#headers)
+  - [Code](#code)
+  - [Lists](#lists)
+- [Components](#components)
+  - [Properties](#component-properties)
+    - [Literals](#literals)
+    - [Variables and Datasets](#variables-and-datasets)
+    - [Expressions](#expressions)
+    - [Refs](#refs)
+- [Variables](#variables)
+  - [Derived Variables](#derived-variables)
+- [Datasets](#datasets)
 
 <h2 id="text">Text</h2>
 
@@ -48,20 +45,20 @@ formatting tasks easier, Idyll borrows some syntax from markdown.
 <h4 id="bold-italic">Bold, italic</h4>
 
 Text surrounded by asterisks (\`*\`) will be bolded,
-e.g. \`*italic*\` becomes *italic*, and \`**bold**\` becomes **bold**.
+e.g. \`*italic*\` becomes _italic_, and \`**bold**\` becomes **bold**.
 
 <h4 id="headers">Headers</h4>
 
 Use a pound sign (\`#\`) to denote a header:
 
-\`\`\`
+~~~
 # Title h1
 ## Title h2
 ### Title h3
 #### Title h4
 ##### Title h5
 ###### Title h6
-\`\`\`
+~~~
 
 <h4 id="code">Code</h4>
 
@@ -71,22 +68,24 @@ as code: \`\` \`y = x * x\` \`\` becomes \`y = x * x\`.
 Text placed between groups of three backticks will be displayed as
 a code block.
 
-\`\`\`
+~~~
 This is a code block
-\`\`\`
+~~~
 
 The above code block is created with this code:
-\`\`\`
+
+~~~
 \\\`\\\`\\\`
 This is a code block
 \\\`\\\`\\\`
-\`\`\`
+~~~
 
 <h4 id="lists">Lists</h4>
 
 Ordered and unordered lists are supported. Lists can be created by using an asterisk (\`*\`)
 or numbers. For example:
-\`\`\`
+
+~~~
 * Unordered item one
 * Unordered item two
 * Unordered item three
@@ -94,7 +93,7 @@ or numbers. For example:
 1. ordered item one
 2. ordered item two
 3. ordered item three
-\`\`\`
+~~~
 
 <h2 id="components">Components</h2>
 
@@ -102,17 +101,17 @@ Besides text, components are the other basic building block of an Idyll document
 Components are denoted with brackets, and can be invoked in one of two ways: they can be self
 closing,
 
-\`\`\`
+~~~
 [Range min:0 max:10 value:value /]
-\`\`\`
+~~~
 
 or have a closing and opening tag with content in between.
 
-\`\`\`
+~~~
 [Button]
 Click Me
 [/Button]
-\`\`\`
+~~~
 
 <h3 id="component-properties">Component properties</h3>
 
@@ -123,11 +122,11 @@ in the following ways:
 
 Number, string, or boolean literals may be used.
 
-\`\`\`
+~~~
 [Component propName:10 /]
 [Component propName:'propValue' /]
 [Component propName:false /]
-\`\`\`
+~~~
 
 <h4 id="variables-and-datasets">Variable and datasets</h4>
 
@@ -135,9 +134,9 @@ A variable or dataset can be passed in directly, this will
 automatically create a binding between that variable and property,
 more on this in the section on [variables and datasets](/components-variables-and-datasets).
 
-\`\`\`
+~~~
 [Component propName:myVar /]
-\`\`\`
+~~~
 
 If the variable changes that update will immediately be reflected in the
 state of the component.
@@ -146,10 +145,10 @@ state of the component.
 
 Use backticks to pass an evaluated expression:
 
-\`\`\`
+~~~
 [Component propName:\\\`2 * 2 * 2\\\` /]
 [Component propName:\\\`{ an: 'object' }\\\` /]
-\`\`\`
+~~~
 
 Note that because Idyll is reactive, if a variable changes, any expressions that reference that
 variable will immediately be recomputed. See this utilized to create reactive vega-lite specifications:
@@ -160,14 +159,13 @@ the expression will automatically be
 converted to a callback. This is convenient
 for updating variables on events, for example.
 
-\`\`\`
+~~~
 [Component onClick:\\\`myVar++\\\` /]
-\`\`\`
+~~~
 
 Idyll uses naming conventions to determine if the expression should be converted to a callback.
 Properties that are named \`onXxxxx\` (e.g. \`onClick\`) or \`handleYyyyy\` (e.g. \`handleMouseMove\`) are
 assumed to expect callbacks.
-
 
 <h4 id="refs">Refs</h4>
 
@@ -175,16 +173,15 @@ There is a special property called \`ref\` that allows you to create a reference
 component on the page. This is primarily used to keep track of elements on the page as
 a reader scrolls. See the section on [refs](/components-refs) for more details.
 
-
 <h2 id="variables">Variables</h2>
 
 Variables can be declared at any point in an Idyll file. Variables use
 the same syntax as a component, but must defined a \`name\` and a \`value\`
 property.
 
-\`\`\`
+~~~
 [var name:'x' value:10 /]
-\`\`\`
+~~~
 
 The above code defines a variable \`x\`, with the initial value of \`10\`.
 
@@ -193,9 +190,9 @@ The above code defines a variable \`x\`, with the initial value of \`10\`.
 A derived variable is similar to a \`var\`, but its value is derived from
 other variables, and is recomputed whenever values change:
 
-\`\`\`
+~~~
 [derived name:'xSquared' value:\\\`x * x\\\` /]
-\`\`\`
+~~~
 
 The above code defines a derived variable \`xSquared\` that depends
 on the value of \`x\`. The value of \`xSquared\` is automatically updated
@@ -208,10 +205,10 @@ A dataset is similar to a variable, except instead of expecting a
 
 Example:
 
-\`\`\`
+~~~
 [data name:'myData' source:'myData.csv' /]
 [Table data:myData /]
-\`\`\`
+~~~
 
 The above code declares a dataset, and uses it as input to a \`Table\` component.
 Datasets can be either \`.csv\` or \`.json\` files. CSV files will automatically be
@@ -226,14 +223,17 @@ Example:
 
 The above code fetches the dataset from the given \`source\` and stores it into \`myAsyncData\`.
 Until the dataset is fetched it will be set to the \`initialValue\`.
-`
+`;
 
 export default ({ url }) => (
-  <Layout url={ url } title={'Idyll Documentation | Markup Syntax'}>
+  <Layout url={url} title={'Idyll Documentation | Markup Syntax'}>
     <Content />
     <p>
       Continue to the next section to learn about{' '}
-      <Link href="/docs/configuration-and-styles"><a>customizing Idyll</a></Link>.
+      <Link href="/docs/configuration-and-styles">
+        <a>customizing Idyll</a>
+      </Link>
+      .
     </p>
   </Layout>
-)
+);


### PR DESCRIPTION
This update the docs:

- adds a list of available plugins to the plugins page
- improve structure of plugins page
- improve the styling of the built-in component details pages
- improve the example code for several components
- add a short introduction to the syntax page

 fixes #644 #647 

