### PR TITLE
add fullWidthSteps option to scroller

### DIFF
--- a/packages/idyll-components/src/scroller.js
+++ b/packages/idyll-components/src/scroller.js
@@ -145,6 +145,8 @@ class Scroller extends React.Component {
       return c.type.name && c.type.name.toLowerCase() === 'graphic';
     });
 
+    const StepContainer = props.fullWidthSteps ? 'div' : TextContainer;
+
     return (
       <div
         ref={ref => (this.ref = ref)}
@@ -170,7 +172,7 @@ class Scroller extends React.Component {
             </div>
           </div>
         ) : null}
-        <TextContainer idyll={idyll}>
+        <StepContainer idyll={idyll}>
           <div className="idyll-scroll-text">
             {mapChildren(
               filterChildren(children, c => {
@@ -183,7 +185,7 @@ class Scroller extends React.Component {
               }
             )}
           </div>
-        </TextContainer>
+        </StepContainer>
       </div>
     );
   }


### PR DESCRIPTION
This adds a new property `fullWidthSteps` to the scroller component. It allows users to opt-out of the width limitation for `[Step]`s in a scroller, as they are normally constrained to the text column width.

See example here: https://mathisonian.github.io/full-width-scroller-steps/ (code: https://github.com/mathisonian/full-width-scroller-steps)