### PR TITLE
docs: Fix simple typo, maddness -> madness

### DIFF
--- a/packages/idyll-cli/test/basic-project/expected-output/build/static/idyll_index.js
+++ b/packages/idyll-cli/test/basic-project/expected-output/build/static/idyll_index.js
@@ -4178,7 +4178,7 @@ function runTimeout(fun) {
         return setTimeout(fun, 0);
     }
     try {
-        // when when somebody has screwed with setTimeout but no I.E. maddness
+        // when when somebody has screwed with setTimeout but no I.E. madness
         return cachedSetTimeout(fun, 0);
     } catch(e){
         try {
@@ -4203,7 +4203,7 @@ function runClearTimeout(marker) {
         return clearTimeout(marker);
     }
     try {
-        // when when somebody has screwed with setTimeout but no I.E. maddness
+        // when when somebody has screwed with setTimeout but no I.E. madness
         return cachedClearTimeout(marker);
     } catch (e){
         try {

--- a/packages/idyll-cli/test/batteries-included/expected-output/build/static/idyll_index.js
+++ b/packages/idyll-cli/test/batteries-included/expected-output/build/static/idyll_index.js
@@ -3588,7 +3588,7 @@ function runTimeout(fun) {
         return setTimeout(fun, 0);
     }
     try {
-        // when when somebody has screwed with setTimeout but no I.E. maddness
+        // when when somebody has screwed with setTimeout but no I.E. madness
         return cachedSetTimeout(fun, 0);
     } catch(e){
         try {
@@ -3613,7 +3613,7 @@ function runClearTimeout(marker) {
         return clearTimeout(marker);
     }
     try {
-        // when when somebody has screwed with setTimeout but no I.E. maddness
+        // when when somebody has screwed with setTimeout but no I.E. madness
         return cachedClearTimeout(marker);
     } catch (e){
         try {

--- a/packages/idyll-cli/test/minified-project/expected-output/build/static/idyll_index.js
+++ b/packages/idyll-cli/test/minified-project/expected-output/build/static/idyll_index.js
@@ -4178,7 +4178,7 @@ function runTimeout(fun) {
         return setTimeout(fun, 0);
     }
     try {
-        // when when somebody has screwed with setTimeout but no I.E. maddness
+        // when when somebody has screwed with setTimeout but no I.E. madness
         return cachedSetTimeout(fun, 0);
     } catch(e){
         try {
@@ -4203,7 +4203,7 @@ function runClearTimeout(marker) {
         return clearTimeout(marker);
     }
     try {
-        // when when somebody has screwed with setTimeout but no I.E. maddness
+        // when when somebody has screwed with setTimeout but no I.E. madness
         return cachedClearTimeout(marker);
     } catch (e){
         try {

--- a/packages/idyll-cli/test/multiple-component-dirs/expected-output/build/static/idyll_index.js
+++ b/packages/idyll-cli/test/multiple-component-dirs/expected-output/build/static/idyll_index.js
@@ -4178,7 +4178,7 @@ function runTimeout(fun) {
         return setTimeout(fun, 0);
     }
     try {
-        // when when somebody has screwed with setTimeout but no I.E. maddness
+        // when when somebody has screwed with setTimeout but no I.E. madness
         return cachedSetTimeout(fun, 0);
     } catch(e){
         try {
@@ -4203,7 +4203,7 @@ function runClearTimeout(marker) {
         return clearTimeout(marker);
     }
     try {
-        // when when somebody has screwed with setTimeout but no I.E. maddness
+        // when when somebody has screwed with setTimeout but no I.E. madness
         return cachedClearTimeout(marker);
     } catch (e){
         try {


### PR DESCRIPTION
There is a small typo in packages/idyll-cli/test/basic-project/expected-output/build/static/idyll_index.js, packages/idyll-cli/test/batteries-included/expected-output/build/static/idyll_index.js, packages/idyll-cli/test/minified-project/expected-output/build/static/idyll_index.js, packages/idyll-cli/test/multiple-component-dirs/expected-output/build/static/idyll_index.js.

Should read `madness` rather than `maddness`.

