### PR TITLE
fix whitespace in AST serialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 
 node_js:
-  - '8'
   - '10'
   - '12'
+  - '14'
 
 env:
   - PACKAGE=idyll-ast

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ environment:
   matrix:
     - nodejs_version: '10'
     - nodejs_version: '12'
+    - nodejs_version: '14'
 
 cache:
   - "%LOCALAPPDATA%\\Yarn"

--- a/packages/idyll-ast/src/index.js
+++ b/packages/idyll-ast/src/index.js
@@ -942,7 +942,7 @@ function childrenToMarkup(node, depth) {
 function nodeToMarkup(node, depth) {
   switch (node.type) {
     case 'textnode':
-      return `${'  '.repeat(depth)}${node.value}`;
+      return `${'  '.repeat(depth)}${node.value.trim()}`;
     case 'component':
       if (node.name.toLowerCase() === 'textcontainer') {
         return `\n${childrenToMarkup(node, depth)}\n`;


### PR DESCRIPTION
Small fix to the `toMarkup` function in the AST. It prevents additional white space from being introduced when an AST is serialized and deserialized multiple times. 