### PR TITLE
wrap components even when they have errors

### DIFF
--- a/packages/idyll-document/src/runtime.js
+++ b/packages/idyll-document/src/runtime.js
@@ -175,14 +175,6 @@ const createWrapper = ({ theme, layout, authorView, userViewComponent }) => {
     }
 
     render() {
-      if (this.state.hasError) {
-        return (
-          <div style={{ border: 'solid red 1px', padding: 10 }}>
-            {this.state.error.message}
-          </div>
-        );
-      }
-
       const state = filterIdyllProps(this.state, this.props.isHTMLNode);
       const { children, ...passThruProps } = filterIdyllProps(
         this.props,
@@ -190,7 +182,7 @@ const createWrapper = ({ theme, layout, authorView, userViewComponent }) => {
       );
       let childComponent = null;
       let uniqueKey = `${this.key}-help`;
-      const returnComponent = React.Children.map(children, (c, i) => {
+      let returnComponent = React.Children.map(children, (c, i) => {
         childComponent = c;
         return React.cloneElement(c, {
           key: `${this.key}-${i}`,
@@ -203,6 +195,13 @@ const createWrapper = ({ theme, layout, authorView, userViewComponent }) => {
           ...passThruProps
         });
       });
+      if (this.state.hasError) {
+        returnComponent = (
+          <div style={{ border: 'solid red 1px', padding: 10 }}>
+            {this.state.error.message}
+          </div>
+        );
+      }
       const metaData = childComponent.type._idyll;
       if (authorView && metaData && metaData.props) {
         // ensure inline elements do not have this overlay


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This modifies the behavior of error handling in the Idyll document. It changes it so that when components throw errors, they can still be wrapped in a user provided author-view component, allowing any editors built on top of Idyll (e.g. https://github.com/idyll-lang/idyll-studio) to continue functioning even when components throw.


* **What is the current behavior?** (You can also link to an open issue here)
If a component throws an error it will not render the AuthorView.


