### PR TITLE
add fullwidth functionality to the markup serializer

### DIFF
--- a/packages/idyll-ast/test/test.js
+++ b/packages/idyll-ast/test/test.js
@@ -392,4 +392,43 @@ One two *three*
     `.trim()
     );
   });
+
+  it('should insert full width props when requested', function() {
+    const markup = util.toMarkup(
+      {
+        id: -1,
+        type: 'component',
+        name: 'div',
+        children: [
+          {
+            id: 1,
+            type: 'component',
+            name: 'Header',
+            properties: {}
+          },
+          {
+            id: 2,
+            type: 'component',
+            name: 'TextContainer',
+            children: [
+              {
+                id: 3,
+                type: 'textnode',
+                value: 'Hello world.'
+              }
+            ]
+          }
+        ]
+      },
+      { insertFullWidth: true }
+    );
+
+    expect(markup.trim()).to.eql(
+      `
+[Header fullWidth:true /]
+
+Hello world.
+    `.trim()
+    );
+  });
 });


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
The AST's  `toMarkup()` function now takes an option `insertFullWidth` (e.g. `toMarkup(ast, { insertFullWidth: true })`) so that the fullWidth props will be correctly serialized onto the resulting idyll markup where appropriate. 
