### PR TITLE
support multiple callbacks in the context

### DIFF
--- a/packages/idyll-document/src/runtime.js
+++ b/packages/idyll-document/src/runtime.js
@@ -281,13 +281,31 @@ class IdyllRuntime extends React.PureComponent {
           return this.state;
         },
         onInitialize: cb => {
-          this._onInitializeState = cb;
+          this._initializeCallbacks.push(cb);
         },
         onMount: cb => {
-          this._onMount = cb;
+          this._mountCallbacks.push(cb);
         },
         onUpdate: cb => {
-          this._onUpdateState = cb;
+          this._updateCallbacks.push(cb);
+        },
+        _initializeCallbacks: [],
+        _mountCallbacks: [],
+        _updateCallbacks: [],
+        _onInitializeState: () => {
+          this._initializeCallbacks.forEach(cb => {
+            cb();
+          });
+        },
+        _onMount: () => {
+          this._mountCallbacks.forEach(cb => {
+            cb();
+          });
+        },
+        _onUpdateState: newData => {
+          this._updateCallbacks.forEach(cb => {
+            cb(newData);
+          });
         }
       });
     }

--- a/packages/idyll-document/src/runtime.js
+++ b/packages/idyll-document/src/runtime.js
@@ -272,21 +272,21 @@ class IdyllRuntime extends React.PureComponent {
     let _mountCallbacks = [];
     let _updateCallbacks = [];
 
-    (this._onInitializeState = () => {
+    this._onInitializeState = () => {
       _initializeCallbacks.forEach(cb => {
         cb();
       });
-    }),
-      (this._onMount = () => {
-        _mountCallbacks.forEach(cb => {
-          cb();
-        });
-      }),
-      (this._onUpdateState = newData => {
-        _updateCallbacks.forEach(cb => {
-          cb(newData);
-        });
+    };
+    this._onMount = () => {
+      _mountCallbacks.forEach(cb => {
+        cb();
       });
+    };
+    this._onUpdateState = newData => {
+      _updateCallbacks.forEach(cb => {
+        cb(newData);
+      });
+    };
     if (typeof props.context === 'function') {
       props.context({
         update: newState => {

--- a/packages/idyll-document/src/runtime.js
+++ b/packages/idyll-document/src/runtime.js
@@ -268,6 +268,9 @@ class IdyllRuntime extends React.PureComponent {
     let hasInitialized = false;
     let initialContext = {};
     // Initialize a custom context
+    let _initializeCallbacks = [];
+    let _mountCallbacks = [];
+    let _updateCallbacks = [];
     if (typeof props.context === 'function') {
       props.context({
         update: newState => {
@@ -281,29 +284,26 @@ class IdyllRuntime extends React.PureComponent {
           return this.state;
         },
         onInitialize: cb => {
-          this._initializeCallbacks.push(cb);
+          _initializeCallbacks.push(cb);
         },
         onMount: cb => {
-          this._mountCallbacks.push(cb);
+          _mountCallbacks.push(cb);
         },
         onUpdate: cb => {
-          this._updateCallbacks.push(cb);
+          _updateCallbacks.push(cb);
         },
-        _initializeCallbacks: [],
-        _mountCallbacks: [],
-        _updateCallbacks: [],
         _onInitializeState: () => {
-          this._initializeCallbacks.forEach(cb => {
+          _initializeCallbacks.forEach(cb => {
             cb();
           });
         },
         _onMount: () => {
-          this._mountCallbacks.forEach(cb => {
+          _mountCallbacks.forEach(cb => {
             cb();
           });
         },
         _onUpdateState: newData => {
-          this._updateCallbacks.forEach(cb => {
+          _updateCallbacks.forEach(cb => {
             cb(newData);
           });
         }

--- a/packages/idyll-document/src/runtime.js
+++ b/packages/idyll-document/src/runtime.js
@@ -271,6 +271,22 @@ class IdyllRuntime extends React.PureComponent {
     let _initializeCallbacks = [];
     let _mountCallbacks = [];
     let _updateCallbacks = [];
+
+    (this._onInitializeState = () => {
+      _initializeCallbacks.forEach(cb => {
+        cb();
+      });
+    }),
+      (this._onMount = () => {
+        _mountCallbacks.forEach(cb => {
+          cb();
+        });
+      }),
+      (this._onUpdateState = newData => {
+        _updateCallbacks.forEach(cb => {
+          cb(newData);
+        });
+      });
     if (typeof props.context === 'function') {
       props.context({
         update: newState => {
@@ -291,21 +307,6 @@ class IdyllRuntime extends React.PureComponent {
         },
         onUpdate: cb => {
           _updateCallbacks.push(cb);
-        },
-        _onInitializeState: () => {
-          _initializeCallbacks.forEach(cb => {
-            cb();
-          });
-        },
-        _onMount: () => {
-          _mountCallbacks.forEach(cb => {
-            cb();
-          });
-        },
-        _onUpdateState: newData => {
-          _updateCallbacks.forEach(cb => {
-            cb(newData);
-          });
         }
       });
     }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
The custom context API (https://idyll-lang.org/docs/plugin-system) now supports multiple listeners when `onUpdate` (and `onMount`, `onInitialize`) are called multiple times.


* **What is the current behavior?** (You can also link to an open issue here)
Only the last callback provided is fired.


* **What is the new behavior (if this is a feature change)?**
All callbacks provided fire.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

