### PR TITLE
fix publish command on windows

### DIFF
--- a/packages/idyll-cli/bin/cmds/publish.js
+++ b/packages/idyll-cli/bin/cmds/publish.js
@@ -51,7 +51,9 @@ exports.handler = async yargs => {
     let files = await readdir(buildPath);
 
     let formData = files.reduce((acc, f) => {
-      acc[p.relative(buildPath, f)] = fs.createReadStream(f);
+      acc[p.relative(buildPath, f).replace(/\\/g, '/')] = fs.createReadStream(
+        f
+      );
       return acc;
     }, {});
     formData.token = token;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Windows only bugfix - fixes an issue where the `idyll publish` command would not properly upload static assets (js, css, etc) to the idyll.pub API.


* **What is the current behavior?** (You can also link to an open issue here)
The publish command says "succeeded" but the resulting URL shows a broken page


* **What is the new behavior (if this is a feature change)?**
The publish command succeeds as expected  


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No