### PR TITLE
Static asset path

### DIFF
--- a/packages/idyll-cli/src/client/_index.html
+++ b/packages/idyll-cli/src/client/_index.html
@@ -42,10 +42,10 @@
     <link rel="stylesheet" href="{{googleFontsUrl}}" />
     {{/googleFontsUrl}}
 
-    <link rel="stylesheet" href="static/idyll_styles.css" />
+    <link rel="stylesheet" href="{{staticOutputDir}}/idyll_styles.css" />
   </head>
   <body>
     <div id="idyll-mount">{{{idyllContent}}}</div>
-    <script src="static/idyll_index.js"></script>
+    <script src="{{staticOutputDir}}/idyll_index.js"></script>
   </body>
 </html>

--- a/packages/idyll-cli/src/index.js
+++ b/packages/idyll-cli/src/index.js
@@ -48,6 +48,7 @@ const idyll = (options = {}, cb) => {
       ssr: true,
       components: 'components',
       static: 'static',
+      static_output_dir: 'static',
       defaultComponents: dirname(require.resolve('idyll-components')),
       layout: 'centered',
       theme: 'github',

--- a/packages/idyll-cli/src/index.js
+++ b/packages/idyll-cli/src/index.js
@@ -3,6 +3,8 @@ const { dirname, basename, extname, join } = require('path');
 const EventEmitter = require('events');
 const mkdirp = require('mkdirp');
 
+console.log('idyll');
+
 const pathBuilder = require('./path-builder');
 const configureNode = require('./node-config');
 const pipeline = require('./pipeline');
@@ -37,6 +39,7 @@ const searchParentDirectories = packageDir => {
 };
 
 const idyll = (options = {}, cb) => {
+  console.log(options);
   const opts = Object.assign(
     {},
     {
@@ -48,7 +51,7 @@ const idyll = (options = {}, cb) => {
       ssr: true,
       components: 'components',
       static: 'static',
-      static_output_dir: 'static',
+      staticOutputDir: 'static',
       defaultComponents: dirname(require.resolve('idyll-components')),
       layout: 'centered',
       theme: 'github',
@@ -65,6 +68,7 @@ const idyll = (options = {}, cb) => {
     options
   );
 
+  console.log(opts);
   const paths = pathBuilder(opts);
   debug('Reading from paths:', paths);
 

--- a/packages/idyll-cli/src/index.js
+++ b/packages/idyll-cli/src/index.js
@@ -3,8 +3,6 @@ const { dirname, basename, extname, join } = require('path');
 const EventEmitter = require('events');
 const mkdirp = require('mkdirp');
 
-console.log('idyll');
-
 const pathBuilder = require('./path-builder');
 const configureNode = require('./node-config');
 const pipeline = require('./pipeline');
@@ -39,7 +37,6 @@ const searchParentDirectories = packageDir => {
 };
 
 const idyll = (options = {}, cb) => {
-  console.log(options);
   const opts = Object.assign(
     {},
     {
@@ -68,7 +65,6 @@ const idyll = (options = {}, cb) => {
     options
   );
 
-  console.log(opts);
   const paths = pathBuilder(opts);
   debug('Reading from paths:', paths);
 

--- a/packages/idyll-cli/src/path-builder.js
+++ b/packages/idyll-cli/src/path-builder.js
@@ -26,7 +26,10 @@ module.exports = function(opts) {
 
   const resolveWithOutputBase = resolveWithBase(getBaseDir(opts.output));
   const OUTPUT_DIR = resolveWithOutputBase(opts.output);
-  const STATIC_OUTPUT_DIR = join(OUTPUT_DIR, opts.static_output_dir);
+  const STATIC_OUTPUT_DIR = join(OUTPUT_DIR, opts.static_output_dir).replace(
+    /\/$/,
+    ''
+  );
   const TMP_DIR = resolveWithProjBase(opts.temp);
 
   return {

--- a/packages/idyll-cli/src/path-builder.js
+++ b/packages/idyll-cli/src/path-builder.js
@@ -26,10 +26,11 @@ module.exports = function(opts) {
 
   const resolveWithOutputBase = resolveWithBase(getBaseDir(opts.output));
   const OUTPUT_DIR = resolveWithOutputBase(opts.output);
-  const STATIC_OUTPUT_DIR = join(OUTPUT_DIR, opts.static_output_dir).replace(
-    /\/$/,
-    ''
-  );
+  console.log(OUTPUT_DIR, opts.staticOutputDir);
+  const STATIC_OUTPUT_DIR = join(
+    OUTPUT_DIR,
+    opts.staticOutputDir || 'static'
+  ).replace(/\/$/, '');
   const TMP_DIR = resolveWithProjBase(opts.temp);
 
   return {

--- a/packages/idyll-cli/src/path-builder.js
+++ b/packages/idyll-cli/src/path-builder.js
@@ -26,7 +26,6 @@ module.exports = function(opts) {
 
   const resolveWithOutputBase = resolveWithBase(getBaseDir(opts.output));
   const OUTPUT_DIR = resolveWithOutputBase(opts.output);
-  console.log(OUTPUT_DIR, opts.staticOutputDir);
   const STATIC_OUTPUT_DIR = join(
     OUTPUT_DIR,
     opts.staticOutputDir || 'static'

--- a/packages/idyll-cli/src/path-builder.js
+++ b/packages/idyll-cli/src/path-builder.js
@@ -26,7 +26,7 @@ module.exports = function(opts) {
 
   const resolveWithOutputBase = resolveWithBase(getBaseDir(opts.output));
   const OUTPUT_DIR = resolveWithOutputBase(opts.output);
-  const STATIC_OUTPUT_DIR = join(OUTPUT_DIR, 'static');
+  const STATIC_OUTPUT_DIR = join(OUTPUT_DIR, opts.static_output_dir);
   const TMP_DIR = resolveWithProjBase(opts.temp);
 
   return {

--- a/packages/idyll-cli/src/pipeline/parse.js
+++ b/packages/idyll-cli/src/pipeline/parse.js
@@ -200,7 +200,7 @@ exports.getHTML = (paths, ast, _components, datasets, template, opts) => {
     template,
     Object.assign(
       {
-        favicon: c.favicon,
+        favicon: opts.favicon,
         usesTex: components.equation,
         googleFontsUrl: getGoogleFontsUrl(opts),
         staticOutputDir: opts.staticOutputDir || 'static'

--- a/packages/idyll-cli/src/pipeline/parse.js
+++ b/packages/idyll-cli/src/pipeline/parse.js
@@ -162,7 +162,7 @@ exports.getBaseHTML = (ast, template, opts) => {
       {
         googleFontsUrl: getGoogleFontsUrl(opts),
         favicon: opts.favicon,
-        staticOutputDir: paths.STATIC_OUTPUT_DIR
+        staticOutputDir: opts.staticOutputDir || 'static'
       },
       parseMeta(ast)
     )
@@ -200,10 +200,10 @@ exports.getHTML = (paths, ast, _components, datasets, template, opts) => {
     template,
     Object.assign(
       {
-        favicon: opts.favicon,
+        favicon: c.favicon,
         usesTex: components.equation,
         googleFontsUrl: getGoogleFontsUrl(opts),
-        staticOutputDir: paths.STATIC_OUTPUT_DIR
+        staticOutputDir: opts.staticOutputDir || 'static'
       },
       meta
     )

--- a/packages/idyll-cli/src/pipeline/parse.js
+++ b/packages/idyll-cli/src/pipeline/parse.js
@@ -126,7 +126,7 @@ const parseMeta = ast => {
 
   let metaProperties = {};
   if (metaNodes.length > 1) {
-    console.warn('There are more than 1 meta nodes');
+    console.warn('There is more than 1 meta node.');
   } else if (metaNodes.length === 1) {
     getPropertyKeys(metaNodes[0]).forEach(key => {
       metaProperties[key] = getProperty(metaNodes[0], key).value;
@@ -161,7 +161,8 @@ exports.getBaseHTML = (ast, template, opts) => {
     Object.assign(
       {
         googleFontsUrl: getGoogleFontsUrl(opts),
-        favicon: opts.favicon
+        favicon: opts.favicon,
+        staticOutputDir: paths.STATIC_OUTPUT_DIR
       },
       parseMeta(ast)
     )
@@ -201,7 +202,8 @@ exports.getHTML = (paths, ast, _components, datasets, template, opts) => {
       {
         favicon: opts.favicon,
         usesTex: components.equation,
-        googleFontsUrl: getGoogleFontsUrl(opts)
+        googleFontsUrl: getGoogleFontsUrl(opts),
+        staticOutputDir: paths.STATIC_OUTPUT_DIR
       },
       meta
     )

--- a/packages/idyll-cli/src/pipeline/parse.js
+++ b/packages/idyll-cli/src/pipeline/parse.js
@@ -126,7 +126,7 @@ const parseMeta = ast => {
 
   let metaProperties = {};
   if (metaNodes.length > 1) {
-    console.warn('There is more than 1 meta node.');
+    console.warn('There is more than one meta node.');
   } else if (metaNodes.length === 1) {
     getPropertyKeys(metaNodes[0]).forEach(key => {
       metaProperties[key] = getProperty(metaNodes[0], key).value;

--- a/packages/idyll-cli/test/basic-project/test.js
+++ b/packages/idyll-cli/test/basic-project/test.js
@@ -95,6 +95,7 @@ test('options work as expected', () => {
     template: resolve(join(__dirname, '/../../src/client/_index.html')),
     datasets: join(PROJECT_DIR, 'data'),
     static: 'static',
+    staticOutputDir: 'static',
     transform: [],
     port: 3000,
     googleFonts: ['Hanalei Fill'],

--- a/packages/idyll-cli/test/minified-project/test.js
+++ b/packages/idyll-cli/test/minified-project/test.js
@@ -95,6 +95,7 @@ test('options work as expected', () => {
     template: resolve(join(__dirname, '/../../src/client/_index.html')),
     datasets: join(PROJECT_DIR, 'data'),
     static: 'static',
+    staticOutputDir: 'static',
     transform: [],
     port: 3000,
     googleFonts: ['Hanalei Fill'],

--- a/packages/idyll-cli/test/multiple-component-dirs/test.js
+++ b/packages/idyll-cli/test/multiple-component-dirs/test.js
@@ -102,6 +102,7 @@ test('options work as expected', () => {
     template: resolve(join(__dirname, '/../../src/client/_index.html')),
     datasets: join(PROJECT_DIR, 'data'),
     static: 'static',
+    staticOutputDir: 'static',
     transform: [],
     port: 3000,
     compiler: {

--- a/packages/idyll-cli/test/path-builder/test.js
+++ b/packages/idyll-cli/test/path-builder/test.js
@@ -1,7 +1,4 @@
-const {
-  dirname,
-  join,
-} = require('path');
+const { dirname, join } = require('path');
 const pathBuilder = require('../../src/path-builder');
 
 function opts(inputPath, outputPath) {
@@ -21,7 +18,8 @@ function opts(inputPath, outputPath) {
     datasets: 'data',
     minify: false,
     ssr: true,
-    components: [ 'components' ],
+    staticOutputDir: 'static',
+    components: ['components'],
     static: 'static',
     defaultComponents: '',
     layout: 'blog',
@@ -37,7 +35,7 @@ function opts(inputPath, outputPath) {
     help: false,
     h: false,
     version: false,
-    m: [ 'components' ],
+    m: ['components'],
     css: 'styles.css',
     c: 'styles.css',
     d: 'data',
@@ -49,14 +47,14 @@ function opts(inputPath, outputPath) {
     googleFonts: [],
     g: [],
     e: 'github',
-    ...overrideOpts,
-  }
+    ...overrideOpts
+  };
 }
 
 describe('path builder with input and output args', () => {
   it('should use absolute -i (input path) args directly', () => {
     const inputPath = join('/', 'absolute', 'nested', 'index.idyll');
-    const pathOpts = opts(inputPath)
+    const pathOpts = opts(inputPath);
     const paths = pathBuilder(pathOpts);
     const expectedInputPath = inputPath;
     const expectedOutputDir = join(process.cwd(), 'build');
@@ -66,7 +64,7 @@ describe('path builder with input and output args', () => {
 
   it('should use absolute -o (output path) arg directly', () => {
     const outputDir = join('/', 'nested', 'build');
-    const pathOpts = opts(null, outputDir)
+    const pathOpts = opts(null, outputDir);
     const paths = pathBuilder(pathOpts);
     const expectedInputPath = join(process.cwd(), pathOpts.inputFile);
     const expectedOutputDir = outputDir;
@@ -77,7 +75,7 @@ describe('path builder with input and output args', () => {
   it('should use absolute -i and -o (input and output path) args directly', () => {
     const inputPath = join('/', 'absolute', 'nested', 'index.idyll');
     const outputDir = join('/', 'outputs', 'nested', 'build');
-    const pathOpts = opts(inputPath, outputDir)
+    const pathOpts = opts(inputPath, outputDir);
     const paths = pathBuilder(pathOpts);
     const expectedInputPath = inputPath;
     const expectedOutputDir = outputDir;
@@ -87,7 +85,7 @@ describe('path builder with input and output args', () => {
 
   it('should resolve relative -i (input path) arg', () => {
     const inputPath = join('nested', 'index.idyll');
-    const pathOpts = opts(inputPath)
+    const pathOpts = opts(inputPath);
     const paths = pathBuilder(pathOpts);
     const expectedInputPath = join(process.cwd(), inputPath);
     const expectedOutputDir = join(process.cwd(), 'build');
@@ -97,7 +95,7 @@ describe('path builder with input and output args', () => {
 
   it('should resolve relative -o (output path) arg', () => {
     const outputPath = join('nested', 'v1', 'build');
-    const pathOpts = opts(null, outputPath)
+    const pathOpts = opts(null, outputPath);
     const paths = pathBuilder(pathOpts);
     const expectedInputPath = join(process.cwd(), pathOpts.inputFile);
     const expectedOutputDir = join(process.cwd(), outputPath);
@@ -108,12 +106,11 @@ describe('path builder with input and output args', () => {
   it('should resolve relative -i and -o (input and output path) args', () => {
     const inputPath = join('nested', 'index.idyll');
     const outputPath = join('build');
-    const pathOpts = opts(inputPath, outputPath)
+    const pathOpts = opts(inputPath, outputPath);
     const paths = pathBuilder(pathOpts);
     const expectedInputPath = join(process.cwd(), inputPath);
     const expectedOutputDir = join(process.cwd(), outputPath);
     expect(paths.IDYLL_INPUT_FILE).toBe(expectedInputPath);
     expect(paths.OUTPUT_DIR).toBe(expectedOutputDir);
   });
-
 });

--- a/packages/idyll-cli/test/static-assets/test.js
+++ b/packages/idyll-cli/test/static-assets/test.js
@@ -101,6 +101,7 @@ test('options work as expected', () => {
     defaultComponents: dirname(require.resolve('idyll-components')),
     temp: '.idyll',
     static: 'static',
+    staticOutputDir: 'static',
     outputCSS: '__idyll_styles.css',
     outputJS: '__idyll_index.js',
     datasets: 'data',


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds an additional option, `staticOutputDir`, which allows for configuration of the name  of the folder into which static assets are built. 


* **What is the current behavior?** (You can also link to an open issue here)
There is no way to configure this, the  path is hard coded. 


* **What is the new behavior (if this is a feature change)?**
You  can now pass `staticOutputDir` to the idyll config. 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
