### PR TITLE
don't blow up on undefined expression

### DIFF
--- a/packages/idyll-document/src/runtime.js
+++ b/packages/idyll-document/src/runtime.js
@@ -91,7 +91,7 @@ const createWrapper = ({
       const vars = values(props.__vars__);
       const exps = values(props.__expr__);
 
-      this.usesRefs = exps.some(v => v.includes('refs.'));
+      this.usesRefs = exps.some(v => v && v.includes('refs.'));
 
       this.state = { hasError: false, error: null };
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix for cases when an expression is undefined


* **What is the current behavior?** (You can also link to an open issue here)
The entire document throws an error `v.includes is undefined`


* **What is the new behavior (if this is a feature change)?**
The document continues to function 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No