### PR TITLE
add min-height to tweet component

### DIFF
--- a/packages/idyll-components/src/tweet.js
+++ b/packages/idyll-components/src/tweet.js
@@ -62,7 +62,11 @@ class Tweet extends Component {
     return (
       <div
         ref={this.tweetContainer}
-        style={this.props.style ? this.props.style : { minHeight: 309 }}
+        style={
+          this.props.style
+            ? this.props.style
+            : { minHeight: 309, marginTop: 10, marginBottom: 10 }
+        }
       >
         {loading && loadingMessage}
       </div>

--- a/packages/idyll-components/src/tweet.js
+++ b/packages/idyll-components/src/tweet.js
@@ -7,7 +7,7 @@ class Tweet extends Component {
 
     this.state = {
       loading: true,
-      loadingMessage: 'Loading tweet ...'
+      loadingMessage: 'Loading tweet...'
     };
     this.tweetContainer = createRef();
     this.loadTweet = this.loadTweet.bind(this);
@@ -59,7 +59,14 @@ class Tweet extends Component {
   render() {
     const { loading, loadingMessage } = this.state;
 
-    return <div ref={this.tweetContainer}>{loading && loadingMessage}</div>;
+    return (
+      <div
+        ref={this.tweetContainer}
+        style={this.props.style ? this.props.style : { minHeight: 309 }}
+      >
+        {loading && loadingMessage}
+      </div>
+    );
   }
 }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds a minimum height to the tweet component by default. 


* **What is the current behavior?** (You can also link to an open issue here)
It initializes with such a small height... when the tweet finally loads it forces a document reflow because of the height change. 


* **What is the new behavior (if this is a feature change)?**
Minimal reflow after loading.
