### PR TITLE
rename componentWillReceiveProps to UNSAFE

### DIFF
--- a/packages/idyll-components/src/desmos.js
+++ b/packages/idyll-components/src/desmos.js
@@ -95,8 +95,8 @@ class Desmos extends React.Component {
     });
   }
 
-  UNSAFE_componentWillUpdate(nextProps) {
-    const { equation } = nextProps;
+  componentDidUpdate(prevProps) {
+    const { equation } = prevProps;
     // Only instantiate & update the calculator
     // when necessary to improve performance.
     if (

--- a/packages/idyll-components/src/desmos.js
+++ b/packages/idyll-components/src/desmos.js
@@ -96,11 +96,11 @@ class Desmos extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { equation } = prevProps;
+    const { equation } = this.props;
     // Only instantiate & update the calculator
     // when necessary to improve performance.
     if (
-      equation !== this.props.equation &&
+      equation !== prevProps.equation &&
       equation !== this.getCurrentLatex()
     ) {
       if (this.calculator) {

--- a/packages/idyll-components/src/desmos.js
+++ b/packages/idyll-components/src/desmos.js
@@ -95,7 +95,7 @@ class Desmos extends React.Component {
     });
   }
 
-  componentWillUpdate(nextProps) {
+  UNSAFE_componentWillUpdate(nextProps) {
     const { equation } = nextProps;
     // Only instantiate & update the calculator
     // when necessary to improve performance.

--- a/packages/idyll-components/src/scroller.js
+++ b/packages/idyll-components/src/scroller.js
@@ -107,11 +107,7 @@ class Scroller extends React.Component {
       this.props.currentState !== prevProps.currentState
     ) {
       d3.selectAll(`#idyll-scroll-${this.id} .idyll-step`)
-        .filter((d, i) => {
-          return (
-            this.props.currentState.currentState === this.SCROLL_NAME_MAP[i]
-          );
-        })
+        .filter((d, i) => this.props.currentState === this.SCROLL_NAME_MAP[i])
         .node()
         .scrollIntoView({ behavior: 'smooth' });
     }

--- a/packages/idyll-components/src/scroller.js
+++ b/packages/idyll-components/src/scroller.js
@@ -90,33 +90,35 @@ class Scroller extends React.Component {
     this.props.updateProps && this.props.updateProps(update);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     if (
-      nextProps.disableScroll &&
-      this.props.currentStep !== nextProps.currentStep
+      this.props.disableScroll &&
+      this.props.currentStep !== prevProps.currentStep
     ) {
       d3.selectAll(`#idyll-scroll-${this.id} .idyll-step`)
         .filter(function(d, i) {
-          return i === nextProps.currentStep;
+          return i === this.props.currentStep;
         })
         .node()
         .scrollIntoView({ behavior: 'smooth' });
     }
     if (
-      nextProps.disableScroll &&
-      this.props.currentState !== nextProps.currentState
+      this.props.disableScroll &&
+      this.props.currentState !== prevProps.currentState
     ) {
       d3.selectAll(`#idyll-scroll-${this.id} .idyll-step`)
         .filter((d, i) => {
-          return nextProps.currentState === this.SCROLL_NAME_MAP[i];
+          return (
+            this.props.currentState.currentState === this.SCROLL_NAME_MAP[i]
+          );
         })
         .node()
         .scrollIntoView({ behavior: 'smooth' });
     }
     if (
-      nextProps.disableScroll &&
-      (!nextProps.currentStep ||
-        nextProps.currentStep < Object.keys(this.SCROLL_STEP_MAP).length - 1)
+      this.props.disableScroll &&
+      (!this.props.currentStep ||
+        this.props.currentStep < Object.keys(this.SCROLL_STEP_MAP).length - 1)
     ) {
       d3.select('body').style('overflow', 'hidden');
     }

--- a/packages/idyll-components/src/scroller.js
+++ b/packages/idyll-components/src/scroller.js
@@ -90,7 +90,7 @@ class Scroller extends React.Component {
     this.props.updateProps && this.props.updateProps(update);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (
       nextProps.disableScroll &&
       this.props.currentStep !== nextProps.currentStep

--- a/packages/idyll-docs/components/editor/index.js
+++ b/packages/idyll-docs/components/editor/index.js
@@ -24,8 +24,6 @@ class LiveIdyllEditor extends React.PureComponent {
     this.setState({ error: error.message });
   }
 
-  componentWillReceiveProps() {}
-
   handleChange = newContent => {
     this.setContent(newContent);
     const { onChange } = this.props;

--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -72,7 +72,7 @@ class IdyllDocument extends React.Component {
     this.setState({ error: error.message });
   }
 
-  componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(newProps) {
     if (newProps.theme !== this.props.theme && newProps.injectThemeCSS) {
       if (themeNode) {
         themeNode.innerHTML = getTheme(newProps.theme).styles;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Rename of the unsafe lifecycle methods as step 1 to get ready for React 17, will have to remove them for 17. 

[https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate](https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate)



* **What is the current behavior?** (You can also link to an open issue here)
[https://github.com/idyll-lang/idyll/issues/711](https://github.com/idyll-lang/idyll/issues/711)


* **What is the new behavior (if this is a feature change)?**
Less warnings in console. 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
Longer term fix is to refactor some of these methods either into hooks or other existing "safe" methods 