### PR TITLE
Bring react table to last v6 version to clear lifecycle warnings. 

### DIFF
--- a/packages/idyll-components/package.json
+++ b/packages/idyll-components/package.json
@@ -49,7 +49,7 @@
     "react-inlinesvg": "^0.8.1",
     "react-latex-patched": "^1.1.1",
     "react-syntax-highlighter": "^5.7.0",
-    "react-table": "6.8.6",
+    "react-table": "6.11.4",
     "react-youtube": "^7.6.0",
     "scrollama": "^2.0.0",
     "victory": "^0.23.0"

--- a/packages/idyll-docs/components/editor/index.js
+++ b/packages/idyll-docs/components/editor/index.js
@@ -24,8 +24,6 @@ class LiveIdyllEditor extends React.PureComponent {
     this.setState({ error: error.message });
   }
 
-  componentWillReceiveProps() {}
-
   handleChange = newContent => {
     this.setContent(newContent);
     const { onChange } = this.props;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9959,12 +9959,13 @@ react-syntax-highlighter@^5.7.0:
     highlight.js "~9.12.0"
     lowlight "~1.9.1"
 
-react-table@6.8.6:
-  version "6.8.6"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-6.8.6.tgz#a0ad8b4839319052d5befc012603fb161e52ede3"
-  integrity sha1-oK2LSDkxkFLVvvwBJgP7Fh5S7eM=
+react-table@6.11.4:
+  version "6.11.4"
+  resolved "https://registry.yarnpkg.com/react-table/-/react-table-6.11.4.tgz#e9d30b4500d2c1cf8e5ba312227d19a256ec1913"
+  integrity sha512-2b114yTjYyDTAha1vOH33QPupzv/KE3i7diouYqmt7O3NIExaWxNxxvbch26MyvL5YSLN17cK9Zk9Eh3ss+Pcg==
   dependencies:
     classnames "^2.2.5"
+    react-is "^16.8.1"
 
 react-test-renderer@^16.0.0, react-test-renderer@^16.0.0-0:
   version "16.13.1"


### PR DESCRIPTION
## 🚧 wip 🚧

Currently looking for good table examples to test with, cleaning up the componentWillMount warnings, the react table package is also throwing these warnings - https://github.com/idyll-lang/idyll/issues/711

But wanted to open a draft PR to see if any thoughts on how Idyll is using react-table and also if/when react hooks integration on horizon. 

- I think the api changes for v7 of react-table and will need peer deps of react w/ hooks
#722
<br/><br/>
- **Please check if the PR fulfills these requirements**

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

* **What is the current behavior?** (You can also link to an open issue here)

- **What is the new behavior (if this is a feature change)?**

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

- **Other information**:
