### PR TITLE
ignore instrumental nodes during markup serialization

### DIFF
--- a/packages/idyll-ast/src/index.js
+++ b/packages/idyll-ast/src/index.js
@@ -967,6 +967,13 @@ function childrenToMarkup(
 }
 
 function nodeToMarkup(node, depth, insertFullWidth, separator = '\n') {
+  if (
+    node.name &&
+    node.name.toLowerCase() === 'IdyllEditorDropTarget'.toLowerCase()
+  ) {
+    return '';
+  }
+
   const markupNodes = [
     'strong',
     'em',

--- a/packages/idyll-ast/test/test.js
+++ b/packages/idyll-ast/test/test.js
@@ -457,4 +457,34 @@ Hello world.
     `.trim()
     );
   });
+
+  it('should ignore instrumental nodes', function() {
+    const markup = util.toMarkup({
+      id: -1,
+      type: 'component',
+      name: 'p',
+      children: [
+        {
+          id: 1,
+          type: 'component',
+          name: 'my-component',
+          properties: {},
+          children: []
+        },
+        {
+          id: 2,
+          type: 'component',
+          name: 'IdyllEditorDropTarget',
+          properties: {},
+          children: []
+        }
+      ]
+    });
+
+    expect(markup).to.eql(
+      `
+[MyComponent /]
+    `.trim()
+    );
+  });
 });


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] Tests for the changes have been added (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Improves that AST serialization algorithm (it should ignore instrumental nodes that are only inserted during article authoring)

* **What is the current behavior?** (You can also link to an open issue here)
Instrumental nodes inserted by idyll-studio are serialized into markup.

- **What is the new behavior (if this is a feature change)?**
- Instrumental nodes inserted by idyll-studio are **note** serialized into markup.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
