### PR TITLE
uses image component to add graphics to annotation

### DIFF
--- a/packages/idyll-components/src/annotation.js
+++ b/packages/idyll-components/src/annotation.js
@@ -4,8 +4,9 @@ const { filterChildren } = require('idyll-component-children');
 class Annotation extends React.PureComponent {
   render() {
     const { children } = this.props;
-    const inline_text = children.slice(-1);
-    const annotation_box = children.slice(0, children.length - 1);
+    const inline_text = children && children.length ? children.slice(-1) : [];
+    const annotation_box =
+      children && children.length ? children.slice(0, children.length - 1) : [];
 
     return (
       <span className="annotated-text">

--- a/packages/idyll-components/src/annotation.js
+++ b/packages/idyll-components/src/annotation.js
@@ -3,12 +3,16 @@ const { filterChildren } = require('idyll-component-children');
 
 class Annotation extends React.PureComponent {
   render() {
-    const { children, annotation, ...props } = this.props;
+    const inline_text = this.props.children.slice(-1);
+    const annotation_box = this.props.children.slice(0, children.length - 1);
+
     return (
       <span className="annotated-text">
-        {this.props.annotation}
+        {filterChildren(inline_text, c => {
+          return c;
+        })}
         <div className="annotation-text">
-          {filterChildren(children, c => {
+          {filterChildren(annotation_box, c => {
             return c;
           })}
         </div>

--- a/packages/idyll-components/src/annotation.js
+++ b/packages/idyll-components/src/annotation.js
@@ -4,20 +4,23 @@ const { filterChildren } = require('idyll-component-children');
 class Annotation extends React.PureComponent {
   render() {
     const { children } = this.props;
-    const inline_text = children && children.length ? children.slice(-1) : [];
-    const annotation_box =
-      children && children.length ? children.slice(0, children.length - 1) : [];
+
+    const annotationBox = filterChildren(children || [], c => {
+      return (
+        c && c.type && c.type.name && c.type.name.toLowerCase() === 'graphic'
+      );
+    });
+
+    const inlineText = filterChildren(children || [], c => {
+      return !c.type || !c.type.name || c.type.name.toLowerCase() !== 'graphic';
+    });
 
     return (
-      <span className="annotated-text">
-        {filterChildren(inline_text, c => {
-          return c;
-        })}
-        <div className="annotation-text">
-          {filterChildren(annotation_box, c => {
-            return c;
-          })}
-        </div>
+      <span>
+        {' '}
+        <span className="annotated-text">
+          {inlineText} <span className="annotation-text">{annotationBox}</span>
+        </span>{' '}
       </span>
     );
   }

--- a/packages/idyll-components/src/annotation.js
+++ b/packages/idyll-components/src/annotation.js
@@ -3,8 +3,9 @@ const { filterChildren } = require('idyll-component-children');
 
 class Annotation extends React.PureComponent {
   render() {
-    const inline_text = this.props.children.slice(-1);
-    const annotation_box = this.props.children.slice(0, children.length - 1);
+    const { children } = this.props;
+    const inline_text = children.slice(-1);
+    const annotation_box = children.slice(0, children.length - 1);
 
     return (
       <span className="annotated-text">
@@ -24,15 +25,7 @@ class Annotation extends React.PureComponent {
 Annotation._idyll = {
   name: 'Annotation',
   tagType: 'open',
-  displayType: 'inline',
-  props: [
-    {
-      name: 'annotation',
-      type: 'string',
-      example: '"This is annotation text"',
-      description: 'The displayed text when user hovers on annotated text.'
-    }
-  ]
+  displayType: 'inline'
 };
 
 export default Annotation;

--- a/packages/idyll-components/src/annotation.js
+++ b/packages/idyll-components/src/annotation.js
@@ -1,15 +1,16 @@
 import React from 'react';
-import Image from './image.js';
+const { filterChildren } = require('idyll-component-children');
 
 class Annotation extends React.PureComponent {
   render() {
-    const hasGraphic = this.props.src;
+    const { children, annotation, ...props } = this.props;
     return (
       <span className="annotated-text">
-        {this.props.children}
+        {this.props.annotation}
         <div className="annotation-text">
-          <Image src={hasGraphic} />
-          {this.props.annotation}
+          {filterChildren(children, c => {
+            return c;
+          })}
         </div>
       </span>
     );
@@ -20,14 +21,10 @@ Annotation._idyll = {
   name: 'Annotation',
   tagType: 'open',
   displayType: 'inline',
-  children: [
-    'Content placed inside of an annotation component will be displayed inline with some styling.'
-  ],
   props: [
     {
       name: 'annotation',
       type: 'string',
-      src: 'src',
       example: '"This is annotation text"',
       description: 'The displayed text when user hovers on annotated text.'
     }

--- a/packages/idyll-components/src/annotation.js
+++ b/packages/idyll-components/src/annotation.js
@@ -6,9 +6,7 @@ class Annotation extends React.PureComponent {
     const { children } = this.props;
 
     const annotationBox = filterChildren(children || [], c => {
-      return (
-        c && c.type && c.type.name && c.type.name.toLowerCase() === 'graphic'
-      );
+      return c.type && c.type.name && c.type.name.toLowerCase() === 'graphic';
     });
 
     const inlineText = filterChildren(children || [], c => {

--- a/packages/idyll-components/src/annotation.js
+++ b/packages/idyll-components/src/annotation.js
@@ -1,11 +1,16 @@
 import React from 'react';
+import Image from './image.js';
 
 class Annotation extends React.PureComponent {
   render() {
+    const hasGraphic = this.props.src;
     return (
       <span className="annotated-text">
         {this.props.children}
-        <span className="annotation-text">{this.props.annotation}</span>
+        <div className="annotation-text">
+          <Image src={hasGraphic} />
+          {this.props.annotation}
+        </div>
       </span>
     );
   }
@@ -22,6 +27,7 @@ Annotation._idyll = {
     {
       name: 'annotation',
       type: 'string',
+      src: 'src',
       example: '"This is annotation text"',
       description: 'The displayed text when user hovers on annotated text.'
     }

--- a/packages/idyll-themes/src/default/styles.js
+++ b/packages/idyll-themes/src/default/styles.js
@@ -1017,7 +1017,7 @@ img {
 .annotated-text,
 .annotated-text:visited {
   background: #efefef;
-  padding: 0 5px;
+  padding: 0 2.5px;
   transition: background 0.25s ease-out;
 }
 

--- a/packages/idyll-themes/src/github/styles.js
+++ b/packages/idyll-themes/src/github/styles.js
@@ -833,7 +833,7 @@ hr {
 .annotated-text,
 .annotated-text:visited {
   background: #efefef;
-  padding: 0 5px;
+  padding: 0 2.5px;
   transition: background 0.25s ease-out;
 }
 

--- a/packages/idyll-themes/src/idyll/styles.js
+++ b/packages/idyll-themes/src/idyll/styles.js
@@ -227,7 +227,7 @@ span.action {
 .annotated-text,
 .annotated-text:visited {
   background: #efefef;
-  padding: 0 5px;
+  padding: 0 2.5px;
   transition: background 0.25s ease-out;
 }
 

--- a/packages/idyll-themes/src/tufte/styles.js
+++ b/packages/idyll-themes/src/tufte/styles.js
@@ -385,7 +385,7 @@ pre {
 .annotated-text,
 .annotated-text:visited {
   background: #efefef;
-  padding: 0 5px;
+  padding: 0 2.5px;
   transition: background 0.25s ease-out;
 }
 


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Uses the `Image` component to for displaying images inside of the annotation div. 

* **What is the current behavior?** (You can also link to an open issue here)
Current `Annotation` component does not allow for images.

- **What is the new behavior (if this is a feature change)?**
New `Annotation` component places images at the start of the annotation, can have text and image in the same annotation div.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None

- **Other information**:
