### PR TITLE
added new preview component and test

### DIFF
--- a/packages/idyll-components/package.json
+++ b/packages/idyll-components/package.json
@@ -50,6 +50,7 @@
     "react-latex-patched": "^1.1.1",
     "react-syntax-highlighter": "^5.7.0",
     "react-table": "6.8.6",
+    "react-tiny-link": "^3.6.1",
     "react-youtube": "^7.6.0",
     "scrollama": "^2.0.0",
     "victory": "^0.23.0"

--- a/packages/idyll-components/src/index.js
+++ b/packages/idyll-components/src/index.js
@@ -31,6 +31,7 @@ export { default as Inline } from './inline';
 export { default as Link } from './link';
 export { default as Loop } from './loop';
 export { default as Preload } from './preload';
+export { default as Preview } from './preview';
 export { default as Radio } from './radio';
 export { default as Range } from './range';
 export { default as Scroller } from './scroller';

--- a/packages/idyll-components/src/preview.js
+++ b/packages/idyll-components/src/preview.js
@@ -1,7 +1,18 @@
 import React from 'react';
-import { ReactTinyLink } from 'react-tiny-link';
 
 class Preview extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      mounted: false
+    };
+  }
+
+  componentDidMount() {
+    this.setState({
+      mounted: true
+    });
+  }
   render() {
     const {
       hasError,
@@ -14,6 +25,16 @@ class Preview extends React.Component {
       media,
       ...props
     } = this.props;
+
+    if (!this.state.mounted) {
+      return (
+        <a href={url}>
+          {title} - {description}
+        </a>
+      );
+    }
+
+    const ReactTinyLink = require('react-tiny-link').ReactTinyLink;
     if (this.props.media) {
       return (
         <ReactTinyLink

--- a/packages/idyll-components/src/preview.js
+++ b/packages/idyll-components/src/preview.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { ReactTinyLink } from 'react-tiny-link';
+
+class Preview extends React.Component {
+  render() {
+    const {
+      hasError,
+      idyll,
+      updateProps,
+      title,
+      description,
+      cardSize,
+      url,
+      media,
+      ...props
+    } = this.props;
+    if (this.props.media) {
+      return (
+        <ReactTinyLink
+          header={title}
+          description={description}
+          cardSize={cardSize}
+          showGraphic={true}
+          url={url}
+          defaultMedia={media}
+        />
+      );
+    }
+    return (
+      <ReactTinyLink
+        header={title}
+        description={description}
+        showGraphic={false}
+        url={url}
+      />
+    );
+  }
+}
+
+Preview._idyll = {
+  name: 'Preview',
+  tagType: 'closed',
+  props: [
+    {
+      name: 'title',
+      type: 'string',
+      example: '"This is the preview title"',
+      description: 'The title text to display on the card'
+    },
+    {
+      name: 'description',
+      type: 'string',
+      example: '"This is the preview description"',
+      description: 'The description text to display on the card'
+    },
+    {
+      name: 'cardSize',
+      type: 'string',
+      example: '"small"',
+      description: 'Designate size of the preview card, can be small or large'
+    },
+    {
+      name: 'url',
+      type: 'string',
+      example: '"https://idyll-lang.org/"',
+      description: 'The URL to open when the link is clicked'
+    },
+    {
+      name: 'media',
+      type: 'string',
+      example: '"https://placebear.com/600/320"',
+      description: 'The media url or directory of the image or gif'
+    }
+  ]
+};
+
+export default Preview;

--- a/packages/idyll-components/test/components.js
+++ b/packages/idyll-components/test/components.js
@@ -24,6 +24,7 @@ import {
   Link,
   Loop,
   Preload,
+  Preview,
   Radio,
   Range,
   Select,
@@ -108,6 +109,9 @@ describe('Sanity Check', () => {
       });
       it('<Loop />', () => {
         expect(() => shallow(<Loop />)).not.toThrow();
+      });
+      it('<Preview />', () => {
+        expect(() => shallow(<Preview />)).not.toThrow();
       });
       it('<Radio />', () => {
         expect(() => shallow(<Radio />)).not.toThrow();
@@ -241,6 +245,9 @@ describe('Sanity Check', () => {
       });
       it('<Loop />', () => {
         expect(() => mount(<Loop />)).not.toThrow();
+      });
+      it('<Preview />', () => {
+        expect(() => shallow(<Preview />)).not.toThrow();
       });
       it('<Radio />', () => {
         expect(() => mount(<Radio />)).not.toThrow();

--- a/yarn.lock
+++ b/yarn.lock
@@ -10010,6 +10010,11 @@ react-test-renderer@^16.0.0, react-test-renderer@^16.0.0-0:
     react-is "^16.8.6"
     scheduler "^0.19.1"
 
+react-tiny-link@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/react-tiny-link/-/react-tiny-link-3.6.1.tgz#69da07660e16e2498c42458b09b02d4c41e6683c"
+  integrity sha512-spQghU5GqBWsLE8rKOTYo/h6MNoZJn8Gqs6jpeQuo/eq2bALkeOke2FfSswVOhGN8z8riDY+TqaJ2eaoNKtrAw==
+
 react-tooltip@4.2.15:
   version "4.2.15"
   resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.15.tgz#ae278931a222434ae597c57aab07be215a2aa5f9"


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds a new `Preview` component, which is a block `Link` component, which can accommodate media in the preview card and a short description. 

<img width="545" alt="Screenshot 2021-04-29 at 1 46 23 PM" src="https://user-images.githubusercontent.com/44358575/116623112-95982a80-a8fa-11eb-99f4-5c39a45f4f56.png">

* **What is the current behavior?** (You can also link to an open issue here)
New feature. 

- **What is the new behavior (if this is a feature change)?**
New feature. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope.

- **Other information**:
This component uses `react-tiny-link`. I noticed that the `idyll` command doesn't run anymore, only `idyll --no-ssr`.
I picked some parameters out of the ones in the `react-tiny-link` docs: https://github.com/winhtaikaung/react-tiny-link, unsure if this is the right amount of control for users to customise their cards. 