### PR TITLE
Pattern prop for TextInput to give feedback about errors 

### DIFF
--- a/packages/idyll-components/src/text-input.js
+++ b/packages/idyll-components/src/text-input.js
@@ -9,13 +9,15 @@ class TextInput extends React.PureComponent {
   onChange(e) {
     const value = e.target.value || '';
     const pattern = this.props.pattern;
+    const patternMismatchMessage =
+      this.props.patternMismatchMessage || `Input value doesn't match pattern`;
 
     this.props.updateProps({ value: value });
 
     if (pattern) {
       try {
         if (!value.match(pattern)) {
-          throw new Error(`Input value doesn't match pattern`);
+          throw new Error(patternMismatchMessage);
         }
 
         eval(value); //check if there's JS syntax errors
@@ -66,6 +68,13 @@ TextInput._idyll = {
       type: 'object',
       example: '/w+/',
       description: 'A regex pattern to validate input field'
+    },
+    {
+      name: 'patternMismatchMessage',
+      type: 'string',
+      example: 'Value doesnt match pattern',
+      description:
+        "A string message to display after a pattern mismatch. Default is: 'Input value is not valid'"
     }
   ]
 };

--- a/packages/idyll-components/src/text-input.js
+++ b/packages/idyll-components/src/text-input.js
@@ -1,25 +1,52 @@
-import React from 'react';
-const ReactDOM = require('react-dom');
-
+import React, { Fragment } from 'react';
 class TextInput extends React.PureComponent {
   constructor(props) {
     super(props);
     this.onChange = this.onChange.bind(this);
+    this.state = { error: { msg: '', isError: false } };
   }
 
   onChange(e) {
-    this.props.updateProps({ value: e.target.value });
+    const value = e.target.value || '';
+    const pattern = this.props.pattern;
+
+    this.props.updateProps({ value: value });
+
+    if (pattern) {
+      try {
+        if (!value.match(pattern)) {
+          throw new Error(`Input value doesn't match pattern`);
+        }
+
+        eval(value); //check if there's JS syntax errors
+        this.setState({ error: { msg: '', isError: false } });
+      } catch (err) {
+        this.setState({
+          error: {
+            msg: err.message || 'Input value is not valid',
+            isError: true
+          }
+        });
+      }
+    }
   }
 
   render() {
+    const { error } = this.state;
     const { idyll, hasError, updateProps, ...props } = this.props;
     return (
-      <input
-        onClick={this.props.onClick || (e => e.stopPropagation())}
-        type="text"
-        onChange={this.onChange}
-        {...props}
-      />
+      <Fragment>
+        <input
+          className={error.isError ? 'idyll-input-error' : ''}
+          onClick={this.props.onClick || (e => e.stopPropagation())}
+          type="text"
+          onChange={this.onChange}
+          {...props}
+        />
+        {error.isError && (
+          <span className="idyll-input-error">{error.msg}</span>
+        )}
+      </Fragment>
     );
   }
 }
@@ -33,6 +60,12 @@ TextInput._idyll = {
       type: 'string',
       example: 'x',
       description: 'The current value of the text entry box.'
+    },
+    {
+      name: 'pattern',
+      type: 'object',
+      example: '/w+/',
+      description: 'A regex pattern to validate input field'
     }
   ]
 };

--- a/packages/idyll-components/src/text-input.js
+++ b/packages/idyll-components/src/text-input.js
@@ -20,7 +20,6 @@ class TextInput extends React.PureComponent {
           throw new Error(patternMismatchMessage);
         }
 
-        eval(value); //check if there's JS syntax errors
         this.setState({ error: { msg: '', isError: false } });
       } catch (err) {
         this.setState({

--- a/packages/idyll-docs/pages/docs/component/[...slug].js
+++ b/packages/idyll-docs/pages/docs/component/[...slug].js
@@ -170,6 +170,18 @@ const Component = props => {
           margin-top: 1em;
         }
 
+        input[type='text'].idyll-input-error {
+          border-color: red;
+        }
+        
+        span.idyll-input-error{
+          display: block;
+          margin: 0 auto;
+          padding: 10px 5px;
+          color: red;
+          width: 100%;
+        }
+
         .idyll-prop code {
           border: solid 1px #222;
           border-radius: 5px;

--- a/packages/idyll-docs/pages/docs/introduction.js
+++ b/packages/idyll-docs/pages/docs/introduction.js
@@ -122,7 +122,7 @@ Write your own equation:
 [var name:"funcString" value:\`"(x) => x * Math.sin(10 / (x || 1))"\` /]
 [derived name:"funcFromString" value:\`eval(funcString)\` /]
 
-[TextInput value:funcString pattern:\`/([a-zA-Z]\\w*|\\([a-zA-Z]\\w*(,\\s*[a-zA-Z]\\w*)*\\)) =>/\` /]
+[TextInput value:funcString pattern:\`/([a-zA-Z]\\w*|\\([a-zA-Z]\\w*(,\\s*[a-zA-Z]\\w*)*\\)) =>/\` patternMismatchMessage:"Input value doesn't match pattern. xx" /]
 
 [Chart
   equation:\` (t) => funcFromString ? funcFromString(t) : 0 \`

--- a/packages/idyll-docs/pages/docs/introduction.js
+++ b/packages/idyll-docs/pages/docs/introduction.js
@@ -122,7 +122,7 @@ Write your own equation:
 [var name:"funcString" value:\`"(x) => x * Math.sin(10 / (x || 1))"\` /]
 [derived name:"funcFromString" value:\`eval(funcString)\` /]
 
-[TextInput value:funcString pattern:\`/([a-zA-Z]\\w*|\\([a-zA-Z]\\w*(,\\s*[a-zA-Z]\\w*)*\\)) =>/\` patternMismatchMessage:"Input value doesn't match pattern. xx" /]
+[TextInput value:funcString pattern:\`/([a-zA-Z]\\w*|\\([a-zA-Z]\\w*(,\\s*[a-zA-Z]\\w*)*\\)) =>/\` patternMismatchMessage:"Input value doesn't match pattern." /]
 
 [Chart
   equation:\` (t) => funcFromString ? funcFromString(t) : 0 \`

--- a/packages/idyll-docs/pages/docs/introduction.js
+++ b/packages/idyll-docs/pages/docs/introduction.js
@@ -122,7 +122,7 @@ Write your own equation:
 [var name:"funcString" value:\`"(x) => x * Math.sin(10 / (x || 1))"\` /]
 [derived name:"funcFromString" value:\`eval(funcString)\` /]
 
-[TextInput value:funcString /]
+[TextInput value:funcString pattern:\`/([a-zA-Z]\\w*|\\([a-zA-Z]\\w*(,\\s*[a-zA-Z]\\w*)*\\)) =>/\` /]
 
 [Chart
   equation:\` (t) => funcFromString ? funcFromString(t) : 0 \`
@@ -219,6 +219,19 @@ const Introduction = ({ url }) => (
         padding: 10px 5px;
         font-size: 18px;
         font-family: Fira Mono, monospace;
+        width: 100%;
+        max-width: 400px;
+      }
+
+      .idyll-root input[type='text'].idyll-input-error {
+        border-color: red;
+      }
+      
+      .idyll-root span.idyll-input-error{
+        display: block;
+        margin: 0 auto;
+        padding: 10px 5px;
+        color: red;
         width: 100%;
         max-width: 400px;
       }

--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -142,7 +142,6 @@ export const evalExpression = (acc, expr, key, context) => {
         return eval('(' + evalString + ')');
       } catch (err) {
         console.warn('Error occurred in Idyll expression');
-        console.error(err);
       }
     }.call(Object.assign({}, acc), e);
   } catch (err) {}

--- a/packages/idyll-themes/src/default/styles.js
+++ b/packages/idyll-themes/src/default/styles.js
@@ -857,7 +857,17 @@ hr {
   font-family: monospace;
 }
 
+input[type='text'].idyll-input-error {
+  border-color: red;
+}
 
+span.idyll-input-error{
+  display: block;
+  margin: 0 auto;
+  padding: 10px 5px;
+  color: red;
+  width: 100%;
+}
 
 .idyll-step-graphic {
   top: 0;

--- a/packages/idyll-themes/src/github/styles.js
+++ b/packages/idyll-themes/src/github/styles.js
@@ -739,7 +739,17 @@ hr {
   font-family: monospace;
 }
 
+input[type='text'].idyll-input-error {
+  border-color: red;
+}
 
+span.idyll-input-error{
+  display: block;
+  margin: 0 auto;
+  padding: 10px 5px;
+  color: red;
+  width: 100%;
+}
 
 .idyll-step-graphic {
   top: 0;

--- a/packages/idyll-themes/src/idyll/styles.js
+++ b/packages/idyll-themes/src/idyll/styles.js
@@ -133,6 +133,17 @@ span.action {
   font-family: monospace;
 }
 
+input[type='text'].idyll-input-error {
+  border-color: red;
+}
+
+span.idyll-input-error{
+  display: block;
+  margin: 0 auto;
+  padding: 10px 5px;
+  color: red;
+  width: 100%;
+}
 
 
 .idyll-step-graphic {

--- a/packages/idyll-themes/src/tufte/styles.js
+++ b/packages/idyll-themes/src/tufte/styles.js
@@ -281,6 +281,17 @@ label.margin-toggle:not(.sidenote-number) { display: none; }
   font-family: monospace;
 }
 
+input[type='text'].idyll-input-error {
+  border-color: red;
+}
+
+span.idyll-input-error{
+  display: block;
+  margin: 0 auto;
+  padding: 10px 5px;
+  color: red;
+  width: 100%;
+}
 
 .idyll-step-graphic {
   top: 0;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

* [ x ] Tests for the changes have been added (for bug fixes / features)
* [ x ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

* New prop named as "pattern" avaiable to handle with input expression errors and expressions which doesn't match the regex pattern;

* Supressed "console.error(err);" on idyll-document/src/utils/index.js as requested on issue (now we have a feature to give user feedback);

* Modified introduction.js on idyll-docs to give stylish to the new input with validation;

* Updated TextInput documentation.

**What is the current behavior?** (You can also link to an open issue here)
When the input was part of an evaluated expression and that expression was invalid an error occurs and also throwed on dev console leading to crash. See issue here: https://github.com/idyll-lang/idyll/issues/675

**What is the new behavior (if this is a feature change)?**
An error message is displayed within the input, so the user can have some feedback. Also the error on console is now suppressed.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

**Other information**:


<img width="645" alt="Screenshot showing all the features commented above" src="https://user-images.githubusercontent.com/50468019/124044900-db4d9e00-d9e4-11eb-9298-3e2d1c88e305.png">
