### PR TITLE
fix logic in idyll-document when inserting CSS onto the page

### DIFF
--- a/packages/idyll-components/src/stepper.js
+++ b/packages/idyll-components/src/stepper.js
@@ -120,9 +120,9 @@ Stepper._idyll = {
   width:400
   height:300 /]
 [/Graphic]
-[Step]A black and white photo[/Step]
-[Step]A color photo[/Step]
-[Step]An animated gif![/Step]
+[Step]Text for step 1[/Step]
+[Step]Text for step 2[/Step]
+[Step]Text for step 3[/Step]
 [StepperControl /]`
   ],
   props: [

--- a/packages/idyll-document/src/index.js
+++ b/packages/idyll-document/src/index.js
@@ -60,10 +60,18 @@ class IdyllDocument extends React.Component {
     }
 
     if (this.props.injectThemeCSS) {
-      themeNode = this.createStyleNode(getTheme(this.props.theme).styles);
+      if (themeNode) {
+        themeNode.innerHTML = getTheme(this.props.theme).styles;
+      } else {
+        themeNode = this.createStyleNode(getTheme(this.props.theme).styles);
+      }
     }
     if (this.props.injectLayoutCSS) {
-      layoutNode = this.createStyleNode(getLayout(this.props.layout).styles);
+      if (layoutNode) {
+        layoutNode.innerHTML = getLayout(this.props.layout).styles;
+      } else {
+        layoutNode = this.createStyleNode(getLayout(this.props.layout).styles);
+      }
     }
   }
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
When change the theme/layout passed to an `<IdyllDocument />` the CSS styles get injected multiple times.

- **What is the new behavior (if this is a feature change)?**
CSS is only injected when necessary. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

- **Other information**:
