### PR TITLE
don't render references section if no citations exist

### DIFF
--- a/packages/idyll-components/src/cite.js
+++ b/packages/idyll-components/src/cite.js
@@ -21,6 +21,9 @@ class References extends React.Component {
     referenceInstances.push(this);
   }
   render() {
+    if (!citations.length) {
+      return null;
+    }
     return (
       <div id="references">
         <h1>References</h1>


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Small bugfix

* **What is the current behavior?** (You can also link to an open issue here)
An empty references section will be added even if no citations exist

- **What is the new behavior (if this is a feature change)?**
- No references section will be rendered unless there are actual references

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No