### PR TITLE
lock specific version of scrollmonitor

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 16.x, 17.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,8 @@ environment:
   matrix:
     - nodejs_version: '12'
     - nodejs_version: '14'
-    - nodejs_version: '15'
+    - nodejs_version: '16'
+    - nodejs_version: '17'
 
 cache:
   - "%LOCALAPPDATA%\\Yarn"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,6 @@ environment:
     - nodejs_version: '12'
     - nodejs_version: '14'
     - nodejs_version: '16'
-    - nodejs_version: '17'
 
 cache:
   - "%LOCALAPPDATA%\\Yarn"

--- a/packages/idyll-document/package.json
+++ b/packages/idyll-document/package.json
@@ -41,7 +41,7 @@
     "object.values": "^1.0.4",
     "react-dom-factories": "^1.0.1",
     "react-tooltip": "4.2.15",
-    "scrollmonitor": "^1.2.3",
+    "scrollmonitor": "1.2.6",
     "scrollparent": "^2.0.1",
     "styled-jsx": "^2.2.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8824,10 +8824,10 @@ scrollama@^2.0.0:
   resolved "https://registry.yarnpkg.com/scrollama/-/scrollama-2.2.3.tgz#c5e41ee56bf76b14162708d6421c1cd42585fb14"
   integrity sha512-fKuGfBaIycyk0TdninJKNgxctSnzjVMAVm0G1fDhZN1KjbDvxVse3K8OElqnvrCAWVup5YN/8K6aOKgj7dmYWA==
 
-scrollmonitor@^1.2.3:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/scrollmonitor/-/scrollmonitor-1.2.7.tgz#e522adb859ad48a216b03210b3d0e354cf788aee"
-  integrity sha512-j6/wcrPugXnl4O+U1KJdTQ+xGEDmnaZ1uum96ObCDas+WtVKYsjJdb2UDz/6m8+GRfeH1jxjVzM6QvFyQGS1bw==
+scrollmonitor@1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/scrollmonitor/-/scrollmonitor-1.2.6.tgz#1df3363de799a958161e4c96ef21a4b8815b4d0e"
+  integrity sha512-e1v7amZ2gS3YeQBTolCF7ZjyKWlJgx0owiF+iizS8HtZReJ4T5aJ3n2q8XlwYGUOg7hGcqiZ57rUZW5+m96RIQ==
 
 scrollparent@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This pins `scrollmonitor` to version `1.2.6` as a temporary fix. Longer term we need to improve our JS bundling functionality to support ES modules. 

This fixes #752 and is related to #629, which we should prioritize implementing. 