### PR TITLE
update d3 dependency in templates

### DIFF
--- a/packages/idyll-template-projects/templates/article/components/custom-d3-component.js
+++ b/packages/idyll-template-projects/templates/article/components/custom-d3-component.js
@@ -1,6 +1,11 @@
 const React = require('react');
 const D3Component = require('idyll-d3-component');
-const d3 = require('d3');
+const d3 = Object.assign(
+  {},
+  require('d3'),
+  require('d3-transition'),
+  require('d3-selection')
+);
 
 const size = 600;
 

--- a/packages/idyll-template-projects/templates/article/package.json
+++ b/packages/idyll-template-projects/templates/article/package.json
@@ -16,7 +16,9 @@
   "dependencies": {
     "idyll": "^5.0.0",
     "idyll-d3-component": "^2.0.0",
-    "d3": "^4.0.0"
+    "d3": "^6.7.0",
+    "d3-selection": "^2.0.0",
+    "d3-transition": "^2.0.0"
   },
   "devDependencies": {
     "gh-pages": "^0.12.0"

--- a/packages/idyll-template-projects/templates/multipage/package.json
+++ b/packages/idyll-template-projects/templates/multipage/package.json
@@ -10,7 +10,9 @@
     "output": "docs/"
   },
   "dependencies": {
-    "d3": "^5.0.0",
+    "d3": "^6.7.0",
+    "d3-selection": "^2.0.0",
+    "d3-transition": "^2.0.0",
     "idyll": "^5.0.0",
     "idyll-d3-component": "^2.0.0"
   }

--- a/packages/idyll-template-projects/templates/multipage/posts/post-1/components/custom-d3-component.js
+++ b/packages/idyll-template-projects/templates/multipage/posts/post-1/components/custom-d3-component.js
@@ -1,6 +1,11 @@
 const React = require('react');
 const D3Component = require('idyll-d3-component');
-const d3 = require('d3');
+const d3 = Object.assign(
+  {},
+  require('d3'),
+  require('d3-transition'),
+  require('d3-selection')
+);
 
 const size = 600;
 

--- a/packages/idyll-template-projects/templates/multipage/posts/post-1/package.json
+++ b/packages/idyll-template-projects/templates/multipage/posts/post-1/package.json
@@ -16,7 +16,9 @@
   "dependencies": {
     "idyll": "^5.0.0",
     "idyll-d3-component": "^2.0.0",
-    "d3": "^4.0.0"
+    "d3": "^6.7.0",
+    "d3-selection": "^2.0.0",
+    "d3-transition": "^2.0.0"
   },
   "devDependencies": {
     "gh-pages": "^0.12.0"

--- a/packages/idyll-template-projects/templates/multipage/template/components/custom-d3-component.js
+++ b/packages/idyll-template-projects/templates/multipage/template/components/custom-d3-component.js
@@ -1,6 +1,11 @@
 const React = require('react');
 const D3Component = require('idyll-d3-component');
-const d3 = require('d3');
+const d3 = Object.assign(
+  {},
+  require('d3'),
+  require('d3-transition'),
+  require('d3-selection')
+);
 
 const size = 600;
 

--- a/packages/idyll-template-projects/templates/multipage/template/package.json
+++ b/packages/idyll-template-projects/templates/multipage/template/package.json
@@ -16,7 +16,9 @@
   "dependencies": {
     "idyll": "^5.0.0",
     "idyll-d3-component": "^2.0.0",
-    "d3": "^4.0.0"
+    "d3": "^6.7.0",
+    "d3-selection": "^2.0.0",
+    "d3-transition": "^2.0.0"
   },
   "devDependencies": {
     "gh-pages": "^0.12.0"

--- a/packages/idyll-template-projects/templates/scrollytelling/components/custom-d3-component.js
+++ b/packages/idyll-template-projects/templates/scrollytelling/components/custom-d3-component.js
@@ -1,6 +1,11 @@
 const React = require('react');
 const D3Component = require('idyll-d3-component');
-const d3 = require('d3');
+const d3 = Object.assign(
+  {},
+  require('d3'),
+  require('d3-transition'),
+  require('d3-selection')
+);
 
 const size = 600;
 

--- a/packages/idyll-template-projects/templates/scrollytelling/package.json
+++ b/packages/idyll-template-projects/templates/scrollytelling/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "idyll": "^5.0.0",
     "idyll-d3-component": "^2.0.0",
-    "d3": "^4.0.0"
+    "d3": "^6.7.0",
+    "d3-selection": "^2.0.0",
+    "d3-transition": "^2.0.0"
   },
   "devDependencies": {
     "gh-pages": "^0.12.0"

--- a/packages/idyll-template-projects/templates/slideshow/package.json
+++ b/packages/idyll-template-projects/templates/slideshow/package.json
@@ -8,7 +8,9 @@
     "css": "styles.css"
   },
   "dependencies": {
-    "d3": "^5.0.0",
+    "d3": "^6.7.0",
+    "d3-selection": "^2.0.0",
+    "d3-transition": "^2.0.0",
     "idyll": "^5.0.0",
     "idyll-d3-component": "^2.0.0",
     "react-map-gl": "^5.0.3",


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Update D3 to v6, the latest major version that Idyll supports. Addresses #754. 

* **What is the current behavior?** (You can also link to an open issue here)
An old version (v4) is used by default. 

- **What is the new behavior (if this is a feature change)?**
v6 is used

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

- **Other information**:
v7 is the latest version of D3, but it relies on ES modules, which aren't yet well supported by our bundling infrastructure. We will update to v7 once #629 is closed. 