### PR TITLE
fix for compatiblity with vega embed

### DIFF
--- a/packages/idyll-cli/src/pipeline/bundle-js.js
+++ b/packages/idyll-cli/src/pipeline/bundle-js.js
@@ -85,6 +85,7 @@ module.exports = function(opts, paths, output) {
       fullPaths: true,
       transform: getTransform(opts, paths),
       paths: [getLocalModules(paths), getGlobalModules(paths)],
+      ignoreMissing: ['iterator.js'], // fix for vega-embed
       plugin: [
         b => {
           if (opts.minify) {
@@ -136,7 +137,9 @@ module.exports = function(opts, paths, output) {
 
   return new Promise((resolve, reject) => {
     b.bundle((err, src) => {
-      if (err) return reject(err);
+      if (err) {
+        return reject(err);
+      }
       resolve(src.toString('utf8'));
       // browserify-incremental has to be piped but we don't need the output
     }).pipe(require('dev-null')());


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This fixes https://github.com/idyll-lang/idyll-vega-lite/issues/16 by telling browserify to ignore the optional `iterator.js` dependency. 

* **What is the current behavior?** (You can also link to an open issue here)
There is a hard crash when trying to include vega/vega-lite in an idyll article

- **What is the new behavior (if this is a feature change)?**
It compiles

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
