### PR TITLE
add getResolvers and getResolverConstructors

### DIFF
--- a/packages/idyll-cli/src/index.js
+++ b/packages/idyll-cli/src/index.js
@@ -189,6 +189,14 @@ const idyll = (options = {}, cb) => {
       return opts;
     }
 
+    getResolvers() {
+      return createResolvers();
+    }
+
+    getResolverConstructors() {
+      return require('./resolvers');
+    }
+
     build(src) {
       // Resolvers are recreated on each build, since new data dependencies might have been added.
       const resolvers = createResolvers();


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds `getResolvers` and `getResolverConstructors` to support work on webpack/next.js loaders

* **What is the current behavior?** (You can also link to an open issue here)
Currently clients can't access these internal elements

- **What is the new behavior (if this is a feature change)?**
Easy access via function

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

- **Other information**:
