### PR TITLE
Make ids an optional property in the AST

### DIFF
--- a/packages/idyll-ast/src/ast.schema.json
+++ b/packages/idyll-ast/src/ast.schema.json
@@ -65,7 +65,7 @@
                 "type": "string"
               }
             },
-            "required": ["id", "type", "value"],
+            "required": ["type", "value"],
             "additionalProperties": false
           },
           {
@@ -116,7 +116,7 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["id", "type", "properties"]
+              "required": ["type", "properties"]
             }
           },
           {
@@ -166,13 +166,12 @@
                   "additionalProperties": false
                 }
               },
-              "required": ["id", "type", "properties"]
+              "required": ["type", "properties"]
             }
           }
         ]
-      },
-      "uniqueItems": true
+      }
     }
   },
-  "required": ["id", "type"]
+  "required": ["type"]
 }

--- a/packages/idyll-ast/src/ast.schema.json
+++ b/packages/idyll-ast/src/ast.schema.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "id": {
-      "desceription": "A unique identifier for the current element",
+      "description": "A unique identifier for the current element",
       "type": "integer"
     },
     "type": {

--- a/packages/idyll-ast/src/converters/index.js
+++ b/packages/idyll-ast/src/converters/index.js
@@ -85,6 +85,9 @@ const convertV1ToV2 = (arrayAst, injectIds) => {
   let id = 1;
   arrayAst.forEach(element => {
     let childData = inverseConvertHelper(element, id, injectIds);
+    if (injectIds) {
+      id = childData.id;
+    }
     jsonAst.children.push(childData.data);
   });
   return jsonAst;

--- a/packages/idyll-ast/src/converters/index.js
+++ b/packages/idyll-ast/src/converters/index.js
@@ -74,16 +74,17 @@ function convertHelper(jsonElement) {
  * @param {*} arrayAst
  * @return Json structred ast correspoding to the arrayAst.
  */
-const convertV1ToV2 = arrayAst => {
+const convertV1ToV2 = (arrayAst, injectIds = false) => {
   let jsonAst = new Object();
-  jsonAst.id = 0;
+  if (injectIds) {
+    jsonAst.id = 0;
+  }
   jsonAst.type = 'component';
   jsonAst.name = 'div';
   jsonAst.children = [];
   let id = 1;
   arrayAst.forEach(element => {
-    let childData = inverseConvertHelper(element, id);
-    id = childData.id;
+    let childData = inverseConvertHelper(element, id, injectIds);
     jsonAst.children.push(childData.data);
   });
   return jsonAst;
@@ -94,9 +95,11 @@ const convertV1ToV2 = arrayAst => {
  * @param {*} arrayElement
  * @return JSON representation of the corresponding arrayElement
  */
-function inverseConvertHelper(arrayElement, id) {
+function inverseConvertHelper(arrayElement, id, injectIds) {
   let elementJson = new Object();
-  elementJson.id = ++id;
+  if (injectIds) {
+    elementJson.id = ++id;
+  }
 
   if (typeof arrayElement === 'string') {
     elementJson.type = 'textnode';
@@ -125,15 +128,19 @@ function inverseConvertHelper(arrayElement, id) {
     if (arrayElement[2]) {
       let children = [];
       arrayElement[2].forEach(element => {
-        let childData = inverseConvertHelper(element, id);
-        id = childData.id;
+        let childData = inverseConvertHelper(element, id, injectIds);
+        if (injectIds) {
+          id = childData.id;
+        }
         children.push(childData.data);
       });
       elementJson.children = children;
     }
   }
   let result = new Object();
-  result.id = id;
+  if (injectIds) {
+    result.id = id;
+  }
   result.data = elementJson;
   return result;
 }

--- a/packages/idyll-ast/src/converters/index.js
+++ b/packages/idyll-ast/src/converters/index.js
@@ -74,7 +74,7 @@ function convertHelper(jsonElement) {
  * @param {*} arrayAst
  * @return Json structred ast correspoding to the arrayAst.
  */
-const convertV1ToV2 = (arrayAst, injectIds = false) => {
+const convertV1ToV2 = (arrayAst, injectIds) => {
   let jsonAst = new Object();
   if (injectIds) {
     jsonAst.id = 0;

--- a/packages/idyll-compiler/src/index.js
+++ b/packages/idyll-compiler/src/index.js
@@ -20,7 +20,7 @@ module.exports = function(input, options, alias, callback) {
   const { content, data } = matter(input.trim());
   options = Object.assign(
     {},
-    { spellcheck: false, smartquotes: true, async: true },
+    { spellcheck: false, smartquotes: true, async: true, injectIds: false },
     options || {}
   );
   const lex = Lexer({}, alias);
@@ -52,7 +52,7 @@ module.exports = function(input, options, alias, callback) {
     .pipe(autoLinkify)
     .end();
 
-  astTransform = convertV1ToV2(astTransform);
+  astTransform = convertV1ToV2(astTransform, options.injectIds);
 
   if (options.postProcessors) {
     // Turn them all into promises

--- a/packages/idyll-compiler/test/test.js
+++ b/packages/idyll-compiler/test/test.js
@@ -1570,7 +1570,7 @@ End text
         This is a new paragraph.
       `;
 
-      expect(compile(input, { async: false })).to.eql({
+      expect(compile(input, { async: false, injectIds: true })).to.eql({
         id: 0,
         type: 'component',
         name: 'div',
@@ -1613,7 +1613,7 @@ End text
       Test 1 2Three 1 2 Three 123Four
     `;
 
-    expect(compile(input, { async: false })).to.eql({
+    expect(compile(input, { async: false, injectIds: true })).to.eql({
       id: 0,
       type: 'component',
       name: 'div',
@@ -1652,7 +1652,7 @@ End text
       [/Equation]
     `;
 
-    expect(compile(input, { async: false })).to.eql({
+    expect(compile(input, { async: false, injectIds: true })).to.eql({
       id: 0,
       type: 'component',
       name: 'div',
@@ -1692,7 +1692,7 @@ End text
       ~ x=1, y:=x*2
       ~ a:=x+y, b="somestring"
     `;
-    expect(compile(input, { async: false })).to.eql({
+    expect(compile(input, { async: false, injectIds: true })).to.eql({
       id: 0,
       type: 'component',
       name: 'div',

--- a/packages/idyll-document/src/runtime.js
+++ b/packages/idyll-document/src/runtime.js
@@ -83,7 +83,7 @@ const createWrapper = ({
     constructor(props) {
       super(props);
 
-      this.key = props.idyllASTNode.id || wrapperKey++;
+      this.key = wrapperKey++;
       this.ref = {};
       this.onUpdateRefs = this.onUpdateRefs.bind(this);
       this.onUpdateProps = this.onUpdateProps.bind(this);

--- a/packages/idyll-document/src/utils/index.js
+++ b/packages/idyll-document/src/utils/index.js
@@ -310,22 +310,20 @@ export const splitAST = ast => {
       const type = getType(node);
       const props = getProperties(node);
       const children = getChildren(node);
-      if (node.id != 0) {
-        if (type === 'var') {
-          state.vars.push(node);
-        } else if (state[type]) {
-          state[type].push(node);
-        } else if (storeElements) {
-          state.elements.push(node);
-        }
-        if (
-          !children ||
-          (children.length === 1 && getType(children[0]) === 'textnode')
-        ) {
-          return;
-        }
-        children.forEach(handleNode(false));
+      if (type === 'var') {
+        state.vars.push(node);
+      } else if (state[type]) {
+        state[type].push(node);
+      } else if (storeElements) {
+        state.elements.push(node);
       }
+      if (
+        !children ||
+        (children.length === 1 && getType(children[0]) === 'textnode')
+      ) {
+        return;
+      }
+      children.forEach(handleNode(false));
     };
   };
 


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] Tests for the changes have been added (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Update the AST schema so that IDs are optional and not injected by default. Add an option to the compiler and AST converters to specify whether or not IDs should be added

* **What is the current behavior?** (You can also link to an open issue here)
IDs are required in the AST but not really used, making AST changes overly burdensome. 

- **What is the new behavior (if this is a feature change)?**
The AST does not include IDs by default and things work as expected without them.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
