### PR TITLE
fix bug in importing AST metadata

### DIFF
--- a/packages/idyll-ast/package.json
+++ b/packages/idyll-ast/package.json
@@ -45,7 +45,7 @@
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-commonjs": "^21.0.2",
     "@rollup/plugin-json": "^4.1.0",
-    "@rollup/plugin-node-resolve": "^13.1.3",
+    "@rollup/plugin-node-resolve": "^13.2.0",
     "concurrently": "^4.1.0",
     "cross-env": "^5.0.5",
     "esm": "^3.2.25",

--- a/packages/idyll-ast/rollup.config.js
+++ b/packages/idyll-ast/rollup.config.js
@@ -1,6 +1,7 @@
 import commonjs from '@rollup/plugin-commonjs';
 import { babel } from '@rollup/plugin-babel';
 import json from '@rollup/plugin-json';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
 
 const pkg = require('./package.json');
 const dependencies = Object.keys(pkg.dependencies || {});
@@ -28,7 +29,10 @@ export default [
         babelHelpers: 'runtime',
         exclude: 'node_modules/**' // only transpile our source code
       }),
-      json(),
+      json({
+        compact: true
+      }),
+      nodeResolve(),
       commonjs()
     ]
   },
@@ -54,7 +58,9 @@ export default [
         babelHelpers: 'runtime',
         exclude: 'node_modules/**' // only transpile our source code
       }),
-      json(),
+      json({
+        compact: true
+      }),
       commonjs()
     ]
   }

--- a/packages/idyll-ast/src/validate.js
+++ b/packages/idyll-ast/src/validate.js
@@ -1,8 +1,9 @@
 import schema from './ast.schema.json';
 import Ajv from 'ajv';
+import metaSchema from 'ajv/lib/refs/json-schema-draft-06.json';
 
 const ajv = new Ajv();
-ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'));
+ajv.addMetaSchema(metaSchema);
 
 let astValidator;
 let propValidator;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2184,6 +2184,18 @@
     is-module "^1.0.0"
     resolve "^1.19.0"
 
+"@rollup/plugin-node-resolve@^13.2.0":
+  version "13.2.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.2.0.tgz#ac516c4649b7133273a944778df439d3081dc3d1"
+  integrity sha512-GuUIUyIKq7EjQxB51XSn6zPHYo+cILQQBYOGYvFFNxws2OVOqCBShAoof2hFrV8bAZzZGDBDQ8m2iUt8SLOUkg==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    "@types/resolve" "1.17.1"
+    builtin-modules "^3.1.0"
+    deepmerge "^4.2.2"
+    is-module "^1.0.0"
+    resolve "^1.19.0"
+
 "@rollup/plugin-replace@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz#e34c457d6a285f0213359740b43f39d969b38a67"
@@ -7149,7 +7161,7 @@ jest-each@^27.5.1:
     jest-util "^27.5.1"
     pretty-format "^27.5.1"
 
-jest-environment-jsdom@27.3.1, jest-environment-jsdom@^27, jest-environment-jsdom@^27.5.1:
+jest-environment-jsdom@^27:
   version "27.3.1"
   resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-27.3.1.tgz#63ac36d68f7a9303494df783494856222b57f73e"
   integrity sha512-3MOy8qMzIkQlfb3W1TfrD7uZHj+xx8Olix5vMENkj5djPmRqndMaXtpnaZkxmxM+Qc3lo+yVzJjzuXbCcZjAlg==
@@ -7160,6 +7172,19 @@ jest-environment-jsdom@27.3.1, jest-environment-jsdom@^27, jest-environment-jsdo
     "@types/node" "*"
     jest-mock "^27.3.0"
     jest-util "^27.3.1"
+    jsdom "^16.6.0"
+
+jest-environment-jsdom@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-27.5.1.tgz#ea9ccd1fc610209655a77898f86b2b559516a546"
+  integrity sha512-TFBvkTC1Hnnnrka/fUb56atfDtJ9VMZ94JkjTbggl1PEpwrYtUBKMezB3inLmWqQsXYLcMwNoDQwoBTAvFfsfw==
+  dependencies:
+    "@jest/environment" "^27.5.1"
+    "@jest/fake-timers" "^27.5.1"
+    "@jest/types" "^27.5.1"
+    "@types/node" "*"
+    jest-mock "^27.5.1"
+    jest-util "^27.5.1"
     jsdom "^16.6.0"
 
 jest-environment-node@^27.5.1:


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Small fix to the `idyll-ast` rollup config to get it to work properly as an ES module

* **What is the current behavior?** (You can also link to an open issue here)
It fails trying to `require()` a json file.

- **What is the new behavior (if this is a feature change)?**
The json file is parsed properly. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
